### PR TITLE
ci: always run Playwright against production URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-unit
     env:
-      # Point Playwright at the right URL: prod for main branch runs,
-      # Vercel preview for PR runs. PLAYWRIGHT_BASE_URL is resolved
-      # per-branch below.
+      # Always run Playwright against the production deployment for
+      # now. The earlier attempt to construct the Vercel PR preview
+      # URL from the branch name (e.g. "*-git-<branch>-<team>.vercel.app")
+      # never resolved — branch slugs longer than 63 chars get
+      # truncated by Vercel and the team-slug guess was wrong. We can
+      # add proper preview-URL detection later (Vercel deployment API
+      # or the Vercel GitHub bot's PR comment) once the suite is
+      # otherwise stable.
+      PLAYWRIGHT_BASE_URL: https://easterseals-volunteer-scheduler.vercel.app
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
       TEST_VOLUNTEER_EMAIL: ${{ secrets.TEST_VOLUNTEER_EMAIL }}
@@ -75,34 +81,15 @@ jobs:
       - name: Install Playwright browser (chromium only)
         run: bunx playwright install --with-deps chromium
 
-      - name: Resolve PLAYWRIGHT_BASE_URL
+      - name: Smoke-check production URL is reachable
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # Vercel's deterministic git-branch preview alias.
-            BRANCH_SLUG=$(echo "${{ github.head_ref }}" | sed 's/[^a-zA-Z0-9]/-/g' | tr '[:upper:]' '[:lower:]')
-            URL="https://easterseals-volunteer-scheduler-git-${BRANCH_SLUG}-sabihusmans-projects.vercel.app"
-            echo "Resolved PR preview URL: $URL"
-          else
-            URL="https://easterseals-volunteer-scheduler.vercel.app"
-            echo "Using production URL: $URL"
+          echo "Targeting $PLAYWRIGHT_BASE_URL"
+          if ! curl -fsS -o /dev/null --max-time 30 "$PLAYWRIGHT_BASE_URL"; then
+            echo "Production URL is not reachable. Aborting."
+            exit 1
           fi
-          echo "PLAYWRIGHT_BASE_URL=$URL" >> "$GITHUB_ENV"
-
-      - name: Wait for Vercel deployment (PR runs only)
-        if: github.event_name == 'pull_request'
-        shell: bash
-        run: |
-          for i in $(seq 1 18); do
-            if curl -fsS -o /dev/null "$PLAYWRIGHT_BASE_URL"; then
-              echo "Preview is live at $PLAYWRIGHT_BASE_URL"
-              exit 0
-            fi
-            echo "Attempt $i: preview not yet live, sleeping 10s..."
-            sleep 10
-          done
-          echo "Preview never became available at $PLAYWRIGHT_BASE_URL"
-          exit 1
+          echo "Production URL responded OK."
 
       - name: Run Playwright E2E
         shell: bash


### PR DESCRIPTION
The previous Resolve PLAYWRIGHT_BASE_URL step constructed a URL of the form

  easterseals-volunteer-scheduler-git-<branch-slug>-sabihusmans-projects.vercel.app

from github.head_ref on PR runs. That never resolved — two problems compounded:

  1. The team slug "sabihusmans-projects" was a guess and didn't match the actual Vercel team slug.
  2. Even with the right team slug, Vercel truncates branch slugs longer than 63 chars in the alias, so any reasonably named fix/* or feature/* branch would fail to match.

The 3-minute wait loop then sat polling a non-existent URL until it timed out, blocking every PR.

Fix: drop the URL construction and the wait loop entirely. Always target https://easterseals-volunteer-scheduler.vercel.app — both on PR runs and main-branch runs. The downside is PRs test against the *previous* deployment of main rather than their own preview, but that's an acceptable trade-off for now: the suite needs to be stable before per-PR preview testing is worth the wiring effort.

Replaced the wait loop with a simple curl smoke check that aborts the job fast if production is somehow down (saves the cost of a ~1 minute Playwright install before failing).

Future work (intentionally NOT in this branch): proper Vercel preview URL detection via either the Vercel deployment API or by parsing the Vercel GitHub bot's PR comment.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [x] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [x] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
