### PR TITLE
fix(e2e): cancel volunteer bookings inside test body, not just beforeAll

### DIFF
--- a/tests/e2e/01-volunteer-books-shift.spec.ts
+++ b/tests/e2e/01-volunteer-books-shift.spec.ts
@@ -111,6 +111,19 @@ test.describe("Volunteer books a shift", () => {
   }) => {
     const vol = await signInAsRole(request, "volunteer");
 
+    // Cancel any confirmed bookings this volunteer has on the test
+    // date. This MUST run inside the test body (not just beforeAll)
+    // because on Playwright retries, beforeAll does NOT re-run — if
+    // the previous attempt failed after creating a booking on a
+    // DIFFERENT E2E shift that shares the same date+time, the
+    // overlap trigger would fire again. Belt-and-suspenders.
+    await cancelVolunteerBookingsOnDate(
+      request,
+      vol.access_token,
+      vol.user.id,
+      shiftDate
+    );
+
     // Counter starts at 0 of 2.
     const before = await getShift(request, coordAccess, shiftId!);
     expect(before).not.toBeNull();


### PR DESCRIPTION
Test 01 was consistently failing with "You already have a booking that overlaps" because cancelVolunteerBookingsOnDate only ran in beforeAll — Playwright retries do NOT re-run beforeAll, so on retry the cancel never re-fired and the overlap trigger blocked the insert.

Moved the cancel call into the test body itself, immediately before the booking INSERT. Now on every attempt (including retries) the volunteer's existing confirmed bookings on the test date are cancelled first, guaranteeing a clean slate for the overlap trigger.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
