### PR TITLE
fix: address Supabase Security Advisor findings

### DIFF
--- a/supabase/migrations/20250414120000_fix_security_advisor.sql
+++ b/supabase/migrations/20250414120000_fix_security_advisor.sql
@@ -1,0 +1,150 @@
+-- =============================================================================
+-- Migration: fix_security_advisor
+-- Description: Address Supabase Security Advisor findings
+--   1. Pin search_path on all SECURITY DEFINER functions missing it
+--   2. Add security_barrier to shift_fill_rates view
+--   3. Tighten overly permissive RLS policies (service_role only)
+-- =============================================================================
+
+BEGIN;
+
+-- =============================================================================
+-- 1. SECURITY DEFINER functions — pin search_path
+-- =============================================================================
+-- Every SECURITY DEFINER function must have search_path pinned to prevent
+-- malicious schema injection. Two functions (log_mfa_reset,
+-- admin_emergency_mfa_reset) already have it set correctly and are skipped.
+-- citext extension functions are also skipped (owned by the extension).
+
+ALTER FUNCTION public.trg_recalculate_consistency_fn()
+  SET search_path = public;
+
+ALTER FUNCTION public.get_shift_rating_aggregates(uuid[])
+  SET search_path = public;
+
+ALTER FUNCTION public.transfer_admin_role(uuid, uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.enforce_eligibility_on_profile_update()
+  SET search_path = public;
+
+ALTER FUNCTION public.export_critical_data()
+  SET search_path = public;
+
+ALTER FUNCTION public.get_shift_popularity(uuid[])
+  SET search_path = public;
+
+ALTER FUNCTION public.sync_volunteer_reported_hours()
+  SET search_path = public;
+
+ALTER FUNCTION public.score_shifts_for_volunteer(uuid, integer)
+  SET search_path = public;
+
+ALTER FUNCTION public.get_shift_consistency(uuid[])
+  SET search_path = public;
+
+ALTER FUNCTION public.trg_update_preferences_on_interaction()
+  SET search_path = public;
+
+ALTER FUNCTION public.update_volunteer_preferences(uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.get_department_report(uuid[], date, date)
+  SET search_path = public;
+
+ALTER FUNCTION public.trg_recalculate_points_fn()
+  SET search_path = public;
+
+ALTER FUNCTION public.recalculate_points(uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.cascade_bg_check_expiry()
+  SET search_path = public;
+
+ALTER FUNCTION public.create_self_confirmation_report()
+  SET search_path = public;
+
+ALTER FUNCTION public.send_self_confirmation_reminders()
+  SET search_path = public;
+
+ALTER FUNCTION public.get_unactioned_shifts()
+  SET search_path = public;
+
+ALTER FUNCTION public.waitlist_accept(uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.admin_delete_unactioned_shift(uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.admin_update_shift_hours(uuid, numeric)
+  SET search_path = public;
+
+ALTER FUNCTION public.admin_action_off_shift(uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.promote_next_waitlist(uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.promote_next_waitlist(uuid, uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.reconcile_shift_counters()
+  SET search_path = public;
+
+ALTER FUNCTION public.waitlist_decline(uuid)
+  SET search_path = public;
+
+
+-- =============================================================================
+-- 2. VIEW security_barrier — shift_fill_rates
+-- =============================================================================
+-- volunteer_shift_reports_safe already has security_barrier=true.
+-- shift_fill_rates is missing it — recreate with the flag.
+
+CREATE OR REPLACE VIEW public.shift_fill_rates
+  WITH (security_barrier = true)
+  AS
+  SELECT id AS shift_id,
+    total_slots,
+    booked_slots,
+    department_id,
+    shift_date,
+    time_type,
+    EXTRACT(dow FROM shift_date) AS day_of_week,
+    CASE
+      WHEN (total_slots = 0) THEN (0)::numeric
+      ELSE round(((booked_slots)::numeric / (total_slots)::numeric), 4)
+    END AS fill_ratio
+  FROM shifts s
+  WHERE ((status <> 'cancelled'::shift_status) AND (shift_date >= CURRENT_DATE));
+
+
+-- =============================================================================
+-- 3. RLS policies — tighten overly permissive checks
+-- =============================================================================
+-- These three policies use bare `true` as their USING or WITH CHECK expression,
+-- which means any authenticated role can hit them. They should be restricted to
+-- the service_role only (used by Edge Functions / pg_cron / server-side calls).
+
+-- 3a. "preferences: system update" on volunteer_preferences
+DROP POLICY "preferences: system update" ON public.volunteer_preferences;
+CREATE POLICY "preferences: system update" ON public.volunteer_preferences
+  FOR UPDATE
+  USING ((current_setting('request.jwt.claims', true)::json ->> 'role') = 'service_role')
+  WITH CHECK ((current_setting('request.jwt.claims', true)::json ->> 'role') = 'service_role');
+
+-- 3b. "preferences: system upsert" on volunteer_preferences
+DROP POLICY "preferences: system upsert" ON public.volunteer_preferences;
+CREATE POLICY "preferences: system upsert" ON public.volunteer_preferences
+  FOR INSERT
+  WITH CHECK ((current_setting('request.jwt.claims', true)::json ->> 'role') = 'service_role');
+
+-- 3c. "Service role can insert logs" on admin_action_log
+-- NOTE: earlier draft referenced public.audit_logs, which does not
+-- exist. The policy lives on public.admin_action_log (baseline line 4598).
+DROP POLICY "Service role can insert logs" ON public.admin_action_log;
+CREATE POLICY "Service role can insert logs" ON public.admin_action_log
+  FOR INSERT
+  WITH CHECK ((current_setting('request.jwt.claims', true)::json ->> 'role') = 'service_role');
+
+COMMIT;


### PR DESCRIPTION
## Summary
Single SQL migration addressing three categories of Security Advisor findings.

1. **Pins `search_path = public` on 26 `SECURITY DEFINER` functions** that were missing it — prevents schema-injection attacks. `log_mfa_reset` and `admin_emergency_mfa_reset` already had it set; citext extension funcs are skipped (owned by extension).
2. **Recreates `public.shift_fill_rates` with `WITH (security_barrier = true)`** to match `public.volunteer_shift_reports_safe`.
3. **Tightens three RLS policies** that had bare `true` checks, restricting to `service_role` only:
   - `"preferences: system update"` on `volunteer_preferences`
   - `"preferences: system upsert"` on `volunteer_preferences`
   - `"Service role can insert logs"` on `admin_action_log`

## Review notes
- Fixed one bug in the generated draft: it referenced `public.audit_logs` (doesn't exist). Corrected to `public.admin_action_log` (baseline line 4598).
- Did **not** cross-reference the 26 functions against the full Security Advisor report — worth a sanity pass before merge.
- **Behavioral risk:** the 3 tightened policies currently accept any authenticated role. After merge, only `role=service_role` passes. Any client-side code writing directly to `volunteer_preferences` or `admin_action_log` as an authenticated user will start failing. Audit callers before merge.

## Test plan
- [ ] Apply locally against a fresh `supabase db reset` — confirm no SQL errors
- [ ] Re-run Security Advisor on staging after apply — confirm the flagged items clear
- [ ] Grep repo for direct client writes to `volunteer_preferences` / `admin_action_log` (RPCs are fine — they use `SECURITY DEFINER`)
- [ ] Verify the waitlist / consistency / reconciliation paths still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)