### PR TITLE
feat: admin shift invitations — invite, accept/decline, conflict hand…

### DIFF
--- a/src/components/InviteVolunteerModal.tsx
+++ b/src/components/InviteVolunteerModal.tsx
@@ -1,0 +1,357 @@
+import { useState, useEffect, useRef } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Loader2, Search, UserPlus, AlertTriangle, CheckCircle } from "lucide-react";
+
+interface Shift {
+  id: string;
+  title: string;
+  shift_date: string;
+  start_time: string;
+  end_time: string;
+  department_id: string;
+  total_slots: number;
+  departments?: { name: string; requires_bg_check?: boolean };
+}
+
+interface VolunteerResult {
+  id: string;
+  full_name: string;
+  email: string;
+  bg_check_status: string;
+  is_active: boolean;
+}
+
+interface ConflictInfo {
+  shiftTitle: string;
+  shiftDate: string;
+  startTime: string;
+  endTime: string;
+}
+
+interface Props {
+  shift: Shift;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSent?: () => void;
+}
+
+export function InviteVolunteerModal({ shift, open, onOpenChange, onSent }: Props) {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [search, setSearch] = useState("");
+  const [results, setResults] = useState<VolunteerResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [selected, setSelected] = useState<VolunteerResult | null>(null);
+  const [sending, setSending] = useState(false);
+  const [conflict, setConflict] = useState<ConflictInfo | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [conflictConfirmOpen, setConflictConfirmOpen] = useState(false);
+  const [alreadyInvited, setAlreadyInvited] = useState<Set<string>>(new Set());
+  const [restricted, setRestricted] = useState<Set<string>>(new Set());
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Load already-invited volunteers and department restrictions
+  useEffect(() => {
+    if (!open) return;
+    (async () => {
+      const [{ data: existing }, { data: restrictions }] = await Promise.all([
+        supabase
+          .from("shift_invitations")
+          .select("volunteer_id")
+          .eq("shift_id", shift.id)
+          .eq("status", "pending")
+          .not("volunteer_id", "is", null),
+        supabase
+          .from("department_restrictions")
+          .select("volunteer_id")
+          .eq("department_id", shift.department_id),
+      ]);
+      setAlreadyInvited(new Set((existing || []).map((r: any) => r.volunteer_id)));
+      setRestricted(new Set((restrictions || []).map((r: any) => r.volunteer_id)));
+    })();
+  }, [open, shift.id, shift.department_id]);
+
+  // Dynamic search
+  useEffect(() => {
+    if (!open || search.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true);
+      const { data } = await supabase
+        .from("profiles")
+        .select("id, full_name, email, bg_check_status, is_active")
+        .eq("role", "volunteer")
+        .eq("is_active", true)
+        .ilike("full_name", `%${search.trim()}%`)
+        .order("full_name")
+        .limit(20);
+      setResults(data || []);
+      setSearching(false);
+    }, 250);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [search, open]);
+
+  // Reset on close
+  useEffect(() => {
+    if (!open) {
+      setSearch("");
+      setResults([]);
+      setSelected(null);
+      setConflict(null);
+    }
+  }, [open]);
+
+  const deptRequiresBg = shift.departments?.requires_bg_check ?? false;
+
+  function isEligible(v: VolunteerResult): { ok: boolean; reason?: string } {
+    if (alreadyInvited.has(v.id)) return { ok: false, reason: "Already invited" };
+    if (restricted.has(v.id)) return { ok: false, reason: "Restricted from department" };
+    if (deptRequiresBg && v.bg_check_status !== "cleared")
+      return { ok: false, reason: `BG check: ${v.bg_check_status}` };
+    return { ok: true };
+  }
+
+  async function checkConflict(volunteerId: string): Promise<ConflictInfo | null> {
+    // Find confirmed bookings on the same date with overlapping times
+    const { data } = await supabase
+      .from("shift_bookings")
+      .select("shifts(title, shift_date, start_time, end_time)")
+      .eq("volunteer_id", volunteerId)
+      .eq("booking_status", "confirmed");
+
+    if (!data) return null;
+
+    for (const b of data as any[]) {
+      const s = b.shifts;
+      if (!s || s.shift_date !== shift.shift_date) continue;
+      // Strict inequality overlap check (same as prevent_overlapping_bookings)
+      const existStart = s.start_time;
+      const existEnd = s.end_time;
+      if (existStart < shift.end_time && existEnd > shift.start_time) {
+        return {
+          shiftTitle: s.title,
+          shiftDate: s.shift_date,
+          startTime: existStart?.slice(0, 5),
+          endTime: existEnd?.slice(0, 5),
+        };
+      }
+    }
+    return null;
+  }
+
+  async function handleSelectVolunteer(v: VolunteerResult) {
+    setSelected(v);
+    // Check for conflicts
+    const c = await checkConflict(v.id);
+    setConflict(c);
+    if (c) {
+      setConflictConfirmOpen(true);
+    } else {
+      setConfirmOpen(true);
+    }
+  }
+
+  async function sendInvitation() {
+    if (!selected || !user) return;
+    setSending(true);
+
+    // Compute expires_at = shift start datetime
+    const expiresAt = new Date(`${shift.shift_date}T${shift.start_time}`).toISOString();
+
+    const { error } = await supabase.from("shift_invitations").insert({
+      shift_id: shift.id,
+      volunteer_id: selected.id,
+      invited_by: user.id,
+      invite_email: selected.email,
+      status: "pending",
+      expires_at: expiresAt,
+      token: crypto.randomUUID(),
+    });
+
+    if (error) {
+      setSending(false);
+      toast({
+        title: "Failed to send invitation",
+        description: error.message.includes("uq_shift_invitation_volunteer")
+          ? "This volunteer already has a pending invitation for this shift."
+          : error.message,
+        variant: "destructive",
+      });
+      setConfirmOpen(false);
+      setConflictConfirmOpen(false);
+      return;
+    }
+
+    // Send notification to the volunteer
+    await supabase.from("notifications").insert({
+      user_id: selected.id,
+      type: "shift_invitation",
+      title: `You've been invited to: ${shift.title}`,
+      message: `An admin has invited you to volunteer for "${shift.title}" on ${shift.shift_date} from ${shift.start_time?.slice(0, 5)} to ${shift.end_time?.slice(0, 5)}. Open your dashboard to respond.`,
+      link: "/dashboard",
+      data: {
+        shift_id: shift.id,
+        shift_title: shift.title,
+        shift_date: shift.shift_date,
+      },
+    });
+
+    setSending(false);
+    setConfirmOpen(false);
+    setConflictConfirmOpen(false);
+    onOpenChange(false);
+
+    toast({
+      title: "Invitation sent",
+      description: `${selected.full_name} has been invited to ${shift.title}.`,
+    });
+    onSent?.();
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <UserPlus className="h-5 w-5" /> Invite Volunteer
+            </DialogTitle>
+            <DialogDescription>
+              Search for a volunteer to invite to <strong>{shift.title}</strong> on {shift.shift_date}.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="relative">
+              <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input
+                className="pl-10"
+                placeholder="Search by name..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                autoFocus
+              />
+            </div>
+
+            <div className="max-h-64 overflow-y-auto space-y-1">
+              {searching && (
+                <div className="flex items-center justify-center py-4">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                </div>
+              )}
+              {!searching && search.trim().length >= 2 && results.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No volunteers found.</p>
+              )}
+              {!searching && results.map((v) => {
+                const elig = isEligible(v);
+                return (
+                  <button
+                    key={v.id}
+                    disabled={!elig.ok}
+                    onClick={() => handleSelectVolunteer(v)}
+                    className="w-full flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5 text-left hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">{v.full_name}</p>
+                      <p className="text-xs text-muted-foreground truncate">{v.email}</p>
+                    </div>
+                    {!elig.ok && (
+                      <Badge variant="outline" className="text-xs shrink-0 text-muted-foreground">
+                        {elig.reason}
+                      </Badge>
+                    )}
+                    {elig.ok && (
+                      <Badge className="text-xs shrink-0 bg-primary/10 text-primary border-primary/20">
+                        Eligible
+                      </Badge>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Standard confirmation (no conflict) */}
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Send Invitation</AlertDialogTitle>
+            <AlertDialogDescription>
+              Invite <strong>{selected?.full_name}</strong> to <strong>{shift.title}</strong> on {shift.shift_date}?
+              They will receive a notification and can accept or decline.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={sending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={sendInvitation} disabled={sending}>
+              {sending ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Sending...</> : <>
+                <CheckCircle className="h-4 w-4 mr-2" />Send Invitation</>}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Conflict warning confirmation */}
+      <AlertDialog open={conflictConfirmOpen} onOpenChange={setConflictConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" /> Scheduling Conflict
+            </AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-3">
+                <p>
+                  <strong>{selected?.full_name}</strong> has a conflicting booking:
+                </p>
+                {conflict && (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
+                    <strong>{conflict.shiftTitle}</strong> on {conflict.shiftDate} from {conflict.startTime} to {conflict.endTime}
+                  </div>
+                )}
+                <p>Do you still want to send the invitation? The volunteer will be asked to resolve the conflict if they accept.</p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={sending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={sendInvitation} disabled={sending}>
+              {sending ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Sending...</> : "Send Anyway"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1204,6 +1204,7 @@ export type Database = {
           shift_id: string
           status: string
           token: string
+          volunteer_id: string | null
         }
         Insert: {
           created_at?: string
@@ -1215,6 +1216,7 @@ export type Database = {
           shift_id: string
           status?: string
           token?: string
+          volunteer_id?: string | null
         }
         Update: {
           created_at?: string
@@ -1226,6 +1228,7 @@ export type Database = {
           shift_id?: string
           status?: string
           token?: string
+          volunteer_id?: string | null
         }
         Relationships: [
           {
@@ -1247,6 +1250,13 @@ export type Database = {
             columns: ["shift_id"]
             isOneToOne: false
             referencedRelation: "shifts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shift_invitations_volunteer_id_fkey"
+            columns: ["volunteer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]
@@ -2052,6 +2062,10 @@ export type Database = {
       transfer_admin_role: {
         Args: { from_admin_id: string; to_coordinator_id: string }
         Returns: undefined
+      }
+      transfer_coordinator_and_delete: {
+        Args: { p_admin_id: string; p_coordinator_id: string }
+        Returns: Json
       }
       update_volunteer_preferences: {
         Args: { p_volunteer_id: string }

--- a/src/pages/ManageShifts.tsx
+++ b/src/pages/ManageShifts.tsx
@@ -49,7 +49,9 @@ import {
   Trash2,
   StickyNote,
   AlertCircle,
+  UserPlus,
 } from "lucide-react";
+import { InviteVolunteerModal } from "@/components/InviteVolunteerModal";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -122,6 +124,7 @@ export default function ManageShifts() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState<ShiftForm>(EMPTY_FORM);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; bookingCount: number } | null>(null);
+  const [inviteShift, setInviteShift] = useState<Shift | null>(null);
 
   /* ---------- Fetch ---------- */
 
@@ -398,6 +401,9 @@ export default function ManageShifts() {
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex items-center justify-end gap-1">
+                    <Button variant="ghost" size="icon" onClick={() => setInviteShift(s)} title="Invite volunteer">
+                      <UserPlus className="h-4 w-4" />
+                    </Button>
                     <Button variant="ghost" size="icon" onClick={() => openEdit(s)}>
                       <Pencil className="h-4 w-4" />
                     </Button>
@@ -623,6 +629,15 @@ export default function ManageShifts() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* ---- Invite volunteer modal ---- */}
+      {inviteShift && (
+        <InviteVolunteerModal
+          shift={inviteShift}
+          open={!!inviteShift}
+          onOpenChange={(open) => { if (!open) setInviteShift(null); }}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/VolunteerDashboard.tsx
+++ b/src/pages/VolunteerDashboard.tsx
@@ -4,8 +4,12 @@ import { useAuth } from "@/contexts/AuthContext";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Calendar, Clock, MapPin, Shield, Award, UserPlus, AlertTriangle, XCircle, ChevronDown, CheckCircle } from "lucide-react";
+import { Calendar, Clock, MapPin, Shield, Award, UserPlus, AlertTriangle, XCircle, ChevronDown, CheckCircle, Mail, Loader2 } from "lucide-react";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { format, differenceInHours } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
 import { OnboardingChecklist } from "@/components/OnboardingChecklist";
@@ -24,6 +28,13 @@ export default function VolunteerDashboard() {
   const [pendingConfirmations, setPendingConfirmations] = useState<any[]>([]);
   const [waitlistOffers, setWaitlistOffers] = useState<any[]>([]);
   const [waitlistPassive, setWaitlistPassive] = useState<any[]>([]);
+  const [invitations, setInvitations] = useState<any[]>([]);
+  const [invitationActioning, setInvitationActioning] = useState<string | null>(null);
+  const [inviteConflict, setInviteConflict] = useState<{
+    invitation: any;
+    conflictBookingId: string;
+    conflictShift: any;
+  } | null>(null);
 
   // Use LOCAL date, not UTC — otherwise in the evening Central time the UTC
   // rollover drops today's shifts from the filter and they disappear from the
@@ -98,6 +109,226 @@ export default function VolunteerDashboard() {
   useEffect(() => {
     fetchBookings();
   }, [fetchBookings]);
+
+  // Fetch pending invitations
+  const fetchInvitations = useCallback(async () => {
+    if (!user) return;
+    const { data } = await supabase
+      .from("shift_invitations")
+      .select("*, shifts(id, title, shift_date, start_time, end_time, total_slots, booked_slots, department_id, departments(name))")
+      .eq("volunteer_id", user.id)
+      .eq("status", "pending")
+      .order("created_at", { ascending: false });
+    // Filter out expired invitations client-side until the cron catches them
+    const now = new Date();
+    setInvitations(
+      (data || []).filter((inv: any) => new Date(inv.expires_at) > now)
+    );
+  }, [user]);
+
+  useEffect(() => {
+    fetchInvitations();
+  }, [fetchInvitations]);
+
+  // Accept invitation
+  const handleInvitationAccept = async (inv: any) => {
+    if (!user) return;
+    const shift = inv.shifts;
+    if (!shift) return;
+    setInvitationActioning(inv.id);
+
+    // Check if shift still has slots
+    const { data: freshShift } = await supabase
+      .from("shifts")
+      .select("booked_slots, total_slots")
+      .eq("id", shift.id)
+      .single();
+
+    if (freshShift && freshShift.booked_slots >= freshShift.total_slots) {
+      toast({
+        title: "Shift fully booked",
+        description: "This shift is now fully booked. Thank you for being available to help fill this spot.",
+      });
+      // Mark as declined since they can't accept
+      await supabase
+        .from("shift_invitations")
+        .update({ status: "declined" })
+        .eq("id", inv.id);
+      setInvitationActioning(null);
+      fetchInvitations();
+      return;
+    }
+
+    // Check for conflicting bookings
+    const { data: myBookings } = await supabase
+      .from("shift_bookings")
+      .select("id, shifts(id, title, shift_date, start_time, end_time, department_id, departments(name))")
+      .eq("volunteer_id", user.id)
+      .eq("booking_status", "confirmed");
+
+    let conflictBooking: any = null;
+    for (const b of (myBookings || []) as any[]) {
+      const s = b.shifts;
+      if (!s || s.shift_date !== shift.shift_date) continue;
+      if (s.start_time < shift.end_time && s.end_time > shift.start_time) {
+        conflictBooking = b;
+        break;
+      }
+    }
+
+    if (conflictBooking) {
+      setInviteConflict({
+        invitation: inv,
+        conflictBookingId: conflictBooking.id,
+        conflictShift: conflictBooking.shifts,
+      });
+      setInvitationActioning(null);
+      return;
+    }
+
+    // No conflict — book directly
+    await completeInvitationAccept(inv);
+  };
+
+  const completeInvitationAccept = async (inv: any, cancelBookingId?: string, cancelledShift?: any) => {
+    if (!user) return;
+    const shift = inv.shifts;
+    setInvitationActioning(inv.id);
+
+    // If cancelling a conflicting booking first
+    if (cancelBookingId) {
+      await supabase
+        .from("shift_bookings")
+        .update({ booking_status: "cancelled", cancelled_at: new Date().toISOString() })
+        .eq("id", cancelBookingId);
+
+      // Notify volunteer and coordinator about the cancelled shift
+      if (cancelledShift) {
+        const { data: coords } = await supabase
+          .from("department_coordinators")
+          .select("coordinator_id")
+          .eq("department_id", cancelledShift.department_id);
+
+        const notifications = [
+          {
+            user_id: user.id,
+            type: "booking_cancelled",
+            title: `Booking cancelled — ${cancelledShift.title}`,
+            message: `Your booking for "${cancelledShift.title}" on ${cancelledShift.shift_date} was cancelled to accept an invitation for "${shift.title}".`,
+            link: "/dashboard",
+          },
+          ...(coords || []).map((c: any) => ({
+            user_id: c.coordinator_id,
+            type: "booking_cancelled",
+            title: `Volunteer cancelled — ${cancelledShift.title}`,
+            message: `${profile?.full_name} cancelled their booking for "${cancelledShift.title}" on ${cancelledShift.shift_date} to accept an admin invitation for "${shift.title}".`,
+            link: "/coordinator",
+          })),
+        ];
+        await supabase.from("notifications").insert(notifications);
+      }
+    }
+
+    // Create the booking for the invited shift
+    // Fetch time slots for the shift and book all of them (full shift)
+    const { data: slots } = await supabase
+      .from("shift_time_slots")
+      .select("id, total_slots, booked_slots")
+      .eq("shift_id", shift.id)
+      .order("slot_start", { ascending: true });
+
+    let bookingError = false;
+    if (slots && slots.length > 0) {
+      for (const slot of slots) {
+        const isFull = slot.booked_slots >= slot.total_slots;
+        const { error } = await supabase.from("shift_bookings").insert({
+          shift_id: shift.id,
+          volunteer_id: user.id,
+          booking_status: isFull ? "waitlisted" : "confirmed",
+          time_slot_id: slot.id,
+        });
+        if (error) { bookingError = true; break; }
+      }
+    } else {
+      // Fallback: shift without time slots
+      const { error } = await supabase.from("shift_bookings").insert({
+        shift_id: shift.id,
+        volunteer_id: user.id,
+        booking_status: "confirmed",
+      });
+      if (error) bookingError = true;
+    }
+
+    if (bookingError) {
+      toast({ title: "Could not book shift", description: "An error occurred while booking. Please try again.", variant: "destructive" });
+      setInvitationActioning(null);
+      return;
+    }
+
+    // Update invitation status
+    await supabase
+      .from("shift_invitations")
+      .update({ status: "accepted" })
+      .eq("id", inv.id);
+
+    // Notify admin and coordinator that invitation was accepted
+    const notifs: any[] = [
+      {
+        user_id: inv.invited_by,
+        type: "shift_invitation",
+        title: `Invitation accepted — ${shift.title}`,
+        message: `${profile?.full_name} accepted the invitation to "${shift.title}" on ${shift.shift_date}.`,
+        data: { shift_id: shift.id, shift_title: shift.title, shift_date: shift.shift_date },
+      },
+    ];
+    const { data: coords } = await supabase
+      .from("department_coordinators")
+      .select("coordinator_id")
+      .eq("department_id", shift.department_id);
+    for (const c of (coords || [])) {
+      if (c.coordinator_id !== inv.invited_by) {
+        notifs.push({
+          user_id: c.coordinator_id,
+          type: "shift_invitation",
+          title: `Volunteer accepted invitation — ${shift.title}`,
+          message: `${profile?.full_name} accepted an invitation to "${shift.title}" on ${shift.shift_date}.`,
+          data: { shift_id: shift.id, shift_title: shift.title, shift_date: shift.shift_date },
+        });
+      }
+    }
+    await supabase.from("notifications").insert(notifs);
+
+    setInvitationActioning(null);
+    setInviteConflict(null);
+    toast({ title: "Shift confirmed!", description: `You're booked for ${shift.title}.` });
+    fetchInvitations();
+    fetchBookings();
+  };
+
+  // Decline invitation
+  const handleInvitationDecline = async (inv: any, reason?: string) => {
+    setInvitationActioning(inv.id);
+
+    await supabase
+      .from("shift_invitations")
+      .update({ status: "declined" })
+      .eq("id", inv.id);
+
+    // Notify admin
+    const shift = inv.shifts;
+    await supabase.from("notifications").insert({
+      user_id: inv.invited_by,
+      type: "shift_invitation",
+      title: `Invitation declined — ${shift?.title || "shift"}`,
+      message: `${profile?.full_name} declined the invitation to "${shift?.title}" on ${shift?.shift_date}.${reason ? ` Reason: ${reason}` : ""}`,
+      data: { shift_id: shift?.id, shift_title: shift?.title, shift_date: shift?.shift_date },
+    });
+
+    setInvitationActioning(null);
+    setInviteConflict(null);
+    toast({ title: "Invitation declined" });
+    fetchInvitations();
+  };
 
   const handleWaitlistAccept = async (bookingId: string) => {
     const { error } = await (supabase as any).rpc("waitlist_accept", { p_booking_id: bookingId });
@@ -420,6 +651,67 @@ export default function VolunteerDashboard() {
         </Card>
       )}
 
+      {invitations.length > 0 && (
+        <Card className="border-primary/30">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Mail className="h-4 w-4 text-primary" /> Shift Invitations
+            </CardTitle>
+            <CardDescription className="text-xs">
+              An admin has invited you to the following shift{invitations.length !== 1 ? "s" : ""}. Respond before the shift starts.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {invitations.map((inv) => {
+              const s = inv.shifts;
+              if (!s) return null;
+              const isActioning = invitationActioning === inv.id;
+              return (
+                <div key={inv.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 py-3 px-3 rounded-md bg-primary/5 border border-primary/10">
+                  <div className="space-y-1 min-w-0">
+                    <p className="font-medium text-sm">{s.title}</p>
+                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      <span className="flex items-center gap-1">
+                        <Calendar className="h-3 w-3" />
+                        {format(new Date(s.shift_date + "T00:00:00"), "MMM d, yyyy")}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <Clock className="h-3 w-3" />
+                        {s.start_time?.slice(0, 5)} – {s.end_time?.slice(0, 5)}
+                      </span>
+                      {s.departments?.name && (
+                        <span className="flex items-center gap-1">
+                          <MapPin className="h-3 w-3" />
+                          {s.departments.name}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex gap-2 shrink-0">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={isActioning}
+                      onClick={() => handleInvitationDecline(inv)}
+                    >
+                      Decline
+                    </Button>
+                    <Button
+                      size="sm"
+                      disabled={isActioning}
+                      onClick={() => handleInvitationAccept(inv)}
+                    >
+                      {isActioning ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : <CheckCircle className="h-4 w-4 mr-1" />}
+                      Accept
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
+
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardContent className="pt-6">
@@ -577,6 +869,55 @@ export default function VolunteerDashboard() {
           <VolunteerImpactCharts />
         </CollapsibleContent>
       </Collapsible>
+
+      {/* Invitation conflict resolution dialog */}
+      <AlertDialog open={!!inviteConflict} onOpenChange={(open) => { if (!open) setInviteConflict(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" /> Scheduling Conflict
+            </AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-3">
+                <p>Accepting this shift will conflict with your existing booking:</p>
+                {inviteConflict?.conflictShift && (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
+                    <strong>{inviteConflict.conflictShift.title}</strong> on{" "}
+                    {inviteConflict.conflictShift.shift_date} from{" "}
+                    {inviteConflict.conflictShift.start_time?.slice(0, 5)} to{" "}
+                    {inviteConflict.conflictShift.end_time?.slice(0, 5)}
+                  </div>
+                )}
+                <p>Would you like to cancel your existing booking and accept this invitation?</p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col sm:flex-row gap-2">
+            <AlertDialogCancel
+              onClick={() => {
+                if (inviteConflict) {
+                  handleInvitationDecline(inviteConflict.invitation, "scheduling conflict");
+                }
+              }}
+            >
+              Keep My Existing Booking &amp; Decline
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (inviteConflict) {
+                  completeInvitationAccept(
+                    inviteConflict.invitation,
+                    inviteConflict.conflictBookingId,
+                    inviteConflict.conflictShift
+                  );
+                }
+              }}
+            >
+              Cancel Existing &amp; Accept Invitation
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -320,6 +320,20 @@ function buildTemplateEmail(payload: EmailPayload): { subject: string; html: str
         ),
       };
 
+    case "shift_invitation":
+      return {
+        subject: `You've been invited to: ${shiftTitle || "a shift"}`,
+        html: brandedHtml(
+          h2("You've Been Invited to a Shift") +
+          p(`An admin has invited you to volunteer for <strong>${shiftTitle || "a shift"}</strong>.`) +
+          (shiftDate ? detail("Date", shiftDate) : "") +
+          (shiftTime ? detail("Time", shiftTime) : "") +
+          (department ? detail("Department", department) : "") +
+          p("Log in to your dashboard to accept or decline this invitation. The invitation expires when the shift starts.") +
+          button("View Invitation", `${APP_URL}/dashboard`)
+        ),
+      };
+
     default:
       // Log the missing type so adding new notification types without
       // a corresponding template surfaces quickly instead of silently

--- a/supabase/migrations/20260413_admin_shift_invitations.sql
+++ b/supabase/migrations/20260413_admin_shift_invitations.sql
@@ -1,0 +1,111 @@
+-- ============================================================
+-- Admin Shift Invitations
+-- ============================================================
+-- Extends the existing shift_invitations table (used for friend
+-- invites) with a volunteer_id column for admin-to-volunteer
+-- direct invitations. Adds RLS, a unique constraint, and a cron
+-- job to expire stale invitations.
+-- ============================================================
+
+-- ── 1. Add volunteer_id column ──────────────────────────────
+ALTER TABLE public.shift_invitations
+  ADD COLUMN IF NOT EXISTS volunteer_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE;
+
+-- ── 2. Unique constraint: one pending admin invitation per volunteer per shift ──
+-- NULL volunteer_id rows (friend invites) are ignored by unique indexes.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_shift_invitation_volunteer
+  ON public.shift_invitations (shift_id, volunteer_id)
+  WHERE volunteer_id IS NOT NULL AND status = 'pending';
+
+-- ── 3. Ensure 'declined' is a valid status ──────────────────
+-- Drop the old check constraint and recreate with 'declined'.
+DO $$
+BEGIN
+  -- Find and drop the existing status check constraint
+  PERFORM 1
+    FROM information_schema.table_constraints
+   WHERE table_name = 'shift_invitations'
+     AND constraint_type = 'CHECK'
+     AND constraint_name LIKE '%status%';
+  IF FOUND THEN
+    EXECUTE (
+      SELECT 'ALTER TABLE public.shift_invitations DROP CONSTRAINT ' || constraint_name
+        FROM information_schema.table_constraints
+       WHERE table_name = 'shift_invitations'
+         AND constraint_type = 'CHECK'
+         AND constraint_name LIKE '%status%'
+       LIMIT 1
+    );
+  END IF;
+EXCEPTION WHEN OTHERS THEN
+  NULL; -- no constraint to drop
+END $$;
+
+ALTER TABLE public.shift_invitations
+  ADD CONSTRAINT shift_invitations_status_check
+  CHECK (status IN ('pending', 'accepted', 'declined', 'expired'));
+
+-- ── 4. RLS policies ─────────────────────────────────────────
+ALTER TABLE public.shift_invitations ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies if any so this migration is idempotent
+DROP POLICY IF EXISTS "Admins can manage all invitations" ON public.shift_invitations;
+DROP POLICY IF EXISTS "Volunteers can read own invitations" ON public.shift_invitations;
+DROP POLICY IF EXISTS "Volunteers can update own invitation status" ON public.shift_invitations;
+DROP POLICY IF EXISTS "Coordinators can insert invitations" ON public.shift_invitations;
+DROP POLICY IF EXISTS "Anyone can insert invitations" ON public.shift_invitations;
+
+-- Admins: full access
+CREATE POLICY "Admins can manage all invitations"
+  ON public.shift_invitations
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+       WHERE id = auth.uid() AND role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+       WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
+
+-- Volunteers: can read their own invitations
+CREATE POLICY "Volunteers can read own invitations"
+  ON public.shift_invitations
+  FOR SELECT
+  USING (volunteer_id = auth.uid() OR invited_by = auth.uid());
+
+-- Volunteers: can update status on their own invitations
+CREATE POLICY "Volunteers can update own invitation status"
+  ON public.shift_invitations
+  FOR UPDATE
+  USING (volunteer_id = auth.uid())
+  WITH CHECK (volunteer_id = auth.uid());
+
+-- Allow authenticated users to insert (for friend invites via invited_by)
+CREATE POLICY "Authenticated users can insert invitations"
+  ON public.shift_invitations
+  FOR INSERT
+  WITH CHECK (auth.uid() IS NOT NULL);
+
+-- ── 5. Cron: expire stale invitations ───────────────────────
+-- Runs every 15 minutes. Marks pending invitations as expired
+-- once their expires_at timestamp has passed.
+SELECT cron.unschedule('expire-shift-invitations')
+  WHERE EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'expire-shift-invitations'
+  );
+
+SELECT cron.schedule(
+  'expire-shift-invitations',
+  '*/15 * * * *',
+  $$
+    UPDATE public.shift_invitations
+       SET status = 'expired'
+     WHERE status = 'pending'
+       AND expires_at < now();
+  $$
+);


### PR DESCRIPTION
…ling

Admin can invite specific volunteers to shifts from ManageShifts via InviteVolunteerModal. The modal searches active volunteers, checks department prerequisites (BG check, restrictions), detects scheduling conflicts, and prevents duplicate pending invitations.

Volunteer dashboard shows a "Shift Invitations" section (hidden when empty) with Accept/Decline buttons. Accepting checks slot availability, detects conflicts with existing bookings, and offers to cancel the conflicting booking + trigger waitlist promotion if the volunteer chooses. Declining notifies the admin.

Migration adds volunteer_id to shift_invitations, a partial unique index, updated status check constraint, RLS policies, and a cron job to expire pending invitations past their expires_at timestamp.

New shift_invitation email template added to send-email edge function.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
