### PR TITLE
feature: add Unactioned Shifts page for volunteers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
     name: Playwright E2E
     runs-on: ubuntu-latest
     needs: lint-and-unit
+    # Only one E2E suite at a time — tests create/delete shifts on a
+    # shared production DB. Parallel runs (push + PR sync events)
+    # delete each other's test shifts mid-test, causing FK errors.
+    concurrency:
+      group: e2e-playwright
+      cancel-in-progress: false
     env:
       # Always run Playwright against the production deployment for
       # now. The earlier attempt to construct the Vercel PR preview

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import AdminDocumentTypes from "./pages/AdminDocumentTypes";
 import DocumentCompliance from "./pages/DocumentCompliance";
 import VolunteerDocuments from "./pages/VolunteerDocuments";
 import Messages from "./pages/Messages";
+import VolunteerUnactionedShifts from "./pages/VolunteerUnactionedShifts";
 
 const queryClient = new QueryClient();
 
@@ -82,6 +83,7 @@ const App = () => (
             <Route path="/my-shifts/confirm/:bookingId" element={<ProtectedRoute requiredRole={["volunteer"]}><ShiftConfirmation /></ProtectedRoute>} />
             <Route path="/notes" element={<ProtectedRoute requiredRole={["volunteer"]}><MyNotes /></ProtectedRoute>} />
             <Route path="/documents" element={<ProtectedRoute requiredRole={["volunteer"]}><VolunteerDocuments /></ProtectedRoute>} />
+            <Route path="/unactioned" element={<ProtectedRoute requiredRole={["volunteer"]}><VolunteerUnactionedShifts /></ProtectedRoute>} />
 
             <Route path="/coordinator" element={<ProtectedRoute requiredRole={["coordinator", "admin"]}><CoordinatorDashboard /></ProtectedRoute>} />
             <Route path="/coordinator/manage" element={<ProtectedRoute requiredRole={["coordinator", "admin"]}><ManageShifts /></ProtectedRoute>} />

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -17,6 +17,7 @@ export function AppSidebar() {
   const volunteerItems = role === "volunteer" ? [
     { title: "My Shifts", url: "/dashboard", icon: Home },
     { title: "Browse Shifts", url: "/shifts", icon: Calendar },
+    { title: "Unactioned Shifts", url: "/unactioned", icon: AlertCircle },
     { title: "Events", url: "/events", icon: CalendarDays },
     { title: "My History", url: "/history", icon: ClipboardList },
     { title: "My Notes", url: "/notes", icon: FileText },

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -67,6 +67,7 @@ function getSections(role: UserRole): NavSection[] {
       items: [
         { label: "My Shifts", to: "/dashboard", icon: Home },
         { label: "Browse Shifts", to: "/shifts", icon: Calendar },
+        { label: "Unactioned Shifts", to: "/unactioned", icon: AlertCircle },
         { label: "Events", to: "/events", icon: CalendarDays },
         { label: "My History", to: "/history", icon: ClipboardList },
         { label: "My Notes", to: "/notes", icon: FileText },

--- a/src/pages/VolunteerUnactionedShifts.tsx
+++ b/src/pages/VolunteerUnactionedShifts.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Calendar, Clock, Building2, CheckCircle, AlertCircle } from "lucide-react";
+import { format } from "date-fns";
+import { timeLabel, parseShiftDate } from "@/lib/calendar-utils";
+
+interface UnactionedBooking {
+  id: string;
+  booking_status: string;
+  confirmation_status: string;
+  checked_in_at: string | null;
+  shifts: {
+    id: string;
+    title: string;
+    shift_date: string;
+    time_type: string;
+    start_time: string | null;
+    end_time: string | null;
+    departments: { name: string } | null;
+  };
+}
+
+export default function VolunteerUnactionedShifts() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [bookings, setBookings] = useState<UnactionedBooking[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) return;
+    const fetch = async () => {
+      // Fetch confirmed bookings that haven't been actioned (still
+      // pending_confirmation) for shifts that have already ended.
+      const today = format(new Date(), "yyyy-MM-dd");
+      const { data } = await supabase
+        .from("shift_bookings")
+        .select(
+          "id, booking_status, confirmation_status, checked_in_at, shifts!shift_bookings_shift_id_fkey(id, title, shift_date, time_type, start_time, end_time, departments(name))"
+        )
+        .eq("volunteer_id", user.id)
+        .eq("booking_status", "confirmed")
+        .eq("confirmation_status", "pending_confirmation")
+        .order("created_at", { ascending: false });
+
+      if (data) {
+        // Client-side filter: only include shifts whose end time has
+        // already passed. We need this because PostgREST can't
+        // compare shift_date + end_time < now() in a single filter.
+        const now = new Date();
+        const ended = (data as unknown as UnactionedBooking[]).filter((b) => {
+          if (!b.shifts) return false;
+          const endStr =
+            b.shifts.end_time ||
+            (b.shifts.time_type === "morning"
+              ? "12:00:00"
+              : b.shifts.time_type === "afternoon"
+              ? "16:00:00"
+              : "17:00:00");
+          const endAt = new Date(`${b.shifts.shift_date}T${endStr}`);
+          return endAt < now;
+        });
+        setBookings(ended);
+      }
+      setLoading(false);
+    };
+    fetch();
+  }, [user]);
+
+  if (loading) {
+    return (
+      <div className="max-w-3xl mx-auto p-6 text-muted-foreground">
+        Loading...
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold flex items-center gap-2">
+          <AlertCircle className="h-6 w-6 text-warning" />
+          Unactioned Shifts
+        </h2>
+        <p className="text-muted-foreground text-sm mt-1">
+          These shifts have ended but you haven't confirmed your attendance yet.
+          Please confirm each one so your volunteer hours are recorded.
+        </p>
+      </div>
+
+      {bookings.length === 0 ? (
+        <Card>
+          <CardContent className="pt-6 text-center space-y-2">
+            <CheckCircle className="h-10 w-10 text-success mx-auto" />
+            <p className="text-muted-foreground">
+              All caught up! No shifts awaiting confirmation.
+            </p>
+            <Button
+              variant="outline"
+              onClick={() => navigate("/dashboard")}
+            >
+              Back to Dashboard
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-3">
+          {bookings.map((b) => (
+            <Card key={b.id}>
+              <CardContent className="pt-4 pb-4">
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                  <div className="space-y-1.5">
+                    <div className="font-medium">{b.shifts.title}</div>
+                    <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+                      <span className="flex items-center gap-1">
+                        <Calendar className="h-3.5 w-3.5" />
+                        {format(
+                          parseShiftDate(b.shifts.shift_date),
+                          "MMM d, yyyy"
+                        )}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <Clock className="h-3.5 w-3.5" />
+                        {timeLabel(b.shifts)}
+                      </span>
+                      {b.shifts.departments?.name && (
+                        <span className="flex items-center gap-1">
+                          <Building2 className="h-3.5 w-3.5" />
+                          {b.shifts.departments.name}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex gap-2 flex-wrap">
+                      {b.checked_in_at ? (
+                        <Badge className="bg-primary/10 text-primary text-xs">
+                          Checked In
+                        </Badge>
+                      ) : (
+                        <Badge
+                          variant="outline"
+                          className="text-xs text-warning border-warning"
+                        >
+                          Not Checked In
+                        </Badge>
+                      )}
+                      <Badge
+                        variant="outline"
+                        className="text-xs text-warning border-warning"
+                      >
+                        Pending Confirmation
+                      </Badge>
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    onClick={() =>
+                      navigate(`/my-shifts/confirm/${b.id}`)
+                    }
+                  >
+                    Confirm Now
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Volunteers previously had no way to find completed shifts that need confirmation except through the notification dropdown. If they dismissed a notification or it expired, they had no second path to the confirmation page.

New page at /unactioned:
  - Lists all the volunteer's confirmed bookings where the shift has ended and confirmation_status = pending_confirmation
  - Each card shows shift title, date, time, department, check-in status, and a "Confirm Now" button linking to the existing /my-shifts/confirm/:bookingId page
  - Shows "All caught up!" when there are no pending confirmations
  - Client-side filters out shifts that haven't ended yet (same shiftEndAt logic used throughout the app)

Navigation:
  - Added "Unactioned Shifts" with AlertCircle icon to the volunteer section of both AppSidebar (desktop) and MobileNav (mobile), positioned right after "Browse Shifts" for discoverability
  - Route added to App.tsx: /unactioned (volunteer role only)

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
