### PR TITLE
fix: mobile nav shows role-specific items + theme-aware colors

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -75,7 +75,12 @@ export function AppLayout({ children }: { children: ReactNode }) {
             {children}
           </main>
         </div>
-        {isMobile && <MobileNav />}
+        {isMobile && (
+          <MobileNav
+            userRole={profile?.role as "volunteer" | "coordinator" | "admin" | undefined}
+            userName={profile?.full_name || undefined}
+          />
+        )}
       </div>
     </SidebarProvider>
   );

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -13,14 +13,23 @@ import {
   Menu,
   Home,
   Calendar,
+  CalendarDays,
+  ClipboardList,
   Clock,
   Settings,
+  Cog,
   Users,
   Shield,
   LogOut,
   Loader2,
   FolderOpen,
+  FileText,
   MessageSquare,
+  Building2,
+  Bell,
+  CheckSquare,
+  BarChart3,
+  AlertCircle,
 } from "lucide-react";
 
 /* ------------------------------------------------------------------ */
@@ -31,39 +40,81 @@ interface NavItem {
   label: string;
   to: string;
   icon: React.ElementType;
-  roles?: ("volunteer" | "coordinator" | "admin")[];
 }
 
+interface NavSection {
+  heading: string;
+  items: NavItem[];
+}
+
+type UserRole = "volunteer" | "coordinator" | "admin";
+
 interface MobileNavProps {
-  userRole?: "volunteer" | "coordinator" | "admin";
+  userRole?: UserRole;
   userName?: string;
 }
 
 /* ------------------------------------------------------------------ */
-/*  Navigation map                                                     */
+/*  Role-based navigation — mirrors AppSidebar.tsx exactly.            */
 /* ------------------------------------------------------------------ */
 
-const NAV_ITEMS: NavItem[] = [
-  { label: "Dashboard", to: "/dashboard", icon: Home },
-  { label: "Browse Shifts", to: "/shifts", icon: Calendar },
-  { label: "My Shifts", to: "/my-shifts", icon: Clock },
-  { label: "Events", to: "/events", icon: Users },
-  { label: "Documents", to: "/documents", icon: FolderOpen },
-  { label: "Messages", to: "/messages", icon: MessageSquare },
-  { label: "Settings", to: "/settings", icon: Settings },
-  {
-    label: "Coverage",
-    to: "/coverage",
-    icon: Shield,
-    roles: ["coordinator", "admin"],
-  },
-  {
-    label: "Admin",
-    to: "/admin",
-    icon: Shield,
-    roles: ["admin"],
-  },
-];
+function getSections(role: UserRole): NavSection[] {
+  const sections: NavSection[] = [];
+
+  if (role === "volunteer") {
+    sections.push({
+      heading: "Volunteer",
+      items: [
+        { label: "My Shifts", to: "/dashboard", icon: Home },
+        { label: "Browse Shifts", to: "/shifts", icon: Calendar },
+        { label: "Events", to: "/events", icon: CalendarDays },
+        { label: "My History", to: "/history", icon: ClipboardList },
+        { label: "My Notes", to: "/notes", icon: FileText },
+        { label: "Documents", to: "/documents", icon: FolderOpen },
+        { label: "Messages", to: "/messages", icon: MessageSquare },
+      ],
+    });
+  }
+
+  if (role === "coordinator" || role === "admin") {
+    sections.push({
+      heading: "Coordinator",
+      items: [
+        { label: "Department Shifts", to: "/coordinator", icon: Building2 },
+        { label: "Manage Shifts", to: "/coordinator/manage", icon: Settings },
+        { label: "Unactioned Shifts", to: "/admin/unactioned-shifts", icon: AlertCircle },
+        { label: "Reports", to: "/reports", icon: BarChart3 },
+        { label: "Messages", to: "/messages", icon: MessageSquare },
+      ],
+    });
+  }
+
+  if (role === "admin") {
+    sections.push({
+      heading: "Admin",
+      items: [
+        { label: "All Shifts", to: "/admin", icon: Calendar },
+        { label: "Users", to: "/admin/users", icon: Users },
+        { label: "Departments", to: "/admin/departments", icon: Building2 },
+        { label: "Events", to: "/admin/events", icon: CalendarDays },
+        { label: "Reminders", to: "/admin/reminders", icon: Bell },
+        { label: "Admin Settings", to: "/admin/settings", icon: Shield },
+        { label: "Doc Types", to: "/admin/documents", icon: FolderOpen },
+        { label: "Compliance", to: "/admin/compliance", icon: CheckSquare },
+      ],
+    });
+  }
+
+  // Common section at the bottom for all roles
+  sections.push({
+    heading: "",
+    items: [
+      { label: "Settings", to: "/settings", icon: Cog },
+    ],
+  });
+
+  return sections;
+}
 
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
@@ -74,9 +125,7 @@ export function MobileNav({ userRole = "volunteer", userName }: MobileNavProps) 
   const [open, setOpen] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
 
-  const visibleItems = NAV_ITEMS.filter(
-    (item) => !item.roles || item.roles.includes(userRole)
-  );
+  const sections = getSections(userRole);
 
   const handleSignOut = async () => {
     setSigningOut(true);
@@ -89,13 +138,13 @@ export function MobileNav({ userRole = "volunteer", userName }: MobileNavProps) 
     }
   };
 
-  /* Active link style helper */
+  /* Active link style helper — uses theme-aware tokens */
   const linkClasses = ({ isActive }: { isActive: boolean }) =>
     [
       "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors",
       isActive
-        ? "bg-[#006B3E]/10 text-[#006B3E]"
-        : "text-gray-700 hover:bg-gray-100",
+        ? "bg-primary/10 text-primary"
+        : "text-foreground hover:bg-muted",
     ].join(" ");
 
   return (
@@ -114,39 +163,48 @@ export function MobileNav({ userRole = "volunteer", userName }: MobileNavProps) 
       <SheetContent side="left" className="flex w-72 flex-col p-0">
         {/* ---- Header ---- */}
         <SheetHeader className="border-b px-4 py-4">
-          <SheetTitle className="text-left text-lg font-bold text-[#006B3E]">
+          <SheetTitle className="text-left text-lg font-bold text-primary">
             Easterseals Iowa
           </SheetTitle>
           {userName && (
-            <p className="text-left text-xs text-gray-500">
+            <p className="text-left text-xs text-muted-foreground">
               Signed in as <span className="font-medium">{userName}</span>
             </p>
           )}
         </SheetHeader>
 
-        {/* ---- Links ---- */}
+        {/* ---- Links grouped by role ---- */}
         <nav className="flex-1 overflow-y-auto px-3 py-4" aria-label="Main">
-          <ul className="space-y-1">
-            {visibleItems.map((item) => (
-              <li key={item.to}>
-                <NavLink
-                  to={item.to}
-                  className={linkClasses}
-                  onClick={() => setOpen(false)}
-                >
-                  <item.icon className="h-4 w-4 shrink-0" />
-                  {item.label}
-                </NavLink>
-              </li>
-            ))}
-          </ul>
+          {sections.map((section) => (
+            <div key={section.heading || "common"} className="mb-4 last:mb-0">
+              {section.heading && (
+                <p className="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  {section.heading}
+                </p>
+              )}
+              <ul className="space-y-0.5">
+                {section.items.map((item) => (
+                  <li key={item.to}>
+                    <NavLink
+                      to={item.to}
+                      className={linkClasses}
+                      onClick={() => setOpen(false)}
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" />
+                      {item.label}
+                    </NavLink>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </nav>
 
         {/* ---- Sign Out ---- */}
         <div className="border-t px-3 py-4">
           <Button
             variant="outline"
-            className="w-full justify-start gap-3 border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
+            className="w-full justify-start gap-3 border-destructive/30 text-destructive hover:bg-destructive/10 hover:text-destructive"
             onClick={handleSignOut}
             disabled={signingOut}
           >
@@ -155,7 +213,7 @@ export function MobileNav({ userRole = "volunteer", userName }: MobileNavProps) 
             ) : (
               <LogOut className="h-4 w-4" />
             )}
-            {signingOut ? "Signing out…" : "Sign Out"}
+            {signingOut ? "Signing out..." : "Sign Out"}
           </Button>
         </div>
       </SheetContent>


### PR DESCRIPTION
Two bugs fixed:

1. Side panel showed generic volunteer menu for all roles. AppLayout rendered <MobileNav /> without passing userRole or userName — the component defaulted to "volunteer" for everyone. Now passes profile.role and profile.full_name from useAuth.

2. MobileNav routes were stale and didn't match AppSidebar.
   - /my-shifts, /coverage were dead routes
   - Coordinators had no access to their real pages
   - Admin saw one generic "Admin" link instead of the full admin menu (Users, Departments, Events, Reminders, Settings, Doc Types, Compliance)

   Rewrote MobileNav to use getSections(role) which returns
   role-grouped nav sections that exactly mirror AppSidebar:
     volunteer: 7 items (dashboard, browse, events, history, notes, docs, messages) coordinator: 5 items (dept shifts, manage, unactioned, reports, messages) admin: 8 items (all shifts, users, depts, events, reminders, settings, doc types, compliance) common: settings (all roles)

   Sections have uppercase group labels matching the sidebar
   ("VOLUNTEER", "COORDINATOR", "ADMIN").

Also fixed: all hardcoded light-only colors in MobileNav replaced with theme-aware tokens:
  - text-[#006B3E] → text-primary
  - bg-[#006B3E]/10 → bg-primary/10
  - text-gray-700 → text-foreground
  - hover:bg-gray-100 → hover:bg-muted
  - text-gray-500 → text-muted-foreground
  - border-red-200 text-red-600 hover:bg-red-50 → border-destructive/30 text-destructive hover:bg-destructive/10

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
