### PR TITLE
feat: coordinator attendance confirmation with dispute escalation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import DocumentCompliance from "./pages/DocumentCompliance";
 import VolunteerDocuments from "./pages/VolunteerDocuments";
 import Messages from "./pages/Messages";
 import VolunteerUnactionedShifts from "./pages/VolunteerUnactionedShifts";
+import AdminDisputes from "./pages/AdminDisputes";
 
 const queryClient = new QueryClient();
 
@@ -98,6 +99,7 @@ const App = () => (
             <Route path="/admin/events" element={<ProtectedRoute requiredRole={["admin"]}><AdminEvents /></ProtectedRoute>} />
             <Route path="/admin/documents" element={<ProtectedRoute requiredRole={["admin"]}><AdminDocumentTypes /></ProtectedRoute>} />
             <Route path="/admin/compliance" element={<ProtectedRoute requiredRole={["admin"]}><DocumentCompliance /></ProtectedRoute>} />
+            <Route path="/admin/disputes" element={<ProtectedRoute requiredRole={["admin"]}><AdminDisputes /></ProtectedRoute>} />
             <Route path="/events" element={<ProtectedRoute><VolunteerEvents /></ProtectedRoute>} />
 
             <Route path="/messages" element={<ProtectedRoute><Messages /></ProtectedRoute>} />

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -5,7 +5,7 @@ import {
   Sidebar, SidebarContent, SidebarGroup, SidebarGroupContent, SidebarGroupLabel,
   SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarFooter, useSidebar,
 } from "@/components/ui/sidebar";
-import { Calendar, CalendarDays, ClipboardList, Users, Shield, Settings, LogOut, Home, Building2, Bell, FileText, Cog, FolderOpen, CheckSquare, MessageSquare, BarChart3, AlertCircle } from "lucide-react";
+import { Calendar, CalendarDays, ClipboardList, Users, Shield, Settings, LogOut, Home, Building2, Bell, FileText, Cog, FolderOpen, CheckSquare, MessageSquare, BarChart3, AlertCircle, Scale } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export function AppSidebar() {
@@ -43,6 +43,7 @@ export function AppSidebar() {
     { title: "Admin Settings", url: "/admin/settings", icon: Shield },
     { title: "Doc Types", url: "/admin/documents", icon: FolderOpen },
     { title: "Compliance", url: "/admin/compliance", icon: CheckSquare },
+    { title: "Disputes", url: "/admin/disputes", icon: Scale },
   ];
 
   const isActive = (path: string) => location.pathname === path;

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -28,6 +28,7 @@ import {
   Building2,
   Bell,
   CheckSquare,
+  Scale,
   BarChart3,
   AlertCircle,
 } from "lucide-react";
@@ -102,6 +103,7 @@ function getSections(role: UserRole): NavSection[] {
         { label: "Admin Settings", to: "/admin/settings", icon: Shield },
         { label: "Doc Types", to: "/admin/documents", icon: FolderOpen },
         { label: "Compliance", to: "/admin/compliance", icon: CheckSquare },
+        { label: "Disputes", to: "/admin/disputes", icon: Scale },
       ],
     });
   }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -81,6 +81,136 @@ export type Database = {
           },
         ]
       }
+      admin_mfa_resets: {
+        Row: {
+          created_at: string
+          id: string
+          notes: string | null
+          reset_by: string
+          reset_method: string
+          target_email: string
+          target_user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          notes?: string | null
+          reset_by: string
+          reset_method?: string
+          target_email: string
+          target_user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          notes?: string | null
+          reset_by?: string
+          reset_method?: string
+          target_email?: string
+          target_user_id?: string
+        }
+        Relationships: []
+      }
+      attendance_disputes: {
+        Row: {
+          admin_decided_at: string | null
+          admin_decided_by: string | null
+          admin_decision: string | null
+          admin_notes: string | null
+          booking_id: string
+          coordinator_id: string
+          coordinator_status: string
+          created_at: string
+          expires_at: string
+          final_hours_awarded: number | null
+          id: string
+          resolved_by: string | null
+          shift_id: string
+          volunteer_id: string
+          volunteer_reported_hours: number | null
+          volunteer_status: string
+        }
+        Insert: {
+          admin_decided_at?: string | null
+          admin_decided_by?: string | null
+          admin_decision?: string | null
+          admin_notes?: string | null
+          booking_id: string
+          coordinator_id: string
+          coordinator_status: string
+          created_at?: string
+          expires_at?: string
+          final_hours_awarded?: number | null
+          id?: string
+          resolved_by?: string | null
+          shift_id: string
+          volunteer_id: string
+          volunteer_reported_hours?: number | null
+          volunteer_status: string
+        }
+        Update: {
+          admin_decided_at?: string | null
+          admin_decided_by?: string | null
+          admin_decision?: string | null
+          admin_notes?: string | null
+          booking_id?: string
+          coordinator_id?: string
+          coordinator_status?: string
+          created_at?: string
+          expires_at?: string
+          final_hours_awarded?: number | null
+          id?: string
+          resolved_by?: string | null
+          shift_id?: string
+          volunteer_id?: string
+          volunteer_reported_hours?: number | null
+          volunteer_status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "attendance_disputes_admin_decided_by_fkey"
+            columns: ["admin_decided_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "attendance_disputes_booking_id_fkey"
+            columns: ["booking_id"]
+            isOneToOne: true
+            referencedRelation: "shift_bookings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "attendance_disputes_coordinator_id_fkey"
+            columns: ["coordinator_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "attendance_disputes_shift_id_fkey"
+            columns: ["shift_id"]
+            isOneToOne: false
+            referencedRelation: "shift_fill_rates"
+            referencedColumns: ["shift_id"]
+          },
+          {
+            foreignKeyName: "attendance_disputes_shift_id_fkey"
+            columns: ["shift_id"]
+            isOneToOne: false
+            referencedRelation: "shifts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "attendance_disputes_volunteer_id_fkey"
+            columns: ["volunteer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       confirmation_reminders: {
         Row: {
           booking_id: string
@@ -125,6 +255,7 @@ export type Database = {
       }
       conversation_participants: {
         Row: {
+          cleared_at: string | null
           conversation_id: string
           id: string
           is_archived: boolean
@@ -133,6 +264,7 @@ export type Database = {
           user_id: string
         }
         Insert: {
+          cleared_at?: string | null
           conversation_id: string
           id?: string
           is_archived?: boolean
@@ -141,6 +273,7 @@ export type Database = {
           user_id: string
         }
         Update: {
+          cleared_at?: string | null
           conversation_id?: string
           id?: string
           is_archived?: boolean
@@ -547,6 +680,38 @@ export type Database = {
           },
         ]
       }
+      mfa_backup_codes: {
+        Row: {
+          code_hash: string
+          created_at: string
+          id: string
+          used_at: string | null
+          user_id: string
+        }
+        Insert: {
+          code_hash: string
+          created_at?: string
+          id?: string
+          used_at?: string | null
+          user_id: string
+        }
+        Update: {
+          code_hash?: string
+          created_at?: string
+          id?: string
+          used_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "mfa_backup_codes_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       notifications: {
         Row: {
           created_at: string
@@ -591,6 +756,98 @@ export type Database = {
           },
         ]
       }
+      parental_consents: {
+        Row: {
+          consent_given_at: string | null
+          consent_method: string
+          created_at: string
+          expires_at: string | null
+          id: string
+          is_active: boolean
+          parent_email: string
+          parent_name: string
+          parent_phone: string | null
+          updated_at: string
+          volunteer_id: string
+        }
+        Insert: {
+          consent_given_at?: string | null
+          consent_method?: string
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          is_active?: boolean
+          parent_email: string
+          parent_name: string
+          parent_phone?: string | null
+          updated_at?: string
+          volunteer_id: string
+        }
+        Update: {
+          consent_given_at?: string | null
+          consent_method?: string
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          is_active?: boolean
+          parent_email?: string
+          parent_name?: string
+          parent_phone?: string | null
+          updated_at?: string
+          volunteer_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "parental_consents_volunteer_id_fkey"
+            columns: ["volunteer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      private_note_access_log: {
+        Row: {
+          access_reason: string
+          accessed_at: string
+          admin_user_id: string
+          id: string
+          note_id: string
+          volunteer_id: string
+        }
+        Insert: {
+          access_reason: string
+          accessed_at?: string
+          admin_user_id: string
+          id?: string
+          note_id: string
+          volunteer_id: string
+        }
+        Update: {
+          access_reason?: string
+          accessed_at?: string
+          admin_user_id?: string
+          id?: string
+          note_id?: string
+          volunteer_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "private_note_access_log_admin_user_id_fkey"
+            columns: ["admin_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "private_note_access_log_volunteer_id_fkey"
+            columns: ["volunteer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           avatar_url: string | null
@@ -599,8 +856,9 @@ export type Database = {
           bg_check_updated_at: string | null
           booking_privileges: boolean
           calendar_token: string | null
-          consistency_score: number
+          consistency_score: number | null
           created_at: string
+          date_of_birth: string | null
           email: string
           emergency_contact: string | null
           emergency_contact_name: string | null
@@ -609,7 +867,9 @@ export type Database = {
           full_name: string
           id: string
           is_active: boolean
+          is_minor: boolean
           location_id: string | null
+          messaging_blocked: boolean
           notif_booking_changes: boolean | null
           notif_document_expiry: boolean | null
           notif_email: boolean
@@ -622,6 +882,7 @@ export type Database = {
           phone: string | null
           phone_verified: boolean
           role: Database["public"]["Enums"]["user_role"]
+          signin_count: number
           tos_accepted_at: string | null
           total_hours: number
           updated_at: string
@@ -635,8 +896,9 @@ export type Database = {
           bg_check_updated_at?: string | null
           booking_privileges?: boolean
           calendar_token?: string | null
-          consistency_score?: number
+          consistency_score?: number | null
           created_at?: string
+          date_of_birth?: string | null
           email: string
           emergency_contact?: string | null
           emergency_contact_name?: string | null
@@ -645,7 +907,9 @@ export type Database = {
           full_name: string
           id: string
           is_active?: boolean
+          is_minor?: boolean
           location_id?: string | null
+          messaging_blocked?: boolean
           notif_booking_changes?: boolean | null
           notif_document_expiry?: boolean | null
           notif_email?: boolean
@@ -658,6 +922,7 @@ export type Database = {
           phone?: string | null
           phone_verified?: boolean
           role?: Database["public"]["Enums"]["user_role"]
+          signin_count?: number
           tos_accepted_at?: string | null
           total_hours?: number
           updated_at?: string
@@ -671,8 +936,9 @@ export type Database = {
           bg_check_updated_at?: string | null
           booking_privileges?: boolean
           calendar_token?: string | null
-          consistency_score?: number
+          consistency_score?: number | null
           created_at?: string
+          date_of_birth?: string | null
           email?: string
           emergency_contact?: string | null
           emergency_contact_name?: string | null
@@ -681,7 +947,9 @@ export type Database = {
           full_name?: string
           id?: string
           is_active?: boolean
+          is_minor?: boolean
           location_id?: string | null
+          messaging_blocked?: boolean
           notif_booking_changes?: boolean | null
           notif_document_expiry?: boolean | null
           notif_email?: boolean
@@ -694,6 +962,7 @@ export type Database = {
           phone?: string | null
           phone_verified?: boolean
           role?: Database["public"]["Enums"]["user_role"]
+          signin_count?: number
           tos_accepted_at?: string | null
           total_hours?: number
           updated_at?: string
@@ -802,7 +1071,10 @@ export type Database = {
           confirmation_status: Database["public"]["Enums"]["confirmation_status"]
           confirmed_at: string | null
           confirmed_by: string | null
+          coordinator_actioned_at: string | null
+          coordinator_actioned_by: string | null
           coordinator_reported_hours: number | null
+          coordinator_status: string | null
           counted_in_consistency: boolean
           created_at: string
           final_hours: number | null
@@ -814,9 +1086,11 @@ export type Database = {
           late_cancel_notified: boolean
           promoted_at: string | null
           shift_id: string
+          time_slot_id: string | null
           updated_at: string
           volunteer_id: string
           volunteer_reported_hours: number | null
+          waitlist_offer_expires_at: string | null
         }
         Insert: {
           booking_status?: Database["public"]["Enums"]["booking_status"]
@@ -825,7 +1099,10 @@ export type Database = {
           confirmation_status?: Database["public"]["Enums"]["confirmation_status"]
           confirmed_at?: string | null
           confirmed_by?: string | null
+          coordinator_actioned_at?: string | null
+          coordinator_actioned_by?: string | null
           coordinator_reported_hours?: number | null
+          coordinator_status?: string | null
           counted_in_consistency?: boolean
           created_at?: string
           final_hours?: number | null
@@ -837,9 +1114,11 @@ export type Database = {
           late_cancel_notified?: boolean
           promoted_at?: string | null
           shift_id: string
+          time_slot_id?: string | null
           updated_at?: string
           volunteer_id: string
           volunteer_reported_hours?: number | null
+          waitlist_offer_expires_at?: string | null
         }
         Update: {
           booking_status?: Database["public"]["Enums"]["booking_status"]
@@ -848,7 +1127,10 @@ export type Database = {
           confirmation_status?: Database["public"]["Enums"]["confirmation_status"]
           confirmed_at?: string | null
           confirmed_by?: string | null
+          coordinator_actioned_at?: string | null
+          coordinator_actioned_by?: string | null
           coordinator_reported_hours?: number | null
+          coordinator_status?: string | null
           counted_in_consistency?: boolean
           created_at?: string
           final_hours?: number | null
@@ -860,14 +1142,23 @@ export type Database = {
           late_cancel_notified?: boolean
           promoted_at?: string | null
           shift_id?: string
+          time_slot_id?: string | null
           updated_at?: string
           volunteer_id?: string
           volunteer_reported_hours?: number | null
+          waitlist_offer_expires_at?: string | null
         }
         Relationships: [
           {
             foreignKeyName: "shift_bookings_confirmed_by_fkey"
             columns: ["confirmed_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shift_bookings_coordinator_actioned_by_fkey"
+            columns: ["coordinator_actioned_by"]
             isOneToOne: false
             referencedRelation: "profiles"
             referencedColumns: ["id"]
@@ -884,6 +1175,13 @@ export type Database = {
             columns: ["shift_id"]
             isOneToOne: false
             referencedRelation: "shifts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shift_bookings_time_slot_id_fkey"
+            columns: ["time_slot_id"]
+            isOneToOne: false
+            referencedRelation: "shift_time_slots"
             referencedColumns: ["id"]
           },
           {
@@ -1591,6 +1889,26 @@ export type Database = {
       }
     }
     Functions: {
+      admin_action_off_shift: {
+        Args: { p_booking_id: string }
+        Returns: undefined
+      }
+      admin_break_glass_read_notes: {
+        Args: { reason: string; target_volunteer_id: string }
+        Returns: Json
+      }
+      admin_delete_unactioned_shift: {
+        Args: { p_booking_id: string }
+        Returns: undefined
+      }
+      admin_emergency_mfa_reset: {
+        Args: { target_email: string }
+        Returns: Json
+      }
+      admin_update_shift_hours: {
+        Args: { p_booking_id: string; p_hours: number }
+        Returns: undefined
+      }
       export_critical_data: { Args: never; Returns: Json }
       get_department_report: {
         Args: { date_from: string; date_to: string; dept_uuids: string[] }
@@ -1639,13 +1957,50 @@ export type Database = {
           shift_id: string
         }[]
       }
+      get_unactioned_shifts: {
+        Args: never
+        Returns: {
+          actioned_off: boolean
+          booking_id: string
+          checked_in: boolean
+          department_name: string
+          hours_since_end: number
+          shift_date: string
+          shift_end: string
+          shift_id: string
+          shift_title: string
+          volunteer_email: string
+          volunteer_id: string
+          volunteer_name: string
+        }[]
+      }
+      get_unread_conversation_count: { Args: never; Returns: number }
+      has_active_booking_on: { Args: { p_shift_id: string }; Returns: boolean }
       is_admin: { Args: never; Returns: boolean }
+      is_coordinator_for_my_dept: {
+        Args: { p_coordinator_id: string }
+        Returns: boolean
+      }
       is_coordinator_or_admin: { Args: never; Returns: boolean }
+      log_mfa_reset: { Args: { target_email: string }; Returns: undefined }
+      mfa_consume_backup_code: { Args: { p_code: string }; Returns: boolean }
+      mfa_generate_backup_codes: { Args: never; Returns: string[] }
+      mfa_unused_backup_code_count: { Args: never; Returns: number }
       my_role: {
         Args: never
         Returns: Database["public"]["Enums"]["user_role"]
       }
+      notification_link_booking_id: {
+        Args: { p_link: string }
+        Returns: string
+      }
       process_confirmation_reminders: { Args: never; Returns: undefined }
+      promote_next_waitlist:
+        | { Args: { p_shift_id: string }; Returns: string }
+        | {
+            Args: { p_shift_id: string; p_time_slot_id?: string }
+            Returns: string
+          }
       recalculate_consistency: {
         Args: { p_volunteer_id: string }
         Returns: undefined
@@ -1654,6 +2009,7 @@ export type Database = {
         Args: { volunteer_uuid: string }
         Returns: undefined
       }
+      reconcile_shift_counters: { Args: never; Returns: undefined }
       resolve_hours_discrepancy: {
         Args: { p_booking_id: string }
         Returns: undefined
@@ -1681,7 +2037,18 @@ export type Database = {
         }[]
       }
       send_self_confirmation_reminders: { Args: never; Returns: undefined }
-      send_shift_reminders: { Args: never; Returns: undefined }
+      shift_end_at: {
+        Args: { p_end_time: string; p_shift_date: string; p_time_type: string }
+        Returns: string
+      }
+      shift_start_at: {
+        Args: {
+          p_shift_date: string
+          p_start_time: string
+          p_time_type: string
+        }
+        Returns: string
+      }
       transfer_admin_role: {
         Args: { from_admin_id: string; to_coordinator_id: string }
         Returns: undefined
@@ -1691,6 +2058,9 @@ export type Database = {
         Returns: undefined
       }
       username_available: { Args: { p_username: string }; Returns: boolean }
+      waitlist_accept: { Args: { p_booking_id: string }; Returns: undefined }
+      waitlist_decline: { Args: { p_booking_id: string }; Returns: undefined }
+      warn_expiring_documents: { Args: never; Returns: undefined }
     }
     Enums: {
       bg_check_status: "pending" | "cleared" | "failed" | "expired"

--- a/src/pages/AdminDisputes.tsx
+++ b/src/pages/AdminDisputes.tsx
@@ -1,0 +1,382 @@
+import { useEffect, useState, useCallback } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertTriangle, CheckCircle, XCircle, Clock, Calendar, Users,
+  Gavel, Timer,
+} from "lucide-react";
+import { format, formatDistanceToNow } from "date-fns";
+import { useToast } from "@/hooks/use-toast";
+import { timeLabel } from "@/lib/calendar-utils";
+import { formatSlotRange } from "@/lib/slot-utils";
+
+interface Dispute {
+  id: string;
+  booking_id: string;
+  shift_id: string;
+  volunteer_id: string;
+  coordinator_id: string;
+  volunteer_status: string;
+  volunteer_reported_hours: number | null;
+  coordinator_status: string;
+  admin_decision: string | null;
+  admin_decided_by: string | null;
+  admin_decided_at: string | null;
+  admin_notes: string | null;
+  resolved_by: string | null;
+  final_hours_awarded: number | null;
+  created_at: string;
+  expires_at: string;
+  // Joined data
+  volunteer: { full_name: string; email: string } | null;
+  coordinator: { full_name: string } | null;
+  admin_decider: { full_name: string } | null;
+  shifts: {
+    title: string;
+    shift_date: string;
+    start_time: string | null;
+    end_time: string | null;
+    time_type: string;
+    departments: { name: string } | null;
+  } | null;
+  shift_bookings: {
+    time_slot_id: string | null;
+    shift_time_slots: { slot_start: string; slot_end: string } | null;
+  } | null;
+}
+
+export default function AdminDisputes() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [disputes, setDisputes] = useState<Dispute[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [resolveTarget, setResolveTarget] = useState<Dispute | null>(null);
+  const [decision, setDecision] = useState<"volunteer_upheld" | "coordinator_upheld" | null>(null);
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const fetchDisputes = useCallback(async () => {
+    const { data, error } = await supabase
+      .from("attendance_disputes")
+      .select(`
+        *,
+        volunteer:profiles!attendance_disputes_volunteer_id_fkey(full_name, email),
+        coordinator:profiles!attendance_disputes_coordinator_id_fkey(full_name),
+        admin_decider:profiles!attendance_disputes_admin_decided_by_fkey(full_name),
+        shifts(title, shift_date, start_time, end_time, time_type, departments(name)),
+        shift_bookings(time_slot_id, shift_time_slots(slot_start, slot_end))
+      `)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      console.error("fetchDisputes error:", error);
+    }
+    setDisputes((data || []) as Dispute[]);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchDisputes();
+  }, [fetchDisputes]);
+
+  const pendingDisputes = disputes.filter((d) => !d.admin_decision);
+  const resolvedDisputes = disputes.filter((d) => !!d.admin_decision);
+
+  const handleResolve = async () => {
+    if (!resolveTarget || !decision || !user) return;
+    if (notes.trim().length < 10) {
+      toast({ title: "Notes required", description: "Please enter at least 10 characters explaining your decision.", variant: "destructive" });
+      return;
+    }
+
+    setSaving(true);
+
+    // 1. Update the dispute
+    const { error: disputeErr } = await supabase
+      .from("attendance_disputes")
+      .update({
+        admin_decision: decision,
+        admin_decided_by: user.id,
+        admin_decided_at: new Date().toISOString(),
+        admin_notes: notes.trim(),
+        resolved_by: "admin",
+        final_hours_awarded: decision === "volunteer_upheld"
+          ? resolveTarget.volunteer_reported_hours || 0
+          : 0,
+      })
+      .eq("id", resolveTarget.id);
+
+    if (disputeErr) {
+      toast({ title: "Error", description: disputeErr.message, variant: "destructive" });
+      setSaving(false);
+      return;
+    }
+
+    // 2. Update the booking
+    const bookingUpdate = decision === "volunteer_upheld"
+      ? {
+          confirmation_status: "confirmed",
+          final_hours: resolveTarget.volunteer_reported_hours || 0,
+          hours_source: "dispute_admin_resolved",
+        }
+      : {
+          confirmation_status: "no_show",
+          final_hours: 0,
+          hours_source: "dispute_admin_resolved",
+        };
+
+    await supabase
+      .from("shift_bookings")
+      .update(bookingUpdate)
+      .eq("id", resolveTarget.booking_id);
+
+    // 3. Notify volunteer
+    const shiftTitle = resolveTarget.shifts?.title || "shift";
+    const shiftDate = resolveTarget.shifts?.shift_date
+      ? format(new Date(resolveTarget.shifts.shift_date + "T00:00:00"), "MMM d")
+      : "";
+
+    const volMessage = decision === "volunteer_upheld"
+      ? `Your attendance for "${shiftTitle}" on ${shiftDate} has been confirmed. Hours awarded: ${resolveTarget.volunteer_reported_hours || 0}h.`
+      : `Your attendance for "${shiftTitle}" on ${shiftDate} could not be confirmed. If you believe this is an error, please contact your coordinator.`;
+
+    await supabase.from("notifications").insert([
+      {
+        user_id: resolveTarget.volunteer_id,
+        type: "dispute_resolved",
+        title: decision === "volunteer_upheld" ? "Attendance confirmed" : "Attendance not confirmed",
+        message: volMessage,
+        link: "/history",
+        is_read: false,
+      },
+      {
+        user_id: resolveTarget.coordinator_id,
+        type: "dispute_resolved",
+        title: "Dispute resolved by admin",
+        message: `The attendance dispute for ${resolveTarget.volunteer?.full_name || "a volunteer"} on "${shiftTitle}" has been resolved: ${decision === "volunteer_upheld" ? "volunteer upheld" : "coordinator upheld"}.`,
+        link: "/coordinator",
+        is_read: false,
+      },
+    ]);
+
+    setSaving(false);
+    setResolveTarget(null);
+    setDecision(null);
+    setNotes("");
+    toast({ title: "Dispute resolved" });
+    fetchDisputes();
+  };
+
+  const DisputeCard = ({ d, showActions }: { d: Dispute; showActions: boolean }) => {
+    const s = d.shifts;
+    const slotInfo = d.shift_bookings?.shift_time_slots;
+    const isPending = !d.admin_decision;
+    const expiresAt = new Date(d.expires_at);
+    const isExpired = expiresAt < new Date();
+
+    return (
+      <Card className={isPending ? "border-amber-500/40" : ""}>
+        <CardContent className="pt-4 pb-4">
+          <div className="space-y-3">
+            {/* Header */}
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1">
+                <div className="font-medium flex items-center gap-2">
+                  {d.volunteer?.full_name || "Unknown Volunteer"}
+                  {isPending && (
+                    <Badge className="text-[10px] bg-amber-500/20 text-amber-700 border-amber-500/40">
+                      <AlertTriangle className="h-2.5 w-2.5 mr-0.5" />Pending
+                    </Badge>
+                  )}
+                  {d.admin_decision === "volunteer_upheld" && (
+                    <Badge className="text-[10px] bg-green-500/20 text-green-700 border-green-500/40">
+                      <CheckCircle className="h-2.5 w-2.5 mr-0.5" />Volunteer Upheld
+                    </Badge>
+                  )}
+                  {d.admin_decision === "coordinator_upheld" && (
+                    <Badge className="text-[10px] bg-red-500/20 text-red-700 border-red-500/40">
+                      <XCircle className="h-2.5 w-2.5 mr-0.5" />Coordinator Upheld
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <Calendar className="h-3 w-3" />
+                    {s?.shift_date ? format(new Date(s.shift_date + "T00:00:00"), "MMM d, yyyy") : "—"}
+                  </span>
+                  <span className="font-medium">{s?.title || "—"}</span>
+                  {s?.departments?.name && <Badge variant="secondary" className="text-[10px]">{s.departments.name}</Badge>}
+                  {slotInfo && (
+                    <span className="text-xs">{formatSlotRange(slotInfo.slot_start, slotInfo.slot_end)}</span>
+                  )}
+                </div>
+              </div>
+              {isPending && !isExpired && (
+                <div className="text-right shrink-0">
+                  <div className="flex items-center gap-1 text-xs text-amber-600">
+                    <Timer className="h-3 w-3" />
+                    Auto-resolves {formatDistanceToNow(expiresAt, { addSuffix: true })}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Claims */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="rounded-md border border-green-500/30 bg-green-500/5 p-3">
+                <div className="text-xs font-medium text-green-700 dark:text-green-400 mb-1">Volunteer's Claim</div>
+                <div className="text-sm">Attended · {d.volunteer_reported_hours ?? "—"}h reported</div>
+                <div className="text-xs text-muted-foreground">{d.volunteer?.email}</div>
+              </div>
+              <div className="rounded-md border border-red-500/30 bg-red-500/5 p-3">
+                <div className="text-xs font-medium text-red-700 dark:text-red-400 mb-1">Coordinator's Claim</div>
+                <div className="text-sm">Absent</div>
+                <div className="text-xs text-muted-foreground">By {d.coordinator?.full_name || "—"}</div>
+              </div>
+            </div>
+
+            {/* Resolution info */}
+            {d.admin_decision && (
+              <div className="rounded-md bg-muted p-3 text-sm space-y-1">
+                <div className="flex items-center gap-2">
+                  <Gavel className="h-3 w-3" />
+                  <span className="font-medium">
+                    {d.resolved_by === "auto_timeout" ? "Auto-resolved after 7 days" : `Resolved by ${d.admin_decider?.full_name || "admin"}`}
+                  </span>
+                  {d.admin_decided_at && (
+                    <span className="text-xs text-muted-foreground">
+                      {format(new Date(d.admin_decided_at), "MMM d, yyyy h:mm a")}
+                    </span>
+                  )}
+                </div>
+                {d.admin_notes && <p className="text-muted-foreground text-xs">{d.admin_notes}</p>}
+                {d.final_hours_awarded != null && (
+                  <div className="text-xs">Hours awarded: <strong>{d.final_hours_awarded}h</strong></div>
+                )}
+              </div>
+            )}
+
+            {/* Actions */}
+            {showActions && isPending && (
+              <div className="flex justify-end gap-2">
+                <Button
+                  size="sm"
+                  className="bg-green-600 hover:bg-green-700 text-white"
+                  onClick={() => {
+                    setResolveTarget(d);
+                    setDecision("volunteer_upheld");
+                    setNotes("");
+                  }}
+                >
+                  <CheckCircle className="h-3 w-3 mr-1" />Uphold Volunteer
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => {
+                    setResolveTarget(d);
+                    setDecision("coordinator_upheld");
+                    setNotes("");
+                  }}
+                >
+                  <XCircle className="h-3 w-3 mr-1" />Uphold Coordinator
+                </Button>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold">Attendance Disputes</h2>
+        <p className="text-muted-foreground">
+          Review cases where coordinators and volunteers disagree on attendance
+        </p>
+      </div>
+
+      {loading ? (
+        <p className="text-muted-foreground">Loading disputes...</p>
+      ) : disputes.length === 0 ? (
+        <Card>
+          <CardContent className="pt-6 text-center text-muted-foreground">
+            No attendance disputes found.
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {pendingDisputes.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-lg font-semibold flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-amber-600" />
+                Pending Review ({pendingDisputes.length})
+              </h3>
+              {pendingDisputes.map((d) => (
+                <DisputeCard key={d.id} d={d} showActions={true} />
+              ))}
+            </div>
+          )}
+
+          {resolvedDisputes.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-lg font-semibold">Resolved ({resolvedDisputes.length})</h3>
+              {resolvedDisputes.map((d) => (
+                <DisputeCard key={d.id} d={d} showActions={false} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Resolve dialog */}
+      <Dialog open={!!resolveTarget} onOpenChange={(open) => { if (!open) { setResolveTarget(null); setDecision(null); setNotes(""); } }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {decision === "volunteer_upheld" ? "Uphold Volunteer's Claim" : "Uphold Coordinator's Claim"}
+            </DialogTitle>
+            <DialogDescription>
+              {decision === "volunteer_upheld"
+                ? `The volunteer's reported hours (${resolveTarget?.volunteer_reported_hours ?? 0}h) will be awarded and the booking marked as completed.`
+                : "The volunteer will be marked as a no-show. No hours will be awarded."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div>
+              <label className="text-sm font-medium">Admin Notes (required, min 10 characters)</label>
+              <Textarea
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Explain your decision..."
+                rows={3}
+              />
+              <p className="text-xs text-muted-foreground mt-1">{notes.length} characters</p>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => { setResolveTarget(null); setDecision(null); }}>Cancel</Button>
+            <Button
+              onClick={handleResolve}
+              disabled={saving || notes.trim().length < 10}
+              className={decision === "volunteer_upheld" ? "bg-green-600 hover:bg-green-700" : ""}
+              variant={decision === "coordinator_upheld" ? "destructive" : "default"}
+            >
+              {saving ? "Saving..." : "Confirm Decision"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/CoordinatorDashboard.tsx
+++ b/src/pages/CoordinatorDashboard.tsx
@@ -134,16 +134,43 @@ export default function CoordinatorDashboard() {
     toast({ title: "Hours updated", description: `Set to ${parsed}h and volunteer total recalculated.` });
   };
 
-  const handleConfirm = async (bookingId: string, status: "confirmed" | "no_show") => {
+  const handleAttendance = async (bookingId: string, status: "attended" | "absent") => {
+    if (status === "absent") {
+      const ok = window.confirm(
+        "This will mark the volunteer as absent. If the volunteer has reported attending this shift, the matter will be escalated to an admin for review."
+      );
+      if (!ok) return;
+    }
     const { error } = await supabase
       .from("shift_bookings")
-      .update({ confirmation_status: status, confirmed_by: user!.id, confirmed_at: new Date().toISOString() })
+      .update({
+        coordinator_status: status,
+        coordinator_actioned_by: user!.id,
+      })
       .eq("id", bookingId);
     if (error) {
       toast({ title: "Error", description: error.message, variant: "destructive" });
     } else {
-      setBookings((prev) => prev.map((b) => b.id === bookingId ? { ...b, confirmation_status: status } : b));
-      toast({ title: `Marked as ${status.replace("_", " ")}` });
+      // Re-fetch to get the trigger's side effects (confirmation_status, final_hours, dispute)
+      const { data: updated } = await supabase
+        .from("shift_bookings")
+        .select("id, confirmation_status, coordinator_status, coordinator_actioned_at, final_hours, hours_source")
+        .eq("id", bookingId)
+        .single();
+      if (updated) {
+        setBookings((prev) => prev.map((b) => b.id === bookingId ? { ...b, ...updated } : b));
+      }
+      // Check if dispute was created
+      const { data: dispute } = await supabase
+        .from("attendance_disputes")
+        .select("id")
+        .eq("booking_id", bookingId)
+        .maybeSingle();
+      if (dispute) {
+        toast({ title: "Dispute created", description: "The volunteer reported attending. An admin will review this dispute.", variant: "default" });
+      } else {
+        toast({ title: `Marked as ${status}` });
+      }
     }
   };
 
@@ -298,41 +325,51 @@ export default function CoordinatorDashboard() {
                                 {b.profiles?.phone && <div className="text-xs text-muted-foreground">📞 {b.profiles.phone}</div>}
                                 {b.profiles?.emergency_contact && <div className="text-xs text-muted-foreground">🆘 {b.profiles.emergency_contact}</div>}
                               </div>
-                              <div className="flex items-center gap-2">
-                                {b.confirmation_status === "pending_confirmation" ? (
+                              <div className="flex items-center gap-2 flex-wrap">
+                                {!b.coordinator_status && b.confirmation_status === "pending_confirmation" ? (
                                   <>
-                                    <Button size="sm" variant="outline" onClick={() => handleConfirm(b.id, "confirmed")}>
-                                      <CheckCircle className="h-3 w-3 mr-1" />Confirm
+                                    <Button size="sm" className="bg-green-600 hover:bg-green-700 text-white" onClick={() => handleAttendance(b.id, "attended")}>
+                                      <CheckCircle className="h-3 w-3 mr-1" />Mark Attended
                                     </Button>
-                                    <Button size="sm" variant="outline" onClick={() => handleConfirm(b.id, "no_show")}>
-                                      <XCircle className="h-3 w-3 mr-1" />No Show
+                                    <Button size="sm" variant="destructive" onClick={() => handleAttendance(b.id, "absent")}>
+                                      <XCircle className="h-3 w-3 mr-1" />Mark Absent
                                     </Button>
                                   </>
-                                ) : (
+                                ) : b.coordinator_status ? (
                                   <>
-                                    <Badge variant={b.confirmation_status === "confirmed" ? "default" : "destructive"} className="text-xs">
-                                      {b.confirmation_status.replace("_", " ")}
+                                    <Badge variant={b.coordinator_status === "attended" ? "default" : "destructive"} className="text-xs">
+                                      {b.coordinator_status === "attended" ? "Attended" : "Absent"}
                                     </Badge>
+                                    {b.coordinator_actioned_at && (
+                                      <span className="text-[10px] text-muted-foreground">
+                                        {format(new Date(b.coordinator_actioned_at), "MMM d, h:mm a")}
+                                      </span>
+                                    )}
+                                    {/* Dispute badge — show if confirmation is still pending after absent marking */}
+                                    {b.coordinator_status === "absent" && b.confirmation_status === "pending_confirmation" && (
+                                      <Badge className="text-[10px] bg-amber-500/20 text-amber-700 border-amber-500/40">
+                                        <AlertTriangle className="h-2.5 w-2.5 mr-0.5" />Disputed — Pending Admin Review
+                                      </Badge>
+                                    )}
                                     {b.confirmation_status === "confirmed" && (
                                       <>
                                         {b.final_hours != null && (
-                                          <Badge variant="secondary" className="text-xs">
-                                            {b.final_hours}h
-                                          </Badge>
+                                          <Badge variant="secondary" className="text-xs">{b.final_hours}h</Badge>
                                         )}
-                                        <Button
-                                          size="sm"
-                                          variant="ghost"
-                                          className="h-7 px-2"
-                                          onClick={() => openHoursEditor(b, s)}
-                                          title="Edit recorded hours"
-                                        >
-                                          <Pencil className="h-3 w-3 mr-1" />
-                                          Edit Hours
+                                        <Button size="sm" variant="ghost" className="h-7 px-2"
+                                          onClick={() => openHoursEditor(b, s)} title="Edit recorded hours">
+                                          <Pencil className="h-3 w-3 mr-1" />Edit Hours
                                         </Button>
                                       </>
                                     )}
+                                    {b.confirmation_status === "no_show" && (
+                                      <Badge variant="destructive" className="text-xs">No Show</Badge>
+                                    )}
                                   </>
+                                ) : (
+                                  <Badge variant={b.confirmation_status === "confirmed" ? "default" : "destructive"} className="text-xs">
+                                    {b.confirmation_status.replace("_", " ")}
+                                  </Badge>
                                 )}
                               </div>
                             </div>

--- a/supabase/migrations/20260411_attendance_disputes.sql
+++ b/supabase/migrations/20260411_attendance_disputes.sql
@@ -1,0 +1,289 @@
+-- ============================================================
+-- Attendance Disputes: coordinator confirmation + dispute escalation
+-- ============================================================
+
+-- ============================================================
+-- 1A. Schema changes on shift_bookings
+-- ============================================================
+ALTER TABLE public.shift_bookings
+  ADD COLUMN IF NOT EXISTS coordinator_status text
+    CHECK (coordinator_status IN ('attended', 'absent')),
+  ADD COLUMN IF NOT EXISTS coordinator_actioned_at timestamptz,
+  ADD COLUMN IF NOT EXISTS coordinator_actioned_by uuid REFERENCES public.profiles(id);
+
+-- ============================================================
+-- 1A. Create attendance_disputes table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.attendance_disputes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  booking_id uuid NOT NULL REFERENCES public.shift_bookings(id) ON DELETE CASCADE UNIQUE,
+  shift_id uuid NOT NULL REFERENCES public.shifts(id),
+  volunteer_id uuid NOT NULL REFERENCES public.profiles(id),
+  coordinator_id uuid NOT NULL REFERENCES public.profiles(id),
+  volunteer_status text NOT NULL,
+  volunteer_reported_hours numeric,
+  coordinator_status text NOT NULL,
+  admin_decision text CHECK (admin_decision IN ('volunteer_upheld', 'coordinator_upheld')),
+  admin_decided_by uuid REFERENCES public.profiles(id),
+  admin_decided_at timestamptz,
+  admin_notes text,
+  resolved_by text CHECK (resolved_by IN ('admin', 'auto_timeout')),
+  final_hours_awarded numeric,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL DEFAULT now() + interval '7 days'
+);
+
+ALTER TABLE public.attendance_disputes ENABLE ROW LEVEL SECURITY;
+
+-- Admins: full access
+CREATE POLICY "attendance_disputes: admin full access"
+  ON public.attendance_disputes
+  FOR ALL
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- Coordinators: read their own disputes
+CREATE POLICY "attendance_disputes: coordinator read own"
+  ON public.attendance_disputes
+  FOR SELECT
+  TO authenticated
+  USING (
+    coordinator_id = auth.uid()
+    AND public.is_coordinator_or_admin()
+  );
+
+-- Volunteers: read only resolved disputes
+CREATE POLICY "attendance_disputes: volunteer read resolved"
+  ON public.attendance_disputes
+  FOR SELECT
+  TO authenticated
+  USING (
+    volunteer_id = auth.uid()
+    AND (admin_decision IS NOT NULL OR now() > expires_at)
+  );
+
+-- Index for fast lookups
+CREATE INDEX IF NOT EXISTS idx_attendance_disputes_booking
+  ON public.attendance_disputes (booking_id);
+CREATE INDEX IF NOT EXISTS idx_attendance_disputes_pending
+  ON public.attendance_disputes (admin_decision)
+  WHERE admin_decision IS NULL;
+
+
+-- ============================================================
+-- 1B. Dispute creation trigger
+-- ============================================================
+-- Fires when coordinator sets coordinator_status on shift_bookings.
+-- Only creates a dispute when volunteer said 'attended' AND
+-- coordinator says 'absent'. All other combos resolve immediately.
+
+CREATE OR REPLACE FUNCTION public.check_attendance_dispute()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_vol_status text;
+  v_vol_hours numeric;
+  v_shift_duration numeric;
+  v_shift_title text;
+  v_shift_date date;
+  v_vol_name text;
+  v_coord_name text;
+BEGIN
+  -- Only act when coordinator_status is being set for the first time
+  IF NEW.coordinator_status IS NULL THEN
+    RETURN NEW;
+  END IF;
+  IF OLD.coordinator_status IS NOT NULL THEN
+    -- Already actioned — lock it
+    RETURN NEW;
+  END IF;
+
+  -- Set timestamp and actor
+  NEW.coordinator_actioned_at := now();
+  -- coordinator_actioned_by should be set by the caller
+
+  -- Get volunteer's self-report
+  SELECT vsr.self_confirm_status, vsr.self_reported_hours
+    INTO v_vol_status, v_vol_hours
+    FROM public.volunteer_shift_reports vsr
+    WHERE vsr.booking_id = NEW.id
+      AND vsr.submitted_at IS NOT NULL
+    LIMIT 1;
+
+  -- Get shift info for notifications and hours calculation
+  SELECT s.title, s.shift_date,
+         GREATEST(0.5, ROUND(EXTRACT(EPOCH FROM (
+           public.shift_end_at(s.shift_date, s.end_time, s.time_type::text)
+           - public.shift_start_at(s.shift_date, s.start_time, s.time_type::text)
+         )) / 3600.0, 2))
+    INTO v_shift_title, v_shift_date, v_shift_duration
+    FROM public.shifts s
+    WHERE s.id = NEW.shift_id;
+
+  -- ── Coordinator marks ATTENDED ──
+  IF NEW.coordinator_status = 'attended' THEN
+    -- No dispute possible. Mark as completed.
+    NEW.confirmation_status := 'confirmed';
+    NEW.final_hours := COALESCE(v_vol_hours, v_shift_duration);
+    NEW.hours_source := COALESCE(NEW.hours_source, 'coordinator');
+    RETURN NEW;
+  END IF;
+
+  -- ── Coordinator marks ABSENT ──
+  IF NEW.coordinator_status = 'absent' THEN
+    -- Check if volunteer claimed attendance
+    IF v_vol_status = 'attended' THEN
+      -- DISPUTE: volunteer says attended, coordinator says absent
+      -- Don't change confirmation_status yet — leave as pending
+
+      -- Get names for notifications
+      SELECT full_name INTO v_vol_name FROM public.profiles WHERE id = NEW.volunteer_id;
+      SELECT full_name INTO v_coord_name FROM public.profiles WHERE id = NEW.coordinator_actioned_by;
+
+      INSERT INTO public.attendance_disputes (
+        booking_id, shift_id, volunteer_id, coordinator_id,
+        volunteer_status, volunteer_reported_hours, coordinator_status
+      ) VALUES (
+        NEW.id, NEW.shift_id, NEW.volunteer_id, NEW.coordinator_actioned_by,
+        'attended', v_vol_hours, 'absent'
+      );
+
+      -- Notify all admins
+      INSERT INTO public.notifications (user_id, type, title, message, data, link, is_read)
+      SELECT
+        p.id,
+        'attendance_dispute',
+        'Attendance dispute: ' || COALESCE(v_vol_name, 'Volunteer'),
+        COALESCE(v_coord_name, 'A coordinator') || ' marked ' || COALESCE(v_vol_name, 'a volunteer') ||
+          ' as absent for "' || COALESCE(v_shift_title, 'shift') || '" on ' ||
+          to_char(v_shift_date, 'Mon DD') || ', but the volunteer reported attending. Admin review required.',
+        jsonb_build_object(
+          'booking_id', NEW.id,
+          'shift_id', NEW.shift_id,
+          'volunteer_id', NEW.volunteer_id,
+          'volunteer_name', v_vol_name,
+          'coordinator_name', v_coord_name,
+          'shift_title', v_shift_title,
+          'shift_date', v_shift_date
+        ),
+        '/admin/disputes',
+        false
+      FROM public.profiles p
+      WHERE p.role = 'admin' AND p.is_active = true;
+
+    ELSE
+      -- No dispute: volunteer didn't claim attendance (or took no action)
+      -- → Mark as no_show directly
+      NEW.confirmation_status := 'no_show';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS trg_check_attendance_dispute ON public.shift_bookings;
+CREATE TRIGGER trg_check_attendance_dispute
+  BEFORE UPDATE OF coordinator_status ON public.shift_bookings
+  FOR EACH ROW
+  EXECUTE FUNCTION check_attendance_dispute();
+
+
+-- ============================================================
+-- 1C. Dispute auto-resolution cron (hourly)
+-- ============================================================
+SELECT cron.unschedule('dispute-auto-resolve') WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'dispute-auto-resolve'
+);
+
+SELECT cron.schedule(
+  'dispute-auto-resolve',
+  '17 * * * *',
+  $cron$
+  WITH resolved AS (
+    UPDATE public.attendance_disputes ad
+    SET admin_decision = 'volunteer_upheld',
+        resolved_by = 'auto_timeout',
+        final_hours_awarded = COALESCE(ad.volunteer_reported_hours, 0),
+        admin_decided_at = now()
+    WHERE ad.admin_decision IS NULL
+      AND now() > ad.expires_at
+    RETURNING ad.booking_id, ad.volunteer_id, ad.coordinator_id,
+              ad.shift_id, ad.volunteer_reported_hours
+  ),
+  booking_updates AS (
+    UPDATE public.shift_bookings sb
+    SET confirmation_status = 'confirmed',
+        final_hours = COALESCE(r.volunteer_reported_hours, 0),
+        hours_source = 'dispute_auto_resolved',
+        updated_at = now()
+    FROM resolved r
+    WHERE sb.id = r.booking_id
+    RETURNING sb.id
+  ),
+  vol_notifs AS (
+    INSERT INTO public.notifications (user_id, type, title, message, link, is_read)
+    SELECT
+      r.volunteer_id,
+      'dispute_resolved',
+      'Attendance confirmed',
+      'Your attendance for "' || s.title || '" on ' ||
+        to_char(s.shift_date, 'Mon DD') ||
+        ' has been confirmed. Hours awarded: ' || COALESCE(r.volunteer_reported_hours, 0) || 'h.',
+      '/history',
+      false
+    FROM resolved r
+    JOIN public.shifts s ON s.id = r.shift_id
+    RETURNING user_id
+  )
+  INSERT INTO public.notifications (user_id, type, title, message, link, is_read)
+  SELECT
+    r.coordinator_id,
+    'dispute_resolved',
+    'Dispute auto-resolved',
+    'The attendance dispute for a volunteer on "' || s.title ||
+      '" was auto-resolved in favor of the volunteer after 7 days without admin review.',
+    '/coordinator',
+    false
+  FROM resolved r
+  JOIN public.shifts s ON s.id = r.shift_id;
+  $cron$
+);
+
+
+-- ============================================================
+-- 1D. Update unactioned-shift-auto-delete behavior
+-- ============================================================
+-- Instead of DELETE, set confirmation_status = 'no_show' when
+-- NEITHER the volunteer NOR the coordinator has taken any action
+-- within 7 days after shift end. This impacts consistency score
+-- via the existing trg_recalculate_consistency trigger.
+
+SELECT cron.unschedule('unactioned-shift-auto-delete') WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'unactioned-shift-auto-delete'
+);
+
+SELECT cron.schedule(
+  'unactioned-shift-auto-delete',
+  '0 8 * * *',
+  $cron$
+  UPDATE public.shift_bookings sb
+  SET confirmation_status = 'no_show',
+      updated_at = now()
+  FROM public.shifts s
+  WHERE sb.shift_id = s.id
+    AND sb.booking_status = 'confirmed'
+    AND sb.confirmation_status = 'pending_confirmation'
+    AND sb.coordinator_status IS NULL
+    AND public.shift_end_at(s.shift_date, s.end_time, s.time_type::text) < now() - interval '7 days'
+    AND sb.checked_in_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.volunteer_shift_reports vsr
+      WHERE vsr.booking_id = sb.id AND vsr.submitted_at IS NOT NULL
+    );
+  $cron$
+);


### PR DESCRIPTION
Adds a two-sided attendance workflow: coordinators independently mark volunteers as "attended" or "absent". When a coordinator marks absent but the volunteer self-reported attending, a dispute is automatically created and escalated to admins.

Migration:
- coordinator_status, coordinator_actioned_at, coordinator_actioned_by columns on shift_bookings
- attendance_disputes table with RLS (admins full, coordinators own, volunteers see only resolved)
- check_attendance_dispute trigger: auto-creates dispute on conflict, auto-confirms on agreement, marks no-show when no volunteer claim
- dispute-auto-resolve hourly cron: upholds volunteer after 7 days
- Updated unactioned-shift-auto-delete to mark no_show instead of deleting bookings

Frontend:
- CoordinatorDashboard: "Mark Attended"/"Mark Absent" buttons with confirmation dialog and dispute badge
- AdminDisputes page at /admin/disputes with resolve workflow
- Sidebar + mobile nav updated with Disputes link

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
