### PR TITLE
fix(db): guard recalculate_points against deleted profile rows

### DIFF
--- a/supabase/migrations/20260423000000_guard_recalculate_points_during_delete.sql
+++ b/supabase/migrations/20260423000000_guard_recalculate_points_during_delete.sql
@@ -1,0 +1,47 @@
+-- Fixes FK violation when deleting users with confirmed bookings.
+-- Trigger chain: delete user → cascade to profiles → cancel_bookings_on_profile_delete fires
+-- → trg_recalculate_points_fn fires → recalculate_points tries to UPDATE a profile row
+-- whose parent auth.users row is being deleted in the same transaction. The guard
+-- prevents the UPDATE when the target profile no longer exists.
+-- Observed: Apr 23 2026, deleting anam@live.ca with confirmed bookings.
+--
+-- Byte-equivalent to the existing function body (baseline:1892–1913 plus the
+-- search_path alter from 20260414000002_fix_security_advisor.sql:101) except
+-- for the IF EXISTS guard wrapping the UPDATE.
+
+CREATE OR REPLACE FUNCTION public.recalculate_points(volunteer_uuid uuid)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_catalog
+  AS $$
+DECLARE
+  pts integer := 0;
+  shift_pts integer := 0;
+  rating_pts integer := 0;
+  milestone_pts integer := 0;
+BEGIN
+  SELECT COALESCE(SUM(COALESCE(final_hours, 0)) * 10, 0)::integer INTO shift_pts
+  FROM shift_bookings
+  WHERE volunteer_id = volunteer_uuid
+    AND booking_status = 'confirmed'
+    AND confirmation_status = 'confirmed';
+
+  SELECT COALESCE(COUNT(*) * 5, 0)::integer INTO rating_pts
+  FROM volunteer_shift_reports vsr
+  JOIN shift_bookings sb ON vsr.booking_id = sb.id
+  WHERE sb.volunteer_id = volunteer_uuid AND vsr.star_rating = 5;
+
+  SELECT COALESCE(floor(total_hours / 10) * 25, 0)::integer INTO milestone_pts
+  FROM profiles WHERE id = volunteer_uuid;
+
+  pts := shift_pts + rating_pts + milestone_pts;
+
+  -- Guard: only update if the profile still exists. Prevents FK violation
+  -- when this function is called from a trigger during a cascading delete
+  -- of the profile row (see file header comment).
+  IF EXISTS (SELECT 1 FROM public.profiles WHERE id = volunteer_uuid) THEN
+    UPDATE profiles SET volunteer_points = pts WHERE id = volunteer_uuid;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Root cause

Deleting a user with confirmed bookings fails with \`ERROR: 23503\` (FK violation) because a trigger chain updates the profile row mid-deletion:

\`\`\`
DELETE auth.users
  └─ ON DELETE CASCADE on profiles.id_fkey
        └─ BEFORE DELETE trigger: cancel_bookings_on_profile_delete
              └─ UPDATE shift_bookings SET booking_status='cancelled'
                    └─ AFTER UPDATE trigger: trg_recalculate_points_fn
                          └─ PERFORM recalculate_points(volunteer_id)
                                └─ UPDATE profiles SET volunteer_points = pts WHERE id = v_uuid
                                      └─ 💥 FK violation (auth.users parent already deleted)
\`\`\`

## Reproduction

Observed **2026-04-23** attempting to delete \`anam@live.ca\` (had confirmed bookings). Users without confirmed bookings (e.g. \`iqbal@outlook.com\`) delete fine because the trigger chain doesn't fire.

## Fix

Single new migration: \`supabase/migrations/20260423000000_guard_recalculate_points_during_delete.sql\`.

\`CREATE OR REPLACE\` on \`public.recalculate_points(uuid)\` adds one \`IF EXISTS\` guard around the final \`UPDATE\`:

\`\`\`sql
IF EXISTS (SELECT 1 FROM public.profiles WHERE id = volunteer_uuid) THEN
  UPDATE profiles SET volunteer_points = pts WHERE id = volunteer_uuid;
END IF;
\`\`\`

Everything else is byte-equivalent to the existing version (baseline:1892–1913 + the \`search_path\` alter from \`20260414000002_fix_security_advisor.sql:101\`). Signature, \`LANGUAGE plpgsql\`, \`SECURITY DEFINER\`, and \`SET search_path = public, pg_catalog\` all preserved explicitly. Owner (\`postgres\`) and GRANTs (\`anon\`, \`authenticated\`, \`service_role\`) are preserved automatically by \`CREATE OR REPLACE\`.

## Impact

| Path | Behavior |
|------|----------|
| Normal (profile exists) | No change — \`UPDATE\` runs exactly as before |
| Cascade (profile row doomed) | \`UPDATE\` skipped — no-op instead of FK violation |

No frontend or edge-function changes. Only DB callers of \`recalculate_points\`:
- \`trg_recalculate_points_fn\` trigger (fires on shift_bookings status changes)
- \`admin_update_shift_hours\` RPC (admin adjusts hours on a live volunteer)

Both operate on live profiles in the normal path, so the guard is a no-op for them.

## Verification

- \`npx supabase db push --linked --dry-run\` → only this migration queued, clean ✅
- \`npx vitest run\` → **103/103 passing** ✅
- No test changes needed (no behavior change for the normal path)

## Deployment note

**Migration must be applied to production immediately after merge** via:

\`\`\`bash
npx supabase db push --linked
\`\`\`

Until the migration is live, the manual workaround remains: cancel a user's confirmed bookings first (via admin UI or SQL), then delete the user.

## Related patterns flagged for Sprint 2

Two other functions follow the same "trigger → RPC → UPDATE on potentially-deleted row" shape. Neither has been observed failing yet, but both are worth auditing in Sprint 2's hardening pass:

- \`trg_recalculate_consistency_fn\` → \`recalculate_consistency()\` — same trigger-after-booking-change pattern
- \`trg_update_preferences_on_interaction\` → \`update_volunteer_preferences()\` — fires on \`volunteer_shift_interactions\` inserts

Not touched in this PR per scope.

## Do not merge without review

Per workflow — branch pushed, not merged. Apply migration to prod right after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)