### PR TITLE
fix: QA audit round 1 — mobile polish + dark theme + button truncation

### DIFF
--- a/src/components/CoverageAlert.tsx
+++ b/src/components/CoverageAlert.tsx
@@ -215,7 +215,7 @@ export default function CoverageAlert() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-8">
-        <Loader2 className="h-5 w-5 animate-spin text-[#006B3E]" />
+        <Loader2 className="h-5 w-5 animate-spin text-primary" />
       </div>
     );
   }
@@ -243,10 +243,10 @@ export default function CoverageAlert() {
                   className="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div className="space-y-0.5">
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="text-sm font-medium text-foreground">
                       {s.department_name}
                     </p>
-                    <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500">
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
                       <span className="flex items-center gap-1">
                         <CalendarDays className="h-3 w-3" />
                         {s.shift_date}
@@ -265,7 +265,7 @@ export default function CoverageAlert() {
 
                   <Button
                     size="sm"
-                    className="w-full sm:w-auto bg-[#006B3E] hover:bg-[#005a33]"
+                    className="w-full sm:w-auto bg-primary hover:bg-primary/90"
                     onClick={() => openInviteModal(s)}
                   >
                     <Users className="mr-1.5 h-3.5 w-3.5" />
@@ -283,7 +283,7 @@ export default function CoverageAlert() {
         open={!!inviteShift}
         onOpenChange={(open) => { if (!open) setInviteShift(null); }}
       >
-        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+        <DialogContent className="max-w-lg max-h-[85dvh] flex flex-col">
           <DialogHeader>
             <DialogTitle>Invite Volunteers</DialogTitle>
             <DialogDescription>
@@ -295,10 +295,10 @@ export default function CoverageAlert() {
 
           {loadingVols ? (
             <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-5 w-5 animate-spin text-[#006B3E]" />
+              <Loader2 className="h-5 w-5 animate-spin text-primary" />
             </div>
           ) : volunteers.length === 0 ? (
-            <p className="py-8 text-center text-sm text-gray-500">
+            <p className="py-8 text-center text-sm text-muted-foreground">
               No eligible volunteers found for this shift.
             </p>
           ) : (
@@ -308,7 +308,7 @@ export default function CoverageAlert() {
                 <Checkbox
                   checked={selected.size === volunteers.length}
                   onCheckedChange={selectAll}
-                  className="data-[state=checked]:bg-[#006B3E] data-[state=checked]:border-[#006B3E]"
+                  className="data-[state=checked]:bg-primary data-[state=checked]:border-primary"
                 />
                 <span className="text-sm font-medium">
                   Select all ({volunteers.length})
@@ -318,17 +318,17 @@ export default function CoverageAlert() {
               <ul className="divide-y">
                 {volunteers.map((v) => (
                   <li key={v.id}>
-                    <label className="flex cursor-pointer items-center gap-3 py-2.5 hover:bg-gray-50 -mx-2 px-2 rounded">
+                    <label className="flex cursor-pointer items-center gap-3 py-2.5 hover:bg-muted -mx-2 px-2 rounded">
                       <Checkbox
                         checked={selected.has(v.id)}
                         onCheckedChange={() => toggle(v.id)}
-                        className="data-[state=checked]:bg-[#006B3E] data-[state=checked]:border-[#006B3E]"
+                        className="data-[state=checked]:bg-primary data-[state=checked]:border-primary"
                       />
                       <div>
-                        <p className="text-sm font-medium text-gray-900">
+                        <p className="text-sm font-medium text-foreground">
                           {v.full_name}
                         </p>
-                        <p className="text-xs text-gray-500">{v.email}</p>
+                        <p className="text-xs text-muted-foreground">{v.email}</p>
                       </div>
                     </label>
                   </li>
@@ -347,7 +347,7 @@ export default function CoverageAlert() {
             <Button
               disabled={selected.size === 0 || sending}
               onClick={sendInvitations}
-              className="bg-[#006B3E] hover:bg-[#005a33]"
+              className="bg-primary hover:bg-primary/90"
             >
               {sending ? (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -115,7 +115,7 @@ export function NotificationBell() {
             : "Notifications"}
         </TooltipContent>
       </Tooltip>
-      <PopoverContent className="w-80 p-0" align="end">
+      <PopoverContent className="w-80 max-w-[calc(100vw-2rem)] p-0" align="end">
         <div className="flex items-center justify-between px-4 py-3 border-b">
           <h4 className="font-semibold text-sm">Notifications</h4>
           {unreadCount > 0 && (

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -19,7 +19,7 @@ const DEPT_COLORS: Record<string, string> = {
   "Adult Day Services": "bg-blue-100 text-blue-800 border-blue-200",
   "Children's Services": "bg-purple-100 text-purple-800 border-purple-200",
   "Transportation": "bg-orange-100 text-orange-800 border-orange-200",
-  "Administration": "bg-gray-100 text-gray-800 border-gray-200",
+  "Administration": "bg-muted text-foreground border-border",
 };
 
 function deptBadgeClass(name: string) {

--- a/src/pages/AdminDepartments.tsx
+++ b/src/pages/AdminDepartments.tsx
@@ -235,17 +235,17 @@ export default function AdminDepartments() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <Loader2 className="h-6 w-6 animate-spin text-[#006B3E]" />
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
       </div>
     );
   }
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-8">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">Departments</h1>
-        <Button onClick={openCreate} className="bg-[#006B3E] hover:bg-[#005a33]">
-          <Plus className="mr-2 h-4 w-4" /> Add Department
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h1 className="text-2xl font-bold text-foreground">Departments</h1>
+        <Button size="sm" onClick={openCreate} className="bg-primary hover:bg-primary/90 whitespace-nowrap">
+          <Plus className="mr-1.5 h-4 w-4" /> Add Department
         </Button>
       </div>
 
@@ -263,7 +263,7 @@ export default function AdminDepartments() {
           <TableBody>
             {departments.length === 0 && (
               <TableRow>
-                <TableCell colSpan={4} className="py-8 text-center text-gray-500">
+                <TableCell colSpan={4} className="py-8 text-center text-muted-foreground">
                   No departments yet.
                 </TableCell>
               </TableRow>
@@ -285,7 +285,7 @@ export default function AdminDepartments() {
                         }}
                       />
                       <Button variant="ghost" size="icon" onClick={saveRename}>
-                        <Check className="h-4 w-4 text-[#006B3E]" />
+                        <Check className="h-4 w-4 text-primary" />
                       </Button>
                       <Button
                         variant="ghost"
@@ -317,7 +317,7 @@ export default function AdminDepartments() {
                         .eq("id", dept.id);
                       fetchDepartments();
                     }}
-                    className="data-[state=checked]:bg-[#006B3E]"
+                    className="data-[state=checked]:bg-primary"
                   />
                 </TableCell>
 
@@ -327,7 +327,7 @@ export default function AdminDepartments() {
                     variant={dept.is_active ? "default" : "secondary"}
                     className={
                       dept.is_active
-                        ? "cursor-pointer bg-[#006B3E] text-white hover:bg-[#005a33]"
+                        ? "cursor-pointer bg-primary text-primary-foreground hover:bg-primary/90"
                         : "cursor-pointer"
                     }
                     onClick={() => toggleActive(dept)}
@@ -396,7 +396,7 @@ export default function AdminDepartments() {
             <div className="flex items-center justify-between rounded-lg border p-3">
               <div>
                 <p className="text-sm font-medium">Requires Background Check</p>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-muted-foreground">
                   Volunteers must have a cleared BG check to sign up.
                 </p>
               </div>
@@ -405,7 +405,7 @@ export default function AdminDepartments() {
                 onCheckedChange={(v) =>
                   setForm((f) => ({ ...f, requires_bg_check: v }))
                 }
-                className="data-[state=checked]:bg-[#006B3E]"
+                className="data-[state=checked]:bg-primary"
               />
             </div>
 
@@ -425,7 +425,7 @@ export default function AdminDepartments() {
             <div className="flex items-center justify-between rounded-lg border p-3">
               <div>
                 <p className="text-sm font-medium">Allows Group Volunteering</p>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-muted-foreground">
                   Let groups sign up together for shifts.
                 </p>
               </div>
@@ -434,7 +434,7 @@ export default function AdminDepartments() {
                 onCheckedChange={(v) =>
                   setForm((f) => ({ ...f, allows_groups: v }))
                 }
-                className="data-[state=checked]:bg-[#006B3E]"
+                className="data-[state=checked]:bg-primary"
               />
             </div>
           </div>
@@ -446,7 +446,7 @@ export default function AdminDepartments() {
             <Button
               onClick={handleSaveDialog}
               disabled={saving}
-              className="bg-[#006B3E] hover:bg-[#005a33]"
+              className="bg-primary hover:bg-primary/90"
             >
               {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {editingId ? "Save Changes" : "Create Department"}

--- a/src/pages/AdminEvents.tsx
+++ b/src/pages/AdminEvents.tsx
@@ -198,7 +198,7 @@ export default function AdminEvents() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <Loader2 className="h-6 w-6 animate-spin text-[#006B3E]" />
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
       </div>
     );
   }
@@ -206,14 +206,14 @@ export default function AdminEvents() {
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-8">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">Events</h1>
-        <Button onClick={openCreate} className="bg-[#006B3E] hover:bg-[#005a33]">
+        <h1 className="text-2xl font-bold text-foreground">Events</h1>
+        <Button onClick={openCreate} className="bg-primary hover:bg-primary/90">
           <Plus className="mr-2 h-4 w-4" /> Create Event
         </Button>
       </div>
 
       {events.length === 0 && (
-        <p className="py-12 text-center text-gray-500">
+        <p className="py-12 text-center text-muted-foreground">
           No events yet. Create one to get started.
         </p>
       )}
@@ -247,7 +247,7 @@ export default function AdminEvents() {
                 </CardDescription>
               )}
             </CardHeader>
-            <CardContent className="space-y-1.5 text-sm text-gray-600">
+            <CardContent className="space-y-1.5 text-sm text-muted-foreground">
               <div className="flex items-center gap-2">
                 <CalendarDays className="h-3.5 w-3.5" />
                 {ev.event_date}
@@ -268,7 +268,7 @@ export default function AdminEvents() {
               </div>
               <div className="pt-1">
                 {ev.requires_bg_check && (
-                  <Badge variant="outline" className="text-xs border-[#006B3E] text-[#006B3E]">
+                  <Badge variant="outline" className="text-xs border-primary text-primary">
                     BG Check Required
                   </Badge>
                 )}
@@ -373,7 +373,7 @@ export default function AdminEvents() {
             <div className="flex items-center justify-between rounded-lg border p-3">
               <div>
                 <p className="text-sm font-medium">Requires Background Check</p>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-muted-foreground">
                   Only cleared volunteers may register.
                 </p>
               </div>
@@ -382,7 +382,7 @@ export default function AdminEvents() {
                 onCheckedChange={(v) =>
                   setForm((f) => ({ ...f, requires_bg_check: v }))
                 }
-                className="data-[state=checked]:bg-[#006B3E]"
+                className="data-[state=checked]:bg-primary"
               />
             </div>
           </div>
@@ -394,7 +394,7 @@ export default function AdminEvents() {
             <Button
               onClick={handleSave}
               disabled={saving}
-              className="bg-[#006B3E] hover:bg-[#005a33]"
+              className="bg-primary hover:bg-primary/90"
             >
               {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {editingId ? "Save Changes" : "Create Event"}

--- a/src/pages/ManageShifts.tsx
+++ b/src/pages/ManageShifts.tsx
@@ -343,7 +343,7 @@ export default function ManageShifts() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <Loader2 className="h-6 w-6 animate-spin text-[#006B3E]" />
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
       </div>
     );
   }
@@ -351,8 +351,8 @@ export default function ManageShifts() {
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-8">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">Manage Shifts</h1>
-        <Button onClick={openCreate} className="bg-[#006B3E] hover:bg-[#005a33]">
+        <h1 className="text-2xl font-bold text-foreground">Manage Shifts</h1>
+        <Button onClick={openCreate} className="bg-primary hover:bg-primary/90">
           <Plus className="mr-2 h-4 w-4" /> New Shift
         </Button>
       </div>
@@ -373,7 +373,7 @@ export default function ManageShifts() {
           <TableBody>
             {shifts.length === 0 && (
               <TableRow>
-                <TableCell colSpan={6} className="py-8 text-center text-gray-500">
+                <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
                   No shifts yet. Create one to get started.
                 </TableCell>
               </TableRow>
@@ -390,9 +390,9 @@ export default function ManageShifts() {
                 <TableCell className="text-center">{s.total_slots}</TableCell>
                 <TableCell className="text-center">
                   {s.coordinator_note ? (
-                    <StickyNote className="mx-auto h-4 w-4 text-[#006B3E]" />
+                    <StickyNote className="mx-auto h-4 w-4 text-primary" />
                   ) : (
-                    <span className="text-gray-300">—</span>
+                    <span className="text-muted-foreground/40">—</span>
                   )}
                 </TableCell>
                 <TableCell className="text-right">
@@ -530,7 +530,7 @@ export default function ManageShifts() {
             {/* Coordinator Note */}
             <div className="space-y-1.5">
               <Label className="flex items-center gap-1.5">
-                <StickyNote className="h-3.5 w-3.5 text-[#006B3E]" />
+                <StickyNote className="h-3.5 w-3.5 text-primary" />
                 Coordinator Note
               </Label>
 
@@ -555,7 +555,7 @@ export default function ManageShifts() {
                 disabled={!noteEditable}
                 className="resize-none disabled:opacity-60"
               />
-              <p className="text-right text-xs text-gray-400">
+              <p className="text-right text-xs text-muted-foreground/60">
                 {form.coordinator_note.length}/{NOTE_MAX}
               </p>
             </div>
@@ -568,7 +568,7 @@ export default function ManageShifts() {
             <Button
               onClick={handleSave}
               disabled={saving}
-              className="bg-[#006B3E] hover:bg-[#005a33]"
+              className="bg-primary hover:bg-primary/90"
             >
               {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {editingId ? "Update Shift" : "Create Shift"}

--- a/src/pages/VolunteerEvents.tsx
+++ b/src/pages/VolunteerEvents.tsx
@@ -178,7 +178,7 @@ export default function VolunteerEvents() {
           )}
         </CardHeader>
 
-        <CardContent className="space-y-1.5 text-sm text-gray-600">
+        <CardContent className="space-y-1.5 text-sm text-muted-foreground">
           <div className="flex items-center gap-2">
             <CalendarDays className="h-3.5 w-3.5" />
             {new Date(ev.event_date + "T00:00").toLocaleDateString("en-US", {
@@ -205,7 +205,7 @@ export default function VolunteerEvents() {
 
           <div className="flex gap-1 pt-1">
             {ev.requires_bg_check && (
-              <Badge variant="outline" className="text-xs border-[#006B3E] text-[#006B3E]">
+              <Badge variant="outline" className="text-xs border-primary text-primary">
                 BG Check
               </Badge>
             )}
@@ -221,7 +221,7 @@ export default function VolunteerEvents() {
           <CardFooter>
             {registered ? (
               <div className="flex w-full items-center justify-between">
-                <span className="flex items-center gap-1.5 text-sm font-medium text-[#006B3E]">
+                <span className="flex items-center gap-1.5 text-sm font-medium text-primary">
                   <CheckCircle2 className="h-4 w-4" />
                   Registered
                 </span>
@@ -241,7 +241,7 @@ export default function VolunteerEvents() {
               </div>
             ) : (
               <Button
-                className="w-full bg-[#006B3E] hover:bg-[#005a33]"
+                className="w-full bg-primary hover:bg-primary/90"
                 disabled={full || busy}
                 onClick={() => handleRegister(ev.id)}
               >
@@ -262,14 +262,14 @@ export default function VolunteerEvents() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <Loader2 className="h-6 w-6 animate-spin text-[#006B3E]" />
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
       </div>
     );
   }
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-8">
-      <h1 className="text-2xl font-bold text-gray-900">Events</h1>
+      <h1 className="text-2xl font-bold text-foreground">Events</h1>
 
       <Tabs defaultValue="browse">
         <TabsList>
@@ -277,7 +277,7 @@ export default function VolunteerEvents() {
           <TabsTrigger value="mine">
             My Registrations
             {myEvents.length > 0 && (
-              <Badge className="ml-2 bg-[#006B3E] text-white text-[10px] px-1.5 py-0">
+              <Badge className="ml-2 bg-primary text-white text-[10px] px-1.5 py-0">
                 {myEvents.length}
               </Badge>
             )}
@@ -287,7 +287,7 @@ export default function VolunteerEvents() {
         {/* Browse */}
         <TabsContent value="browse" className="pt-4">
           {events.length === 0 ? (
-            <p className="py-12 text-center text-gray-500">
+            <p className="py-12 text-center text-muted-foreground">
               No upcoming events right now. Check back soon!
             </p>
           ) : (
@@ -302,7 +302,7 @@ export default function VolunteerEvents() {
         {/* My Registrations */}
         <TabsContent value="mine" className="pt-4">
           {myEvents.length === 0 ? (
-            <p className="py-12 text-center text-gray-500">
+            <p className="py-12 text-center text-muted-foreground">
               You haven't registered for any events yet.
             </p>
           ) : (


### PR DESCRIPTION
Full front-end audit across desktop (1440/1280px) and mobile (390/375/412px) viewports as admin, coordinator, and volunteer.

CRITICAL / HIGH fixes:

1. CoverageAlert.tsx — dialog uses vh instead of dvh max-h-[85vh] → max-h-[85dvh] so the invite-volunteers dialog doesn't clip behind mobile browser chrome.

2. NotificationBell.tsx — popover w-80 (320px) clips on 390px Added max-w-[calc(100vw-2rem)] so the notification panel stays within the viewport on narrow phones.

3. AdminDepartments.tsx — "Add Department" button text truncation Added flex-wrap + whitespace-nowrap + size="sm" so the button text doesn't get cut off at 390px. Also fixed heading from hardcoded text-gray-900 to text-foreground.

4. Dark theme sweep — ~30 hardcoded colors replaced across 7 files bg-[#006B3E] → bg-primary, text-gray-* → text-foreground/ text-muted-foreground, data-[state=checked]:bg-[#006B3E] → data-[state=checked]:bg-primary. Files: AdminDepartments, AdminEvents, ManageShifts, VolunteerEvents, CoverageAlert, AdminDashboard (badge color).

MEDIUM / LOW (documented, not fixed this round):
- 4 pages have empty states with no actionable next-step link (BrowseShifts, CoordinatorDashboard, ShiftHistory, Reports)
- Long shift titles on mobile could benefit from truncate class
- Export buttons ("Export All Hours", "Export CSV") are at risk of wrapping on very narrow viewports but currently fit at 390px

Tested at: 1440px, 1280px, 390px (iPhone 14), 375px (iPhone SE) Roles tested: admin (all pages), coordinator (dashboard, shifts),
  volunteer (dashboard, browse, history, messages, settings)

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
