### PR TITLE
fix: add volunteer_id to no-show report upsert (RLS fix)

### DIFF
--- a/src/pages/ShiftConfirmation.tsx
+++ b/src/pages/ShiftConfirmation.tsx
@@ -91,10 +91,12 @@ export default function ShiftConfirmation() {
 
     if (attended === false) {
       // Self-reported no-show — upsert so it works whether or not a row exists
+      // volunteer_id is required by RLS (volunteer_id = auth.uid())
       const { error: reportErr } = await supabase
         .from("volunteer_shift_reports")
         .upsert({
           booking_id: bookingId!,
+          volunteer_id: user.id,
           self_confirm_status: "no_show" as any,
           submitted_at: new Date().toISOString(),
         }, { onConflict: "booking_id" });


### PR DESCRIPTION
The previous fix (PR #21) added volunteer_id to the "Yes, I attended" upsert path but missed the "No, I didn't attend" path. Same RLS error: volunteer_id was NULL, failing the volunteer_id = auth.uid() check.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
