### PR TITLE
chore: gate SMS sending behind SMS_ENABLED feature flag

### DIFF
--- a/supabase/functions/notification-webhook/index.ts
+++ b/supabase/functions/notification-webhook/index.ts
@@ -152,6 +152,13 @@ Deno.serve(async (req) => {
     }
 
     // ── Send SMS ──
+    // SMS delivery is gated by a global feature flag. The Twilio sending
+    // number is currently not verified for our destination numbers, so
+    // messages are accepted by Twilio's API but silently dropped at the
+    // carrier. Set SMS_ENABLED=true in Supabase secrets to re-enable
+    // once the Twilio number/recipients are verified.
+    const smsEnabled = Deno.env.get("SMS_ENABLED") === "true";
+
     // Only send to the volunteer's own phone number. Previously this
     // fell back to emergency_contact_phone when profile.phone was null,
     // which was a privacy concern — the emergency contact (likely a
@@ -160,7 +167,7 @@ Deno.serve(async (req) => {
     // volunteer hasn't set a phone number, SMS is simply not sent.
     const smsTarget = profile.phone || null;
     // Urgent waitlist offers send SMS regardless of notif_sms pref.
-    if ((profile.notif_sms || isUrgentWaitlistOffer) && smsTarget) {
+    if (smsEnabled && (profile.notif_sms || isUrgentWaitlistOffer) && smsTarget) {
       // Build a concise SMS message from notification
       let smsBody = `[Easterseals Iowa] ${record.title || "Notification"}: ${(record.message || "").slice(0, 140)}`;
 


### PR DESCRIPTION
Twilio accepts our API calls and returns a message SID, but the sending number isn't verified for our destination numbers, so messages are silently dropped at the carrier. Rather than have users' notif_sms preference produce no-op sends, gate SMS dispatch on a Supabase secret SMS_ENABLED=true. Default (unset) = disabled.

Email notifications are unaffected — the email branch runs independently.

To re-enable once the Twilio number is verified:
  npx supabase secrets set SMS_ENABLED=true --project-ref esycmohgumryeqteiwla

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] 🚀 Feature (`feature/`)
- [ ] 🐛 Bug fix (`fix/`)
- [ ] 🧹 Chore / maintenance (`chore/`)

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] All existing tests pass (`npx vitest run`)
- [ ] Linting passes (`npx eslint .`)
- [ ] Manual testing completed

## Screenshots

<!-- If UI change, attach before/after screenshots -->

## Related Issue / PRD Section

<!-- Link to issue, ticket, or PRD section -->
