### PR TITLE
chore: add Dependabot config for weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable automated dependency security updates
- Monitors npm dependencies in the repo root, weekly on Mondays
- Monitors GitHub Actions workflow dependencies, weekly on Mondays
- Caps open PRs at 5 per ecosystem to avoid noise
- Auto-labels all Dependabot PRs as \`dependencies\` for filtering

## Test plan
- [ ] Verify Dependabot picks up the config (Insights > Dependency graph > Dependabot after merge)
- [ ] Confirm the first batch of update PRs gets the \`dependencies\` label
- [ ] Verify open-PR cap is respected