### PR TITLE
fix(e2e): use admin token for E2E shift cleanup

### DIFF
--- a/tests/e2e/01-volunteer-books-shift.spec.ts
+++ b/tests/e2e/01-volunteer-books-shift.spec.ts
@@ -53,8 +53,10 @@ test.describe("Volunteer books a shift", () => {
     const request = await playwright.request.newContext();
     const coord = await signInAsRole(request, "coordinator");
     coordAccess = coord.access_token;
-    // Clean up any orphaned E2E shifts from previous failed runs
-    await cleanupStaleE2EShifts(request, coordAccess);
+    // Clean up orphaned E2E shifts using ADMIN token (coordinator
+    // RLS can't delete shifts in other departments)
+    const admin = await signInAsRole(request, "admin");
+    await cleanupStaleE2EShifts(request, admin.access_token);
     const departmentId = await getTestDepartmentId(request, coordAccess);
     shiftDate = uniqueShiftDate(SHIFT_DATE_OFFSET_DAYS);
     uniqueTitle = `E2E-BookFlow-${Date.now()}`;

--- a/tests/e2e/02-waitlist-promotion.spec.ts
+++ b/tests/e2e/02-waitlist-promotion.spec.ts
@@ -62,8 +62,9 @@ test.describe("Waitlist promotion lifecycle", () => {
     // --- 1. Coordinator creates the 1-slot shift ---
     const coord = await signInAsRole(request, "coordinator");
     coordAccess = coord.access_token;
-    // Clean up orphaned E2E shifts from previous failed runs
-    await cleanupStaleE2EShifts(request, coordAccess);
+    // Clean up orphaned E2E shifts using ADMIN token
+    const adminForCleanup = await signInAsRole(request, "admin");
+    await cleanupStaleE2EShifts(request, adminForCleanup.access_token);
     const departmentId = await getTestDepartmentId(request, coordAccess);
     const shiftDate = uniqueShiftDate(SHIFT_DATE_OFFSET_DAYS);
     const shift = await createShift(request, coordAccess, {

--- a/tests/e2e/03-coordinator-confirms-attendance.spec.ts
+++ b/tests/e2e/03-coordinator-confirms-attendance.spec.ts
@@ -56,7 +56,9 @@ test.describe("Coordinator confirms attendance", () => {
     // --- 1. Coordinator creates a far-past shift ---
     const coord = await signInAsRole(request, "coordinator");
     coordAccess = coord.access_token;
-    await cleanupStaleE2EShifts(request, coordAccess);
+    // Clean up orphaned E2E shifts using ADMIN token
+    const adminForCleanup = await signInAsRole(request, "admin");
+    await cleanupStaleE2EShifts(request, adminForCleanup.access_token);
     const departmentId = await getTestDepartmentId(request, coordAccess);
     const pastDate = uniquePastShiftDate(PAST_DATE_OFFSET_DAYS);
     const shift = await createShift(request, coordAccess, {

--- a/tests/e2e/04-admin-delete-shift.spec.ts
+++ b/tests/e2e/04-admin-delete-shift.spec.ts
@@ -46,8 +46,9 @@ test.describe("Admin hard-deletes shift with bookings", () => {
   }) => {
     // --- 1. Coordinator creates a 2-slot shift on a unique date ---
     const coord = await signInAsRole(request, "coordinator");
-    // Clean up orphaned E2E shifts from previous failed runs
-    await cleanupStaleE2EShifts(request, coord.access_token);
+    // Clean up orphaned E2E shifts using ADMIN token
+    const adminForCleanup = await signInAsRole(request, "admin");
+    await cleanupStaleE2EShifts(request, adminForCleanup.access_token);
     const departmentId = await getTestDepartmentId(
       request,
       coord.access_token

--- a/tests/e2e/fixtures/db.ts
+++ b/tests/e2e/fixtures/db.ts
@@ -285,17 +285,44 @@ export async function getTestDepartmentId(
  * A human-created shift would have to be intentionally named with
  * that prefix to be affected.
  */
+/**
+ * IMPORTANT: call this with the ADMIN access token, not the
+ * coordinator's. The coordinator's RLS only allows deleting shifts
+ * in their own departments — E2E shifts in other departments
+ * silently survive the DELETE. The admin has unrestricted DELETE.
+ */
 export async function cleanupStaleE2EShifts(
   request: APIRequestContext,
-  accessToken: string
+  adminAccessToken: string
 ): Promise<number> {
+  // 1. Find all E2E shift IDs first
+  const listRes = await request.get(
+    `${SUPABASE_URL}/rest/v1/shifts?select=id&title=like.E2E-%25`,
+    { headers: headers(adminAccessToken) }
+  );
+  if (!listRes.ok()) return 0;
+  const shiftRows = (await listRes.json()) as Array<{ id: string }>;
+  if (!shiftRows || shiftRows.length === 0) return 0;
+
+  const ids = shiftRows.map((r) => r.id);
+
+  // 2. Explicitly delete bookings for these shifts (belt-and-suspenders
+  // in case CASCADE doesn't fire through RLS context)
+  for (const id of ids) {
+    await request.delete(
+      `${SUPABASE_URL}/rest/v1/shift_bookings?shift_id=eq.${id}`,
+      { headers: headers(adminAccessToken) }
+    );
+  }
+
+  // 3. Delete the shifts themselves
   const res = await request.delete(
     `${SUPABASE_URL}/rest/v1/shifts?title=like.E2E-%25`,
-    { headers: { ...headers(accessToken), Prefer: "return=representation" } }
+    { headers: { ...headers(adminAccessToken), Prefer: "return=representation" } }
   );
   if (!res.ok()) return 0;
-  const rows = await res.json();
-  return Array.isArray(rows) ? rows.length : 0;
+  const deleted = await res.json();
+  return Array.isArray(deleted) ? deleted.length : 0;
 }
 
 /** Nuke a shift and everything it owns — used for teardown safety. */


### PR DESCRIPTION
E2E test shifts kept reappearing because cleanupStaleE2EShifts used the coordinator's access token. The coordinator's RLS only allows deleting shifts in their assigned departments — E2E shifts created in other departments silently survived the DELETE (PostgREST returns 200 with 0 rows affected, no error).

Fix:
  - All 4 specs now sign in as admin and pass the admin token to cleanupStaleE2EShifts (admin has unrestricted DELETE on shifts)
  - cleanupStaleE2EShifts now explicitly deletes bookings for each E2E shift before deleting the shifts themselves, as belt-and- suspenders against CASCADE not firing through the RLS context

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
