### PR TITLE
fix: show onboarding modal on first 3 sign-ins only

### DIFF
--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -105,14 +105,21 @@ export default function OnboardingModal() {
 
     const { data: profile } = await supabase
       .from("profiles")
-      .select("onboarding_complete, full_name, phone, emergency_contact_name, emergency_contact_phone, role")
+      .select("onboarding_complete, signin_count, full_name, phone, emergency_contact_name, emergency_contact_phone, role")
       .eq("id", user.id)
       .single();
 
     // Skip onboarding for admins and coordinators
     if (profile && (profile.role === "admin" || profile.role === "coordinator")) return;
 
-    if (profile && !profile.onboarding_complete) {
+    // Show the modal if the user hasn't completed onboarding AND
+    // they've signed in 3 or fewer times. After 3 sign-ins, stop
+    // showing it automatically — the user can still open it from
+    // the dashboard checklist if they want to finish later.
+    const signinCount = (profile as { signin_count?: number } | null)?.signin_count ?? 0;
+    const shouldShow = profile && !profile.onboarding_complete && signinCount <= 3;
+
+    if (shouldShow) {
       setForm({
         full_name: profile.full_name ?? "",
         phone: profile.phone ?? "",

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -44,11 +44,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Defer the profile fetch with setTimeout(..., 0) as recommended by
     // Supabase docs.
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      (_event, session) => {
+      (event, session) => {
         setSession(session);
         setUser(session?.user ?? null);
         if (session?.user) {
           setTimeout(() => { fetchProfile(session.user.id); }, 0);
+
+          // Increment signin_count on actual sign-in (not token
+          // refresh). Drives the onboarding modal: show on the first
+          // 3 sign-ins if onboarding isn't complete. Best-effort
+          // read-then-write — if it fails the counter just stays the
+          // same. Low stakes.
+          if (event === "SIGNED_IN") {
+            const uid = session.user.id;
+            setTimeout(async () => {
+              const { data } = await supabase
+                .from("profiles")
+                .select("signin_count")
+                .eq("id", uid)
+                .single();
+              const current = (data as { signin_count?: number } | null)?.signin_count ?? 0;
+              await supabase
+                .from("profiles")
+                .update({ signin_count: current + 1 } as never)
+                .eq("id", uid);
+            }, 0);
+          }
         } else {
           setProfile(null);
         }

--- a/supabase/migrations/20260409_signin_count.sql
+++ b/supabase/migrations/20260409_signin_count.sql
@@ -1,0 +1,8 @@
+-- =============================================
+-- Track how many times a user has signed in.
+-- Used by the onboarding modal to decide whether to display:
+--   show if signin_count <= 3 AND onboarding_complete = false
+-- =============================================
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS signin_count integer NOT NULL DEFAULT 0;


### PR DESCRIPTION
Adds signin_count tracking to profiles and gates the onboarding modal on both onboarding_complete AND signin_count <= 3.

1. Migration: adds signin_count integer DEFAULT 0 to profiles. Applied to remote DB via supabase db query.

2. AuthContext: on SIGNED_IN events (not token refresh), does a best-effort read-then-write to increment signin_count by 1. Deferred via setTimeout(0) to avoid the GoTrue auth lock deadlock. If it fails (race, RLS), the counter stays the same — low stakes.

3. OnboardingModal: init() now fetches signin_count alongside onboarding_complete. The modal displays only when BOTH conditions are true: - onboarding_complete = false - signin_count <= 3 After 3 sign-ins, the modal stops appearing automatically. The dashboard checklist still shows incomplete items so the user can finish onboarding at their own pace.

The "don't show again" checkbox (from fix/onboarding-modal-controls) still works — it sets onboarding_complete = true immediately, which satisfies the first condition and permanently suppresses the modal regardless of signin_count.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
