### PR TITLE
fix(e2e): auto-cleanup orphaned test shifts on every run

### DIFF
--- a/tests/e2e/01-volunteer-books-shift.spec.ts
+++ b/tests/e2e/01-volunteer-books-shift.spec.ts
@@ -5,6 +5,7 @@ import {
   getShift,
   listBookingsForShift,
   hardCleanupShift,
+  cleanupStaleE2EShifts,
   getTestDepartmentId,
   uniqueShiftDate,
   expectOk,
@@ -52,6 +53,8 @@ test.describe("Volunteer books a shift", () => {
     const request = await playwright.request.newContext();
     const coord = await signInAsRole(request, "coordinator");
     coordAccess = coord.access_token;
+    // Clean up any orphaned E2E shifts from previous failed runs
+    await cleanupStaleE2EShifts(request, coordAccess);
     const departmentId = await getTestDepartmentId(request, coordAccess);
     shiftDate = uniqueShiftDate(SHIFT_DATE_OFFSET_DAYS);
     uniqueTitle = `E2E-BookFlow-${Date.now()}`;

--- a/tests/e2e/02-waitlist-promotion.spec.ts
+++ b/tests/e2e/02-waitlist-promotion.spec.ts
@@ -5,6 +5,7 @@ import {
   getShift,
   listBookingsForShift,
   hardCleanupShift,
+  cleanupStaleE2EShifts,
   getTestDepartmentId,
   uniqueShiftDate,
   expectOk,
@@ -61,6 +62,8 @@ test.describe("Waitlist promotion lifecycle", () => {
     // --- 1. Coordinator creates the 1-slot shift ---
     const coord = await signInAsRole(request, "coordinator");
     coordAccess = coord.access_token;
+    // Clean up orphaned E2E shifts from previous failed runs
+    await cleanupStaleE2EShifts(request, coordAccess);
     const departmentId = await getTestDepartmentId(request, coordAccess);
     const shiftDate = uniqueShiftDate(SHIFT_DATE_OFFSET_DAYS);
     const shift = await createShift(request, coordAccess, {

--- a/tests/e2e/03-coordinator-confirms-attendance.spec.ts
+++ b/tests/e2e/03-coordinator-confirms-attendance.spec.ts
@@ -4,6 +4,7 @@ import {
   createShift,
   listBookingsForShift,
   hardCleanupShift,
+  cleanupStaleE2EShifts,
   getTestDepartmentId,
   uniquePastShiftDate,
   expectOk,
@@ -55,6 +56,7 @@ test.describe("Coordinator confirms attendance", () => {
     // --- 1. Coordinator creates a far-past shift ---
     const coord = await signInAsRole(request, "coordinator");
     coordAccess = coord.access_token;
+    await cleanupStaleE2EShifts(request, coordAccess);
     const departmentId = await getTestDepartmentId(request, coordAccess);
     const pastDate = uniquePastShiftDate(PAST_DATE_OFFSET_DAYS);
     const shift = await createShift(request, coordAccess, {

--- a/tests/e2e/04-admin-delete-shift.spec.ts
+++ b/tests/e2e/04-admin-delete-shift.spec.ts
@@ -9,6 +9,7 @@ import {
   uniqueShiftDate,
   expectOk,
   cancelVolunteerBookingsOnDate,
+  cleanupStaleE2EShifts,
   authHeaders,
   SUPABASE_URL,
 } from "./fixtures/db";
@@ -45,6 +46,8 @@ test.describe("Admin hard-deletes shift with bookings", () => {
   }) => {
     // --- 1. Coordinator creates a 2-slot shift on a unique date ---
     const coord = await signInAsRole(request, "coordinator");
+    // Clean up orphaned E2E shifts from previous failed runs
+    await cleanupStaleE2EShifts(request, coord.access_token);
     const departmentId = await getTestDepartmentId(
       request,
       coord.access_token

--- a/tests/e2e/fixtures/db.ts
+++ b/tests/e2e/fixtures/db.ts
@@ -273,6 +273,31 @@ export async function getTestDepartmentId(
   return rows[0].department_id;
 }
 
+/**
+ * Delete ALL shifts whose title starts with "E2E-". These are
+ * exclusively created by the Playwright test fixtures — real shifts
+ * never use this prefix. This is the primary defense against orphaned
+ * test data: each spec calls this in beforeAll so that any leftovers
+ * from a previous failed run (where afterAll never executed) are
+ * cleaned before the next run creates new ones.
+ *
+ * Safe against real data: the WHERE clause is `title LIKE 'E2E-%'`.
+ * A human-created shift would have to be intentionally named with
+ * that prefix to be affected.
+ */
+export async function cleanupStaleE2EShifts(
+  request: APIRequestContext,
+  accessToken: string
+): Promise<number> {
+  const res = await request.delete(
+    `${SUPABASE_URL}/rest/v1/shifts?title=like.E2E-%25`,
+    { headers: { ...headers(accessToken), Prefer: "return=representation" } }
+  );
+  if (!res.ok()) return 0;
+  const rows = await res.json();
+  return Array.isArray(rows) ? rows.length : 0;
+}
+
 /** Nuke a shift and everything it owns — used for teardown safety. */
 export async function hardCleanupShift(
   request: APIRequestContext,


### PR DESCRIPTION
E2E test shifts (title prefix "E2E-") accumulated when CI runs failed before afterAll could clean up. Over 20+ failed runs this left 60+ orphaned shifts in the live DB.

Fix: each spec now calls cleanupStaleE2EShifts() in its setup (beforeAll or the test body before creating new shifts). This function DELETEs all shifts WHERE title LIKE 'E2E-%', which is a prefix exclusively used by the test fixtures — real shifts never have this prefix, so production data cannot be affected.

The cleanup runs BEFORE creating the test's own shift, so:
  - Orphans from previous failed runs are cleaned
  - The test's own shift is created fresh
  - afterAll still cleans up the test's specific shift on success
  - If afterAll fails, the NEXT run's beforeAll catches it

Added cleanupStaleE2EShifts() to tests/e2e/fixtures/db.ts and called it in all 4 spec files.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
