### PR TITLE
fix(db): generate_shift_time_slots SECURITY DEFINER

### DIFF
--- a/supabase/migrations/20260409_slot_generator_security_definer.sql
+++ b/supabase/migrations/20260409_slot_generator_security_definer.sql
@@ -1,0 +1,66 @@
+-- =============================================
+-- CRITICAL FIX: shift creation is broken for all clients in
+-- production. The 20260408_p1_p2_p3_hardening migration added a
+-- restrictive RLS policy "shift_time_slots: deny client insert"
+-- (WITH CHECK false) to lock the slot counter table down, but it
+-- did NOT update the trigger function generate_shift_time_slots to
+-- SECURITY DEFINER. The trigger therefore runs in the caller's auth
+-- context, hits the deny policy, and 403s back to the client.
+--
+-- Symptom: any user (coordinator, admin, E2E test) trying to INSERT
+-- into shifts via PostgREST gets:
+--   {"code":"42501","message":"new row violates row-level security
+--    policy \"shift_time_slots: deny client insert\" for table
+--    \"shift_time_slots\""}
+--
+-- Fix: recreate the trigger function as SECURITY DEFINER with an
+-- explicit search_path. SECURITY DEFINER lets the function bypass
+-- RLS on shift_time_slots when it cascades from a shift insert,
+-- which is the intended behavior — slot generation is an internal
+-- system operation, not a user action.
+--
+-- This is the same pattern already used by sync_booked_slots and
+-- has_active_booking_on (see the recursion-fix migration).
+-- =============================================
+
+CREATE OR REPLACE FUNCTION public.generate_shift_time_slots()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  slot_start time;
+  slot_end   time;
+  duration_hours numeric;
+BEGIN
+  IF NEW.start_time IS NULL OR NEW.end_time IS NULL THEN
+    RETURN NEW;
+  END IF;
+  IF NEW.end_time <= NEW.start_time THEN
+    RETURN NEW;
+  END IF;
+  IF NEW.total_slots IS NULL OR NEW.total_slots <= 0 THEN
+    RETURN NEW;
+  END IF;
+
+  duration_hours := EXTRACT(EPOCH FROM (NEW.end_time - NEW.start_time)) / 3600.0;
+
+  -- Short shifts (≤4 h) get a single time slot.
+  IF duration_hours <= 4 THEN
+    INSERT INTO public.shift_time_slots (shift_id, slot_start, slot_end, total_slots)
+    VALUES (NEW.id, NEW.start_time, NEW.end_time, NEW.total_slots);
+    RETURN NEW;
+  END IF;
+
+  -- Longer shifts split into 2-hour chunks.
+  slot_start := NEW.start_time;
+  WHILE slot_start < NEW.end_time LOOP
+    slot_end := LEAST(slot_start + interval '2 hours', NEW.end_time);
+    INSERT INTO public.shift_time_slots (shift_id, slot_start, slot_end, total_slots)
+    VALUES (NEW.id, slot_start, slot_end, NEW.total_slots);
+    slot_start := slot_end;
+  END LOOP;
+  RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
CRITICAL: shift creation has been broken for every client (UI and REST) since the 20260408_p1_p2_p3_hardening migration landed. That migration added a restrictive RLS policy on shift_time_slots ("deny client insert", WITH CHECK false) but did not update the trigger function generate_shift_time_slots to SECURITY DEFINER.

The trigger fires on INSERT INTO shifts and cascades into shift_time_slots. Without SECURITY DEFINER, the trigger inherits the caller's auth context, hits the deny policy, and 403s back to PostgREST with:

  code: 42501
  message: new row violates row-level security policy
           "shift_time_slots: deny client insert"
           for table "shift_time_slots"

Symptom in production: every coordinator who tries to create a shift via /coordinator/manage gets a generic toast error and the shift is not created. The Playwright E2E suite caught this on its first real run against prod.

Fix: recreate the trigger function as SECURITY DEFINER with an explicit search_path = public. SECURITY DEFINER is the same pattern used by sync_booked_slots, has_active_booking_on, and the other trigger helpers — slot generation is an internal cascade, not a direct user action, so RLS bypass is correct here.

Already applied to the live DB via supabase db query. The function is now prosecdef: true on remote.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
