### PR TITLE
feat(analytics): add Vercel Analytics

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 import { ThemeProvider } from "next-themes";
+import { Analytics } from "@vercel/analytics/react";
 import App from "./App.tsx";
 import { initSentry, Sentry } from "./lib/sentry";
 import "./index.css";
@@ -37,6 +38,7 @@ createRoot(document.getElementById("root")!).render(
   <Sentry.ErrorBoundary fallback={<ErrorFallback />}>
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <App />
+      <Analytics />
     </ThemeProvider>
   </Sentry.ErrorBoundary>
 );


### PR DESCRIPTION
## Summary
- Adds `@vercel/analytics` and mounts `<Analytics />` inside the root render.
- Zero config — auto-activates on Vercel deployments. No API keys, no env vars.
- Privacy-friendly and cookieless (no GDPR banner needed).

## Test plan
- [ ] `npm run build` succeeds
- [ ] After deploy, visit the production URL and confirm pageviews show up in the Vercel Analytics tab
- [ ] Confirm no new network errors in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)