### PR TITLE
ci: skip Playwright E2E on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
     name: Playwright E2E
     runs-on: ubuntu-latest
     needs: lint-and-unit
+    # Skip on Dependabot PRs: they run without access to repo secrets
+    # (secrets must be duplicated into the Dependabot namespace), so
+    # SUPABASE_ANON_KEY and other E2E creds come through empty. Unit
+    # tests and lint still run on these PRs.
+    if: github.actor != 'dependabot[bot]'
     # Only one E2E suite at a time — tests create/delete shifts on a
     # shared production DB. Parallel runs (push + PR sync events)
     # delete each other's test shifts mid-test, causing FK errors.


### PR DESCRIPTION
## Summary

- Adds `if: github.actor != 'dependabot[bot]'` to the `e2e` job in `.github/workflows/ci.yml`
- Lint + Vitest still run on every PR, including Dependabot's
- `comment-on-pr` already handles `skipped` status correctly (⏭️ badge)

## Why

Dependabot PRs (e.g. #289) fail at `tests/e2e/fixtures/session.ts:62` with:
> SUPABASE_ANON_KEY env var is required for E2E tests

This isn't a missing secret — the repo has it. GitHub restricts secret access on Dependabot PRs by default to block malicious dep updates from exfiltrating keys. The Dependabot secrets namespace (`gh secret list --app dependabot`) is empty.

Skipping E2E on these PRs is the low-friction fix: dependency bumps rarely change runtime behavior.

## Alternatives considered

- Duplicate all 7 test secrets into the Dependabot namespace — more secure boundary but more ceremony per secret rotation.
- Move E2E to `push` on main only — cheaper, but catches bugs later.

## Test plan

- [ ] Merge this PR
- [ ] Re-run CI on PR #289 and confirm `e2e` shows as Skipped (not Failed)
- [ ] Confirm `lint-and-unit` still runs and passes
- [ ] On a normal (non-Dependabot) PR, confirm `e2e` still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)