### PR TITLE
fix: add volunteer_id to shift report upsert (RLS fix)

### DIFF
--- a/src/pages/ShiftConfirmation.tsx
+++ b/src/pages/ShiftConfirmation.tsx
@@ -154,10 +154,15 @@ export default function ShiftConfirmation() {
     // Save to volunteer_shift_reports — upsert so it works whether or not a row exists.
     // The DB trigger automatically syncs self_reported_hours to
     // shift_bookings.volunteer_reported_hours and runs resolve_hours_discrepancy().
+    // volunteer_id is required by the RLS policy (volunteer_id = auth.uid()).
+    // Without it the inserted row gets volunteer_id = NULL which fails
+    // the WITH CHECK and returns "new row violates row-level security
+    // policy for table volunteer_shift_reports".
     const { error: reportErr } = await supabase
       .from("volunteer_shift_reports")
       .upsert({
         booking_id: bookingId!,
+        volunteer_id: user.id,
         self_confirm_status: "attended" as any,
         self_reported_hours: hoursNum,
         star_rating: rating,


### PR DESCRIPTION
Submitting shift confirmation failed with:
  new row violates row-level security policy for table
  "volunteer_shift_reports"

The upsert payload was missing volunteer_id. The column has no DEFAULT, so the inserted row got volunteer_id = NULL which failed the RLS check (volunteer_id = auth.uid()). Added user.id to the upsert payload.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
