### PR TITLE
fix: pass service role key as Authorization header in notification-we…

### DIFF
--- a/supabase/functions/notification-webhook/index.ts
+++ b/supabase/functions/notification-webhook/index.ts
@@ -24,7 +24,11 @@ Deno.serve(async (req) => {
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
     const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    const supabase = createClient(supabaseUrl, serviceRoleKey);
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      global: {
+        headers: { Authorization: `Bearer ${serviceRoleKey}` },
+      },
+    });
 
     // Get the user's email, phone, and notification preferences
     const { data: profile } = await supabase


### PR DESCRIPTION
…bhook

The Supabase JS client's createClient(url, key) sets the key as the apikey header but does not guarantee it is used as the Authorization header for functions.invoke() calls. When notification-webhook called send-sms, the functions gateway rejected the request with 401 because the Authorization header was missing or carried the anon key from the incoming pg_net trigger request instead of the service role key.

Fix: explicitly set global.headers.Authorization = Bearer <serviceRoleKey>
so all downstream function invocations (send-email, send-sms) authenticate correctly.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
