### PR TITLE
fix: data retention cron — prune read notifications older than 90 days

### DIFF
--- a/supabase/migrations/20260410_data_retention_cron.sql
+++ b/supabase/migrations/20260410_data_retention_cron.sql
@@ -1,0 +1,28 @@
+-- =============================================
+-- Data retention: prune stale read notifications.
+--
+-- The notifications table grows unbounded — every booking, message,
+-- shift reminder, and system event inserts a row. Read notifications
+-- have no further value after a few months. Without cleanup, the
+-- table bloats and slows queries (particularly the bell dropdown
+-- which filters is_read = false but still scans the full table on
+-- Supabase's free/pro tier without partitioning).
+--
+-- This cron runs daily at 03:00 CT (08:00 UTC) and deletes
+-- is_read = true notifications older than 90 days. Unread
+-- notifications are NEVER deleted — they stay until the user
+-- actions them or marks them read.
+-- =============================================
+
+SELECT cron.unschedule('prune-read-notifications')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'prune-read-notifications');
+
+SELECT cron.schedule(
+  'prune-read-notifications',
+  '0 8 * * *',   -- 03:00 CT = 08:00 UTC
+  $cron$
+  DELETE FROM public.notifications
+  WHERE is_read = true
+    AND created_at < now() - interval '90 days';
+  $cron$
+);


### PR DESCRIPTION
The notifications table grows unbounded. Every booking, message, shift reminder, and system event inserts a row. Read notifications have no value after a few months but were never cleaned up.

New pg_cron job 'prune-read-notifications' runs daily at 03:00 CT:
  DELETE FROM notifications
  WHERE is_read = true AND created_at < now() - interval '90 days'

Unread notifications are never deleted — they stay until the user actions them. Only read + older-than-90-days rows are pruned.

Applied to remote DB (job #21).

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
