### PR TITLE
fix: harden unrestricted RLS policies on admin_action_log and volunteer_preferences

### DIFF
--- a/supabase/migrations/20260414130000_harden_rls_policies.sql
+++ b/supabase/migrations/20260414130000_harden_rls_policies.sql
@@ -1,0 +1,67 @@
+-- =============================================================================
+-- Migration: harden_rls_policies
+-- Description: Restrict three unrestricted RLS policies flagged by the
+--   Supabase Security Advisor. All three policies were written as
+--   WITH CHECK (true) / USING (true), meaning any authenticated or anon
+--   session could write directly to these tables via the REST API.
+--
+-- Tables affected:
+--   1. admin_action_log  — INSERT policy "Service role can insert logs"
+--   2. volunteer_preferences — UPDATE policy "preferences: system update"
+--   3. volunteer_preferences — INSERT policy "preferences: system upsert"
+--
+-- Fix: restrict all three to service_role JWT claim only.
+--
+-- Safety analysis:
+--   • admin_action_log is written exclusively by two edge functions
+--     (admin-act-on-behalf, admin-reset-mfa) that use the SERVICE_ROLE_KEY
+--     (adminClient). Service-role requests bypass RLS entirely, so the
+--     policy is never evaluated for legitimate writes. Restricting it
+--     blocks only direct REST API abuse.
+--
+--   • volunteer_preferences is written exclusively by
+--     public.update_volunteer_preferences(), a SECURITY DEFINER function
+--     that runs as the postgres role and also bypasses RLS. Restricting
+--     the policies does not affect trigger-based writes at all.
+--
+-- No existing write paths are broken by this change.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. admin_action_log — INSERT policy
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Service role can insert logs" ON public.admin_action_log;
+
+CREATE POLICY "Service role can insert logs"
+  ON public.admin_action_log
+  FOR INSERT
+  WITH CHECK (
+    (current_setting('request.jwt.claims', true)::json ->> 'role') = 'service_role'
+  );
+
+-- ---------------------------------------------------------------------------
+-- 2. volunteer_preferences — UPDATE policy
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "preferences: system update" ON public.volunteer_preferences;
+
+CREATE POLICY "preferences: system update"
+  ON public.volunteer_preferences
+  FOR UPDATE
+  USING (
+    (current_setting('request.jwt.claims', true)::json ->> 'role') = 'service_role'
+  )
+  WITH CHECK (
+    (current_setting('request.jwt.claims', true)::json ->> 'role') = 'service_role'
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. volunteer_preferences — INSERT policy
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "preferences: system upsert" ON public.volunteer_preferences;
+
+CREATE POLICY "preferences: system upsert"
+  ON public.volunteer_preferences
+  FOR INSERT
+  WITH CHECK (
+    (current_setting('request.jwt.claims', true)::json ->> 'role') = 'service_role'
+  );


### PR DESCRIPTION
## Summary

- **`admin_action_log` INSERT** — `"Service role can insert logs"` changed from `WITH CHECK (true)` to `WITH CHECK (jwt.role = 'service_role')`. Any authenticated user could previously insert fabricated audit entries directly via the REST API.
- **`volunteer_preferences` UPDATE** — `"preferences: system update"` restricted from `USING (true) / WITH CHECK (true)` to service_role only. Previously any user could overwrite any volunteer's affinity/reliability scores.
- **`volunteer_preferences` INSERT** — `"preferences: system upsert"` restricted from `WITH CHECK (true)` to service_role only.

## Safety

Legitimate write paths are unaffected:
- Edge functions (`admin-act-on-behalf`, `admin-reset-mfa`) use `adminClient` (SERVICE_ROLE_KEY) — service-role requests **bypass RLS entirely**
- `update_volunteer_preferences()` is `SECURITY DEFINER` running as `postgres` — also **bypasses RLS entirely**

The policies now enforce what they were named to do all along.

## Verification

- `supabase db push --dry-run --linked` ✅ — only this migration queued
- Applied to local Docker container, confirmed all three policies show the JWT `role` check in `pg_policies`

**Do not apply to production without approval.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)