### PR TITLE
fix(e2e): re-export SUPABASE_URL/SUPABASE_ANON_KEY from fixtures/db

### DIFF
--- a/tests/e2e/fixtures/db.ts
+++ b/tests/e2e/fixtures/db.ts
@@ -1,6 +1,15 @@
 import type { APIRequestContext } from "@playwright/test";
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from "./session";
 
+// Re-export so spec files can import these constants from a single
+// fixtures entry point. The original split between session.ts and
+// db.ts was an internal artifact — every spec that calls a db helper
+// also needs the URL/key to make ad-hoc REST calls under the user's
+// own session, and forcing them to import from two paths just to
+// satisfy module boundaries was a footgun. Several specs already
+// import these from "./fixtures/db" expecting them to be exported.
+export { SUPABASE_URL, SUPABASE_ANON_KEY };
+
 /**
  * Supabase REST helpers for E2E setup / teardown / verification.
  *


### PR DESCRIPTION
The Playwright job on main is failing with:

  SyntaxError: The requested module './fixtures/db' does not provide
  an export named 'SUPABASE_ANON_KEY'

Three spec files (02-waitlist-promotion, 03-coordinator-confirms, 04-admin-delete-shift) import SUPABASE_URL and SUPABASE_ANON_KEY from "./fixtures/db" so they can issue ad-hoc REST calls under each role's own session. The constants live in session.ts and were imported into db.ts for internal use, but db.ts never re-exported them — so the spec imports resolved to undefined at module load time and Node bailed before the test even ran.

Fix: re-export both from db.ts. Single-line surface change; no test logic touched. typescript --noEmit passes.

This was a pre-existing oversight in feature/playwright-e2e that only surfaced once feature/ci-test-gates merged and the workflow actually ran the suite for the first time.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
