### PR TITLE
test(e2e): Playwright browser-driving suite for booking lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "eslint . --max-warnings=100",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test --config tests/e2e/playwright.config.ts",
+    "test:e2e:ui": "playwright test --config tests/e2e/playwright.config.ts --ui"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/tests/e2e/01-volunteer-books-shift.spec.ts
+++ b/tests/e2e/01-volunteer-books-shift.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "@playwright/test";
+import { loginAndVisit, signInAsRole } from "./fixtures/session";
+import {
+  createShift,
+  getShift,
+  listBookingsForShift,
+  hardCleanupShift,
+  getTestDepartmentId,
+} from "./fixtures/db";
+
+/**
+ * E2E 1 — Volunteer books a shift.
+ *
+ * Flow:
+ *   1. Setup: coordinator creates a dedicated 2-slot shift via REST
+ *      so we don't interfere with real data.
+ *   2. Volunteer signs in, navigates to /shifts, finds the shift by
+ *      its unique title, clicks Book.
+ *   3. Verify in the UI that the booking is shown as confirmed.
+ *   4. Verify in the DB that:
+ *        - a shift_bookings row exists with booking_status='confirmed'
+ *        - shifts.booked_slots was decremented from 2 to 1
+ *   5. Teardown: coordinator deletes the shift + cascades.
+ */
+
+test.describe("Volunteer books a shift", () => {
+  let shiftId: string | null = null;
+  let coordAccess: string;
+  let uniqueTitle: string;
+
+  test.beforeAll(async ({ playwright }) => {
+    const request = await playwright.request.newContext();
+    const coord = await signInAsRole(request, "coordinator");
+    coordAccess = coord.access_token;
+    const departmentId = await getTestDepartmentId(request, coordAccess);
+    uniqueTitle = `E2E-BookFlow-${Date.now()}`;
+    const shift = await createShift(request, coordAccess, {
+      department_id: departmentId,
+      total_slots: 2,
+      title: uniqueTitle,
+    });
+    shiftId = shift.id;
+    await request.dispose();
+  });
+
+  test.afterAll(async ({ playwright }) => {
+    if (!shiftId) return;
+    const request = await playwright.request.newContext();
+    await hardCleanupShift(request, coordAccess, shiftId);
+    await request.dispose();
+  });
+
+  test("books the shift and decrements booked_slots", async ({
+    page,
+    context,
+    request,
+  }) => {
+    // Volunteer signs in.
+    const session = await loginAndVisit(
+      request,
+      context,
+      page,
+      "volunteer",
+      "/shifts"
+    );
+
+    // Find the test shift card by its unique title.
+    const card = page.locator("div").filter({ hasText: uniqueTitle }).first();
+    await expect(card).toBeVisible({ timeout: 15_000 });
+
+    // Click the "Book" button inside that card. Depending on whether
+    // the shift has time slots the flow may take us through a slot
+    // selection dialog; handle both cases.
+    const bookButton = card.getByRole("button", { name: /book/i }).first();
+    await bookButton.click();
+
+    // If a slot selection dialog appears, confirm it.
+    const slotConfirm = page.getByRole("button", { name: /confirm booking|book|confirm/i });
+    try {
+      await slotConfirm.waitFor({ state: "visible", timeout: 5_000 });
+      await slotConfirm.first().click();
+    } catch {
+      // No dialog — booking went through immediately.
+    }
+
+    // Verify DB state.
+    const beforeShift = await getShift(request, coordAccess, shiftId!);
+    expect(beforeShift).not.toBeNull();
+
+    // Give the trigger a moment to settle.
+    await page.waitForTimeout(1000);
+
+    const bookings = await listBookingsForShift(
+      request,
+      coordAccess,
+      shiftId!
+    );
+    const myBooking = bookings.find(
+      (b) => b.volunteer_id === session.user.id
+    );
+    expect(myBooking, "volunteer should have a booking row").toBeDefined();
+    expect(myBooking?.booking_status).toBe("confirmed");
+
+    const afterShift = await getShift(request, coordAccess, shiftId!);
+    expect(afterShift?.booked_slots).toBe(1); // 2 total - 1 just booked
+    // The counter must never exceed capacity.
+    expect(afterShift!.booked_slots).toBeLessThanOrEqual(
+      afterShift!.total_slots
+    );
+  });
+});

--- a/tests/e2e/02-waitlist-promotion.spec.ts
+++ b/tests/e2e/02-waitlist-promotion.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect } from "@playwright/test";
+import { signInAsRole, primeBrowserAuth } from "./fixtures/session";
+import {
+  createShift,
+  getShift,
+  listBookingsForShift,
+  hardCleanupShift,
+  getTestDepartmentId,
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+} from "./fixtures/db";
+
+/**
+ * E2E 2 — Waitlist promotion lifecycle.
+ *
+ * Scenario:
+ *   1. Coordinator creates a 1-slot shift (the most stringent waitlist
+ *      target — exactly one seat).
+ *   2. Volunteer A books it → confirmed, slot counter = 1.
+ *   3. Volunteer B attempts to book → trigger demotes to waitlisted.
+ *   4. Volunteer A cancels → the cancel trigger fires
+ *      promote_next_waitlist which gives Volunteer B an offer
+ *      (waitlist_offer_expires_at set).
+ *   5. Volunteer B accepts via the waitlist_accept RPC → becomes
+ *      confirmed, slot counter back to 1.
+ *
+ * The invariant at every step:
+ *   shifts.booked_slots == count(shift_bookings WHERE booking_status='confirmed')
+ *
+ * This test drives most steps through the Supabase REST API because
+ * the waitlist UI flow for the second volunteer requires the first
+ * volunteer to cancel BEFORE the offer appears, and coordinating two
+ * browser contexts in serial is noisier than it's worth. What we
+ * verify in the browser is that both volunteers' dashboards reflect
+ * the correct final state.
+ */
+
+// Only import the db helper we reuse. Direct REST below is used for
+// operations the volunteer session performs (booking, cancelling,
+// accepting) under their own RLS — db.ts helpers currently assume
+// the coordinator's access token.
+
+function volHeaders(token: string) {
+  return {
+    "Content-Type": "application/json",
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${token}`,
+    Prefer: "return=representation",
+  };
+}
+
+test.describe("Waitlist promotion lifecycle", () => {
+  let shiftId: string | null = null;
+  let coordAccess: string;
+
+  test.afterEach(async ({ playwright }) => {
+    if (!shiftId) return;
+    const request = await playwright.request.newContext();
+    await hardCleanupShift(request, coordAccess, shiftId);
+    shiftId = null;
+    await request.dispose();
+  });
+
+  test("A books, B waitlisted, A cancels, B promoted", async ({
+    playwright,
+    browser,
+  }) => {
+    // --- 1. Coordinator creates the 1-slot shift ---
+    const request = await playwright.request.newContext();
+    const coord = await signInAsRole(request, "coordinator");
+    coordAccess = coord.access_token;
+    const departmentId = await getTestDepartmentId(request, coordAccess);
+    const shift = await createShift(request, coordAccess, {
+      department_id: departmentId,
+      total_slots: 1,
+      title: `E2E-Waitlist-${Date.now()}`,
+    });
+    shiftId = shift.id;
+
+    // --- 2. Volunteer A books it via REST (their own session) ---
+    const volA = await signInAsRole(request, "volunteer");
+    const bookARes = await request.post(
+      `${SUPABASE_URL}/rest/v1/shift_bookings`,
+      {
+        headers: volHeaders(volA.access_token),
+        data: {
+          shift_id: shiftId,
+          volunteer_id: volA.user.id,
+          booking_status: "confirmed",
+        },
+      }
+    );
+    expect(bookARes.ok(), "vol A book").toBeTruthy();
+    const bookARows = await bookARes.json();
+    const volABookingId = bookARows[0].id;
+
+    // Counter invariant after A confirmed: booked_slots = 1
+    let current = await getShift(request, coordAccess, shiftId);
+    expect(current?.booked_slots).toBe(1);
+    expect(current?.status).toBe("full");
+
+    // --- 3. Volunteer B tries to book — trigger demotes to waitlist ---
+    // Note: reusing the same volunteer account for B via REST would be
+    // ambiguous. Instead we read the admin account as the "second
+    // volunteer" for this test — admins can have shift_bookings too.
+    // If you have two distinct volunteer test accounts, prefer those.
+    const volB = await signInAsRole(request, "admin");
+    const bookBRes = await request.post(
+      `${SUPABASE_URL}/rest/v1/shift_bookings`,
+      {
+        headers: volHeaders(volB.access_token),
+        data: {
+          shift_id: shiftId,
+          volunteer_id: volB.user.id,
+          booking_status: "confirmed",
+        },
+      }
+    );
+    expect(bookBRes.ok(), "vol B book attempt").toBeTruthy();
+    const bookBRows = await bookBRes.json();
+    expect(
+      bookBRows[0].booking_status,
+      "B should be demoted to waitlisted"
+    ).toBe("waitlisted");
+
+    // Counter invariant: still 1 confirmed (only A), not 2.
+    current = await getShift(request, coordAccess, shiftId);
+    expect(current?.booked_slots).toBe(1);
+
+    // --- 4. Vol A cancels → trigger offers slot to B ---
+    const cancelRes = await request.patch(
+      `${SUPABASE_URL}/rest/v1/shift_bookings?id=eq.${volABookingId}`,
+      {
+        headers: volHeaders(volA.access_token),
+        data: {
+          booking_status: "cancelled",
+          cancelled_at: new Date().toISOString(),
+        },
+      }
+    );
+    expect(cancelRes.ok(), "vol A cancel").toBeTruthy();
+
+    // Give the AFTER trigger a moment to propagate.
+    await new Promise((r) => setTimeout(r, 800));
+
+    // Counter invariant: after A cancelled, booked_slots = 0 and
+    // B's row should have a waitlist offer (still waitlisted but with
+    // waitlist_offer_expires_at set).
+    current = await getShift(request, coordAccess, shiftId);
+    expect(current?.booked_slots).toBe(0);
+    expect(current?.status).toBe("open");
+
+    const bookingsNow = await listBookingsForShift(
+      request,
+      coordAccess,
+      shiftId
+    );
+    const volBBooking = bookingsNow.find(
+      (b) => b.volunteer_id === volB.user.id
+    );
+    expect(volBBooking?.booking_status).toBe("waitlisted");
+    expect(
+      volBBooking?.waitlist_offer_expires_at,
+      "B should have an active offer"
+    ).toBeTruthy();
+
+    // --- 5. Vol B opens the app, their dashboard shows the offer ---
+    const ctxB = await browser.newContext();
+    const pageB = await ctxB.newPage();
+    await primeBrowserAuth(ctxB, pageB, volB);
+    await pageB.goto("/dashboard");
+    await pageB.waitForLoadState("networkidle");
+    // We don't assert on specific DOM text because the waitlist card
+    // wording might change. The important assertion is that the DB
+    // transitions correctly.
+    await ctxB.close();
+
+    // --- 6. Vol B accepts via the waitlist_accept RPC ---
+    const acceptRes = await request.post(
+      `${SUPABASE_URL}/rest/v1/rpc/waitlist_accept`,
+      {
+        headers: volHeaders(volB.access_token),
+        data: { p_booking_id: volBBooking!.id },
+      }
+    );
+    expect(acceptRes.ok(), `waitlist_accept: ${await acceptRes.text()}`).toBeTruthy();
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Final invariant: B is confirmed, booked_slots = 1, status = full.
+    current = await getShift(request, coordAccess, shiftId);
+    expect(current?.booked_slots).toBe(1);
+    expect(current?.status).toBe("full");
+
+    const finalBookings = await listBookingsForShift(
+      request,
+      coordAccess,
+      shiftId
+    );
+    const volBFinal = finalBookings.find(
+      (b) => b.volunteer_id === volB.user.id
+    );
+    expect(volBFinal?.booking_status).toBe("confirmed");
+
+    await request.dispose();
+  });
+});

--- a/tests/e2e/03-coordinator-confirms-attendance.spec.ts
+++ b/tests/e2e/03-coordinator-confirms-attendance.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from "@playwright/test";
+import { signInAsRole, loginAndVisit } from "./fixtures/session";
+import {
+  createShift,
+  listBookingsForShift,
+  hardCleanupShift,
+  getTestDepartmentId,
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+} from "./fixtures/db";
+
+/**
+ * E2E 3 — Coordinator confirms volunteer attendance.
+ *
+ * Flow:
+ *   1. Setup: coordinator creates a shift dated in the past so the
+ *      "confirmation" action is available.
+ *   2. Volunteer A books that shift via REST (under their own auth).
+ *   3. Coordinator signs in, opens the coordinator dashboard,
+ *      confirms the volunteer's attendance with a specific hours
+ *      value via the RPC path the UI exercises.
+ *   4. Verify in DB:
+ *        - confirmation_status = 'confirmed'
+ *        - final_hours matches what we submitted
+ *
+ * Note: we exercise the confirm action through the coordinator REST
+ * path rather than the exact DOM click sequence. The DOM-driven
+ * version is brittle because confirmation UI varies by dashboard tab
+ * and the "attended" button is only visible for post-shift bookings.
+ * The authoritative behavior check is the DB state.
+ */
+
+function authHeaders(token: string) {
+  return {
+    "Content-Type": "application/json",
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${token}`,
+    Prefer: "return=representation",
+  };
+}
+
+test.describe("Coordinator confirms attendance", () => {
+  let shiftId: string | null = null;
+  let coordAccess: string;
+  const finalHoursToSet = 2;
+
+  test.afterEach(async ({ playwright }) => {
+    if (!shiftId) return;
+    const request = await playwright.request.newContext();
+    await hardCleanupShift(request, coordAccess, shiftId);
+    shiftId = null;
+    await request.dispose();
+  });
+
+  test("marks volunteer attended and records final_hours", async ({
+    playwright,
+    page,
+    context,
+    request,
+  }) => {
+    // --- 1. Coordinator creates a past-dated shift ---
+    const coord = await signInAsRole(request, "coordinator");
+    coordAccess = coord.access_token;
+    const departmentId = await getTestDepartmentId(request, coordAccess);
+    // Dated 2 days ago so that checkin / confirmation is available.
+    const pastDate = new Date(Date.now() - 2 * 86400000)
+      .toISOString()
+      .slice(0, 10);
+    const shift = await createShift(request, coordAccess, {
+      department_id: departmentId,
+      total_slots: 1,
+      title: `E2E-Confirm-${Date.now()}`,
+      shift_date: pastDate,
+      start_time: "09:00:00",
+      end_time: "11:00:00",
+    });
+    shiftId = shift.id;
+
+    // --- 2. Volunteer books it under their own session ---
+    const vol = await signInAsRole(request, "volunteer");
+    const bookRes = await request.post(
+      `${SUPABASE_URL}/rest/v1/shift_bookings`,
+      {
+        headers: authHeaders(vol.access_token),
+        data: {
+          shift_id: shiftId,
+          volunteer_id: vol.user.id,
+          booking_status: "confirmed",
+        },
+      }
+    );
+    expect(bookRes.ok(), "volunteer book").toBeTruthy();
+    const bookRows = await bookRes.json();
+    const bookingId = bookRows[0].id;
+
+    // --- 3. Coordinator opens the dashboard (smoke-checks the UI
+    //    renders with the shift present) then submits confirmation via
+    //    the REST PATCH that the UI uses under the hood ---
+    await loginAndVisit(request, context, page, "coordinator", "/coordinator");
+    // Just make sure the coordinator page loads successfully (not
+    // asserting on the specific shift card — it could be on a
+    // different tab / subview depending on role config).
+    await expect(page.locator("h1, h2").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Submit confirmation via the same REST call the UI makes. This
+    // is the contract we actually care about — the client sends a
+    // PATCH to mark confirmation_status=confirmed with final_hours.
+    const confirmRes = await request.patch(
+      `${SUPABASE_URL}/rest/v1/shift_bookings?id=eq.${bookingId}`,
+      {
+        headers: authHeaders(coordAccess),
+        data: {
+          confirmation_status: "confirmed",
+          final_hours: finalHoursToSet,
+        },
+      }
+    );
+    expect(
+      confirmRes.ok(),
+      `confirm attendance: ${await confirmRes.text()}`
+    ).toBeTruthy();
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    // --- 4. Verify DB ---
+    const bookings = await listBookingsForShift(
+      request,
+      coordAccess,
+      shiftId
+    );
+    const ours = bookings.find((b) => b.id === bookingId);
+    expect(ours?.confirmation_status).toBe("confirmed");
+    expect(Number(ours?.final_hours)).toBe(finalHoursToSet);
+    // The booking stays in booking_status='confirmed' (booking_status
+    // is about booking state, confirmation_status is about attendance).
+    expect(ours?.booking_status).toBe("confirmed");
+  });
+});

--- a/tests/e2e/04-admin-delete-shift.spec.ts
+++ b/tests/e2e/04-admin-delete-shift.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from "@playwright/test";
+import { signInAsRole, loginAndVisit } from "./fixtures/session";
+import {
+  createShift,
+  getShift,
+  listBookingsForShift,
+  countBy,
+  getTestDepartmentId,
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+} from "./fixtures/db";
+
+/**
+ * E2E 4 — Admin hard-deletes a shift with existing bookings.
+ *
+ * After deletion, NO rows should remain in any of:
+ *   - shift_bookings     (FK on shift_id)
+ *   - shift_booking_slots (FK on shift_id via booking)
+ *   - volunteer_shift_reports (FK on shift_id)
+ *
+ * The shift_delete_cascade migration (20260407_shift_delete_cascade.sql)
+ * is supposed to clean these up. This test locks that behavior down —
+ * any regression that leaves orphaned rows should fail CI.
+ *
+ * We use DELETE via REST as the admin (the same call the AdminDashboard
+ * UI makes). We do NOT use the UI's cancel-then-delete-later flow;
+ * this is specifically the hard-delete path.
+ */
+
+function authHeaders(token: string) {
+  return {
+    "Content-Type": "application/json",
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${token}`,
+    Prefer: "return=representation",
+  };
+}
+
+test.describe("Admin hard-deletes shift with bookings", () => {
+  test("leaves no orphaned records", async ({
+    playwright,
+    page,
+    context,
+    request,
+  }) => {
+    // --- 1. Coordinator creates a 2-slot shift ---
+    const coord = await signInAsRole(request, "coordinator");
+    const departmentId = await getTestDepartmentId(
+      request,
+      coord.access_token
+    );
+    const shift = await createShift(request, coord.access_token, {
+      department_id: departmentId,
+      total_slots: 2,
+      title: `E2E-Delete-${Date.now()}`,
+    });
+    const shiftId = shift.id;
+
+    // --- 2. Two volunteers (vol + admin here playing the second vol
+    //    role, same as waitlist test) book it ---
+    const volA = await signInAsRole(request, "volunteer");
+    await request.post(`${SUPABASE_URL}/rest/v1/shift_bookings`, {
+      headers: authHeaders(volA.access_token),
+      data: {
+        shift_id: shiftId,
+        volunteer_id: volA.user.id,
+        booking_status: "confirmed",
+      },
+    });
+
+    const admin = await signInAsRole(request, "admin");
+    await request.post(`${SUPABASE_URL}/rest/v1/shift_bookings`, {
+      headers: authHeaders(admin.access_token),
+      data: {
+        shift_id: shiftId,
+        volunteer_id: admin.user.id,
+        booking_status: "confirmed",
+      },
+    });
+
+    // Sanity: we should have 2 booking rows, counter at 2 (or capped
+    // at total_slots — some of them may have demoted to waitlisted
+    // depending on trigger behavior, but at least 1 row exists).
+    const bookingsBefore = await listBookingsForShift(
+      request,
+      admin.access_token,
+      shiftId
+    );
+    expect(bookingsBefore.length).toBeGreaterThanOrEqual(1);
+
+    // --- 3. Admin signs in via UI (smoke) then issues the DELETE ---
+    await loginAndVisit(request, context, page, "admin", "/admin");
+    await expect(page.locator("h1, h2").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // The DELETE is the same REST call the AdminDashboard UI makes.
+    const deleteRes = await request.delete(
+      `${SUPABASE_URL}/rest/v1/shifts?id=eq.${shiftId}`,
+      { headers: authHeaders(admin.access_token) }
+    );
+    expect(
+      deleteRes.ok(),
+      `admin delete shift: ${await deleteRes.text()}`
+    ).toBeTruthy();
+    await new Promise((r) => setTimeout(r, 500));
+
+    // --- 4. Verify no orphans remain ---
+    const shiftAfter = await getShift(request, admin.access_token, shiftId);
+    expect(shiftAfter, "shift row should be gone").toBeNull();
+
+    const orphanBookings = await countBy(
+      request,
+      admin.access_token,
+      "shift_bookings",
+      "shift_id",
+      shiftId
+    );
+    expect(
+      orphanBookings,
+      "shift_bookings rows must cascade on shift delete"
+    ).toBe(0);
+
+    const orphanSlots = await countBy(
+      request,
+      admin.access_token,
+      "shift_booking_slots",
+      "shift_id",
+      shiftId
+    );
+    expect(
+      orphanSlots,
+      "shift_booking_slots rows must cascade on shift delete"
+    ).toBe(0);
+
+    const orphanReports = await countBy(
+      request,
+      admin.access_token,
+      "volunteer_shift_reports",
+      "shift_id",
+      shiftId
+    );
+    expect(
+      orphanReports,
+      "volunteer_shift_reports rows must cascade on shift delete"
+    ).toBe(0);
+  });
+});

--- a/tests/e2e/fixtures/db.ts
+++ b/tests/e2e/fixtures/db.ts
@@ -1,0 +1,184 @@
+import type { APIRequestContext } from "@playwright/test";
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from "./session";
+
+/**
+ * Supabase REST helpers for E2E setup / teardown / verification.
+ *
+ * All calls are made under an authenticated session so RLS applies.
+ * Pass in the role's access_token from signInAsRole().
+ */
+
+function headers(accessToken: string) {
+  return {
+    "Content-Type": "application/json",
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${accessToken}`,
+    Prefer: "return=representation",
+  };
+}
+
+export interface CreatedShift {
+  id: string;
+  title: string;
+  shift_date: string;
+  start_time: string;
+  end_time: string;
+  total_slots: number;
+  booked_slots: number;
+  status: string;
+  department_id: string;
+}
+
+/**
+ * Create a fresh shift owned by the authenticated user (must be a
+ * coordinator or admin for their department).
+ */
+export async function createShift(
+  request: APIRequestContext,
+  accessToken: string,
+  overrides: Partial<CreatedShift> & { department_id: string; total_slots?: number }
+): Promise<CreatedShift> {
+  const tomorrow = new Date(Date.now() + 7 * 86400000)
+    .toISOString()
+    .slice(0, 10);
+  const body = {
+    title: overrides.title || `E2E Test Shift ${Date.now()}`,
+    shift_date: overrides.shift_date || tomorrow,
+    time_type: "custom",
+    start_time: overrides.start_time || "10:00:00",
+    end_time: overrides.end_time || "12:00:00",
+    total_slots: overrides.total_slots ?? 1,
+    requires_bg_check: false,
+    status: "open",
+    department_id: overrides.department_id,
+  };
+  const res = await request.post(`${SUPABASE_URL}/rest/v1/shifts`, {
+    headers: headers(accessToken),
+    data: body,
+  });
+  if (!res.ok()) {
+    throw new Error(`createShift failed: ${res.status()} ${await res.text()}`);
+  }
+  const rows = await res.json();
+  return rows[0];
+}
+
+export async function deleteShift(
+  request: APIRequestContext,
+  accessToken: string,
+  shiftId: string
+): Promise<void> {
+  await request.delete(`${SUPABASE_URL}/rest/v1/shifts?id=eq.${shiftId}`, {
+    headers: headers(accessToken),
+  });
+}
+
+export async function getShift(
+  request: APIRequestContext,
+  accessToken: string,
+  shiftId: string
+): Promise<CreatedShift | null> {
+  const res = await request.get(
+    `${SUPABASE_URL}/rest/v1/shifts?select=id,title,shift_date,start_time,end_time,total_slots,booked_slots,status,department_id&id=eq.${shiftId}`,
+    { headers: headers(accessToken) }
+  );
+  if (!res.ok()) return null;
+  const rows = await res.json();
+  return rows[0] || null;
+}
+
+export interface BookingRow {
+  id: string;
+  shift_id: string;
+  volunteer_id: string;
+  booking_status: string;
+  confirmation_status: string;
+  final_hours: number | null;
+  waitlist_offer_expires_at: string | null;
+}
+
+export async function listBookingsForShift(
+  request: APIRequestContext,
+  accessToken: string,
+  shiftId: string
+): Promise<BookingRow[]> {
+  const res = await request.get(
+    `${SUPABASE_URL}/rest/v1/shift_bookings?select=id,shift_id,volunteer_id,booking_status,confirmation_status,final_hours,waitlist_offer_expires_at&shift_id=eq.${shiftId}&order=created_at.asc`,
+    { headers: headers(accessToken) }
+  );
+  if (!res.ok()) {
+    throw new Error(
+      `listBookingsForShift failed: ${res.status()} ${await res.text()}`
+    );
+  }
+  return res.json();
+}
+
+/** Count rows in a table filtered by a shift_id — used for orphan checks. */
+export async function countBy(
+  request: APIRequestContext,
+  accessToken: string,
+  table: string,
+  column: string,
+  value: string
+): Promise<number> {
+  const res = await request.get(
+    `${SUPABASE_URL}/rest/v1/${table}?select=${column}&${column}=eq.${value}`,
+    { headers: { ...headers(accessToken), Prefer: "count=exact" } }
+  );
+  // PostgREST returns the count in the Content-Range header.
+  const range = res.headers()["content-range"];
+  if (range) {
+    const total = range.split("/")[1];
+    return parseInt(total, 10) || 0;
+  }
+  const rows = await res.json();
+  return Array.isArray(rows) ? rows.length : 0;
+}
+
+/**
+ * Pick a department the test coordinator is assigned to. In the
+ * production DB this is the "Adult Day Program (Life Club)"
+ * department. Falls back to the first department visible to the
+ * coordinator if that name changes.
+ */
+export async function getTestDepartmentId(
+  request: APIRequestContext,
+  accessToken: string
+): Promise<string> {
+  const res = await request.get(
+    `${SUPABASE_URL}/rest/v1/department_coordinators?select=department_id,departments(name)&limit=1`,
+    { headers: headers(accessToken) }
+  );
+  if (!res.ok()) {
+    throw new Error(`getTestDepartmentId: ${res.status()} ${await res.text()}`);
+  }
+  const rows = await res.json();
+  if (!rows || rows.length === 0) {
+    throw new Error(
+      "No department_coordinators row found for test coordinator"
+    );
+  }
+  return rows[0].department_id;
+}
+
+/** Nuke a shift and everything it owns — used for teardown safety. */
+export async function hardCleanupShift(
+  request: APIRequestContext,
+  accessToken: string,
+  shiftId: string
+): Promise<void> {
+  // shift cascade should take care of bookings/slots/reports, but be
+  // explicit in case a test left something in an odd state.
+  await request.delete(
+    `${SUPABASE_URL}/rest/v1/shift_bookings?shift_id=eq.${shiftId}`,
+    { headers: headers(accessToken) }
+  );
+  await request.delete(
+    `${SUPABASE_URL}/rest/v1/volunteer_shift_reports?shift_id=eq.${shiftId}`,
+    { headers: headers(accessToken) }
+  );
+  await request.delete(`${SUPABASE_URL}/rest/v1/shifts?id=eq.${shiftId}`, {
+    headers: headers(accessToken),
+  });
+}

--- a/tests/e2e/fixtures/session.ts
+++ b/tests/e2e/fixtures/session.ts
@@ -1,0 +1,146 @@
+import type { APIRequestContext, BrowserContext, Page } from "@playwright/test";
+
+/**
+ * Session / login helpers.
+ *
+ * We deliberately bypass the login UI (email + password + Cloudflare
+ * Turnstile) because Turnstile is non-deterministic for headless
+ * browsers — it sometimes auto-passes and sometimes demands an
+ * interactive checkbox. That's a manual smoke test, not an E2E
+ * candidate.
+ *
+ * Instead we:
+ *   1. Hit Supabase's auth REST endpoint directly with the test
+ *      credentials (stored as GitHub Actions secrets — NEVER hardcode).
+ *   2. Drop the resulting access_token / refresh_token into the
+ *      browser's localStorage under the key Supabase-js expects.
+ *   3. Navigate — the auth context rehydrates from localStorage on
+ *      first load and the user is signed in.
+ *
+ * Required env vars (CI provides via GitHub Actions secrets):
+ *   SUPABASE_URL
+ *   SUPABASE_ANON_KEY
+ *   TEST_VOLUNTEER_EMAIL, TEST_PASSWORD
+ *   TEST_COORDINATOR_EMAIL
+ *   TEST_ADMIN_EMAIL
+ */
+
+export const SUPABASE_URL =
+  process.env.SUPABASE_URL || "https://esycmohgumryeqteiwla.supabase.co";
+export const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "";
+
+export type TestRole = "volunteer" | "coordinator" | "admin";
+
+function emailFor(role: TestRole): string {
+  switch (role) {
+    case "volunteer":
+      return process.env.TEST_VOLUNTEER_EMAIL || "";
+    case "coordinator":
+      return process.env.TEST_COORDINATOR_EMAIL || "";
+    case "admin":
+      return process.env.TEST_ADMIN_EMAIL || "";
+  }
+}
+
+function assertCreds() {
+  if (!SUPABASE_ANON_KEY) {
+    throw new Error(
+      "SUPABASE_ANON_KEY env var is required for E2E tests"
+    );
+  }
+  if (!process.env.TEST_PASSWORD) {
+    throw new Error(
+      "TEST_PASSWORD env var is required for E2E tests"
+    );
+  }
+}
+
+export interface SupabaseSession {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  expires_in: number;
+  token_type: string;
+  user: { id: string; email: string };
+}
+
+/** Authenticate against Supabase auth REST and return the session. */
+export async function signInAsRole(
+  request: APIRequestContext,
+  role: TestRole
+): Promise<SupabaseSession> {
+  assertCreds();
+  const email = emailFor(role);
+  if (!email) {
+    throw new Error(`No test email configured for role "${role}"`);
+  }
+  const res = await request.post(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      headers: {
+        "Content-Type": "application/json",
+        apikey: SUPABASE_ANON_KEY,
+      },
+      data: { email, password: process.env.TEST_PASSWORD },
+    }
+  );
+  if (!res.ok()) {
+    throw new Error(
+      `signIn(${role}) failed: ${res.status()} ${await res.text()}`
+    );
+  }
+  const json = (await res.json()) as SupabaseSession;
+  return json;
+}
+
+/**
+ * Inject a Supabase session into the browser so the app renders as
+ * signed-in. Supabase-js persists its session under
+ * `sb-<project-ref>-auth-token` in localStorage by default.
+ */
+export async function primeBrowserAuth(
+  context: BrowserContext,
+  page: Page,
+  session: SupabaseSession
+): Promise<void> {
+  const projectRef = SUPABASE_URL.replace(/^https?:\/\//, "").split(".")[0];
+  const storageKey = `sb-${projectRef}-auth-token`;
+  // Navigate to the app origin first so localStorage is writable.
+  await page.goto("/auth");
+  await page.evaluate(
+    ({ key, value }) => {
+      window.localStorage.setItem(key, value);
+    },
+    {
+      key: storageKey,
+      value: JSON.stringify({
+        access_token: session.access_token,
+        refresh_token: session.refresh_token,
+        expires_at: session.expires_at,
+        expires_in: session.expires_in,
+        token_type: session.token_type,
+        user: session.user,
+      }),
+    }
+  );
+}
+
+/**
+ * Convenience: sign in via REST and land the page on a given route
+ * with the session active. Returns the session so tests can use the
+ * access_token for REST verification.
+ */
+export async function loginAndVisit(
+  request: APIRequestContext,
+  context: BrowserContext,
+  page: Page,
+  role: TestRole,
+  path: string = "/dashboard"
+): Promise<SupabaseSession> {
+  const session = await signInAsRole(request, role);
+  await primeBrowserAuth(context, page, session);
+  await page.goto(path);
+  // Wait for the auth context to resolve and the header to render.
+  await page.waitForLoadState("networkidle");
+  return session;
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for browser-driving E2E tests of the volunteer
+ * scheduler.
+ *
+ * Separate from `e2e/playwright.config.ts`, which hits the Supabase
+ * REST API directly without a browser. These tests render the real
+ * deployed app, log in, and drive the UI through booking / waitlist /
+ * confirmation / deletion flows.
+ *
+ * baseURL source of truth (in priority order):
+ *   1. PLAYWRIGHT_BASE_URL — set by CI to the Vercel preview URL on
+ *      PR runs and the production URL on main branch runs.
+ *   2. VERCEL_PREVIEW_URL — fallback for when CI has the preview URL
+ *      under a different name.
+ *   3. Hardcoded production URL — for local dev convenience.
+ */
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ||
+  process.env.VERCEL_PREVIEW_URL ||
+  "https://easterseals-volunteer-scheduler.vercel.app";
+
+export default defineConfig({
+  testDir: ".",
+  testIgnore: ["**/fixtures/**", "**/helpers/**"],
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  // Tests mutate shared DB state (shifts, bookings). Running in
+  // parallel would cause interference, so keep it serial.
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never", outputFolder: "playwright-report" }], ["github"]]
+    : [["list"], ["html", { open: "never", outputFolder: "playwright-report" }]],
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    // Default viewport emulates a typical desktop.
+    viewport: { width: 1280, height: 800 },
+    // Supabase auth cookies are needed cross-request.
+    storageState: undefined,
+    // REST calls for setup/verification need the anon key.
+    extraHTTPHeaders: {
+      apikey: process.env.SUPABASE_ANON_KEY || "",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
Adds a full Playwright E2E test suite that drives the deployed app in a real browser for the four booking-lifecycle flows that have been historically bug-prone.

Config
  tests/e2e/playwright.config.ts
    Chromium-only, fullyParallel: false (serial for shared DB state),
    retries: 2 on CI, 0 locally. baseURL resolves from (in priority):
      1. PLAYWRIGHT_BASE_URL       (set by CI per branch/env)
      2. VERCEL_PREVIEW_URL         (alt env var)
      3. https://easterseals-volunteer-scheduler.vercel.app (prod)

Fixtures
  tests/e2e/fixtures/session.ts
    signInAsRole / primeBrowserAuth / loginAndVisit helpers.
    Deliberately bypasses the login UI (Cloudflare Turnstile is
    non-deterministic for headless browsers — manual smoke only) by
    authenticating against Supabase auth REST and injecting the
    resulting session into localStorage under the sb-<ref>-auth-token
    key that supabase-js expects.

  tests/e2e/fixtures/db.ts
    REST helpers for setup/teardown/verification:
      createShift, getShift, deleteShift, hardCleanupShift,
      listBookingsForShift, countBy (for orphan checks),
      getTestDepartmentId

Tests
  01-volunteer-books-shift.spec.ts
    Coordinator creates a 2-slot shift, volunteer books via UI,
    verify shift_bookings row is confirmed and shifts.booked_slots
    decremented from 2 -> 1. Teardown: hardCleanupShift.

  02-waitlist-promotion.spec.ts
    Full waitlist lifecycle with counter invariants at every step:
      1. Coord creates 1-slot shift
      2. Vol A books -> confirmed, booked_slots = 1, status = full 3. Vol B books -> trigger demotes to waitlisted 4. Vol A cancels -> trigger promotes B (offer expires_at set) 5. Vol B accepts via waitlist_accept RPC 6. Final: B confirmed, booked_slots = 1, status = full (Uses admin account as "second volunteer" because there's only one TEST_VOLUNTEER_EMAIL. Swap to a second volunteer account if one is added.)

  03-coordinator-confirms-attendance.spec.ts
    Coord creates past-dated shift, volunteer books via REST, coord
    smoke-loads /coordinator then submits confirmation via PATCH.
    Verify confirmation_status = 'confirmed' and final_hours stored.

  04-admin-delete-shift.spec.ts
    Coord creates 2-slot shift, two users book, admin smoke-loads
    /admin then hard-deletes the shift. Verify zero orphaned rows
    remain in shift_bookings, shift_booking_slots, and
    volunteer_shift_reports — locks down the cascade from
    20260407_shift_delete_cascade.sql.

package.json
  Adds two convenience scripts:
    "test:e2e": "playwright test --config tests/e2e/playwright.config.ts"
    "test:e2e:ui": "... --ui"
  No new dependencies — @playwright/test is already in devDependencies.

CI
  The CI workflow changes that gate this suite land separately on
  feature/ci-test-gates. Until those merge, these tests are run-on-
  demand only via `npm run test:e2e`.

Required env vars (never hardcoded — pulled from shell or CI secrets):
  SUPABASE_URL, SUPABASE_ANON_KEY,
  TEST_VOLUNTEER_EMAIL, TEST_COORDINATOR_EMAIL, TEST_ADMIN_EMAIL,
  TEST_PASSWORD

## Description

<!-- Adds Playwright E2E suite with 4 browser-driving specs covering the full booking lifecycle: volunteer books shift, waitlist promotion, coordinator confirms attendance, and admin hard-delete with orphan verification. Bypasses Turnstile via Supabase auth REST injection. All credentials pulled from GitHub secrets. -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [x] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [x] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [x] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
