### PR TITLE
fix: hide consistency score until 5 shifts completed

### DIFF
--- a/src/pages/BrowseShifts.tsx
+++ b/src/pages/BrowseShifts.tsx
@@ -97,7 +97,7 @@ export default function BrowseShifts() {
   // Booking window based on consistency score
   const extendedBooking = profile?.extended_booking === true;
   const maxBookingDays = extendedBooking ? 21 : 14;
-  const consistencyScore = profile?.consistency_score ?? 0;
+  const consistencyScore = profile?.consistency_score; // null = < 5 shifts completed
 
   const fetchData = useCallback(async () => {
     // Calculate max booking date based on profile
@@ -256,7 +256,9 @@ export default function BrowseShifts() {
                   Extended booking unlocked — book up to <strong>3 weeks</strong> in advance
                 </p>
                 <p className="text-muted-foreground text-xs mt-0.5">
-                  Your consistency score is {consistencyScore}% over your last 5 shifts. Keep it above 90% to retain this perk.
+                  {consistencyScore != null
+                    ? `Your consistency score is ${consistencyScore}% over your last 5 shifts. Keep it above 90% to retain this perk.`
+                    : "Keep completing shifts and maintaining 90%+ attendance to retain this perk."}
                 </p>
               </>
             ) : (
@@ -265,7 +267,7 @@ export default function BrowseShifts() {
                   Standard booking window — 2 weeks in advance
                 </p>
                 <p className="text-muted-foreground text-xs mt-0.5">
-                  {consistencyScore > 0
+                  {consistencyScore != null
                     ? `Your consistency score is ${consistencyScore}%. Reach 90% over your last 5 shifts to unlock a 3-week booking window.`
                     : "Complete 5 shifts with a 90% attendance rate to unlock a 3-week booking window."}
                 </p>

--- a/src/pages/VolunteerDashboard.tsx
+++ b/src/pages/VolunteerDashboard.tsx
@@ -430,9 +430,15 @@ export default function VolunteerDashboard() {
         </Card>
         <Card>
           <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{profile?.consistency_score ?? 0}%</div>
+            <div className="text-2xl font-bold">
+              {profile?.consistency_score != null ? `${profile.consistency_score}%` : "—"}
+            </div>
             <p className="text-sm text-muted-foreground">Consistency Score</p>
-            <p className="text-xs text-muted-foreground mt-1">Based on last 5 shifts</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {profile?.consistency_score != null
+                ? "Based on last 5 shifts"
+                : "Complete 5 shifts to see your score"}
+            </p>
           </CardContent>
         </Card>
         <Card>

--- a/supabase/migrations/20260409_consistency_null_under_5.sql
+++ b/supabase/migrations/20260409_consistency_null_under_5.sql
@@ -1,0 +1,59 @@
+-- =============================================
+-- Fix: consistency score should not show any value until the
+-- volunteer has completed a minimum of 5 shifts. Previously the
+-- function set score to 0 when total < 5, which displayed as "0%"
+-- in the UI — misleading because it implies the volunteer has a
+-- poor score rather than "not enough data yet."
+--
+-- Change: set consistency_score = NULL when total < 5. The frontend
+-- interprets NULL as "not enough shifts" and shows "—" or the
+-- "Complete 5 shifts to unlock..." message instead of a percentage.
+-- =============================================
+
+-- Allow NULL on consistency_score (was NOT NULL DEFAULT 0)
+ALTER TABLE public.profiles ALTER COLUMN consistency_score DROP NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.recalculate_consistency(p_volunteer_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  attended   int;
+  total      int;
+  score      numeric(5,2);
+  extended   boolean;
+BEGIN
+  SELECT
+    COUNT(*) FILTER (WHERE confirmation_status = 'confirmed'),
+    COUNT(*)
+  INTO attended, total
+  FROM (
+    SELECT confirmation_status
+    FROM public.shift_bookings b
+    JOIN public.shifts s ON s.id = b.shift_id
+    WHERE b.volunteer_id = p_volunteer_id
+      AND b.booking_status = 'confirmed'
+      AND b.confirmation_status IN ('confirmed', 'no_show')
+      AND s.shift_date <= current_date
+    ORDER BY s.shift_date DESC
+    LIMIT 5
+  ) recent;
+
+  -- Don't compute a score until the volunteer has at least 5
+  -- completed shifts. NULL signals "not enough data" to the UI.
+  IF total < 5 THEN
+    score    := NULL;
+    extended := false;
+  ELSE
+    score    := ROUND((attended::numeric / total) * 100, 2);
+    extended := score >= 90;
+  END IF;
+
+  UPDATE public.profiles
+  SET consistency_score = score,
+      extended_booking  = extended,
+      updated_at        = now()
+  WHERE id = p_volunteer_id;
+END;
+$function$;


### PR DESCRIPTION
Consistency score should not display any value until the volunteer has completed a minimum of 5 shifts. Previously it showed 0% for new volunteers — misleading because it implies poor attendance rather than insufficient data.

Server-side (migration applied to remote):
  - ALTER TABLE profiles ALTER COLUMN consistency_score DROP NOT NULL
  - recalculate_consistency() now sets consistency_score = NULL when total completed shifts < 5 (was: set to 0)
  - extended_booking remains false until 5 shifts AND >= 90%

Frontend:
  - VolunteerDashboard: shows "—" when consistency_score is null, with "Complete 5 shifts to see your score" subtitle
  - BrowseShifts: booking-window card shows "Complete 5 shifts..." message when score is null (same as before for 0, but now triggered by NULL which is semantically correct)

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
