### PR TITLE
fix(e2e): getTestDepartmentId must filter by caller id

### DIFF
--- a/tests/e2e/01-volunteer-books-shift.spec.ts
+++ b/tests/e2e/01-volunteer-books-shift.spec.ts
@@ -58,7 +58,7 @@ test.describe("Volunteer books a shift", () => {
     // RLS can't delete shifts in other departments)
     const admin = await signInAsRole(request, "admin");
     await cleanupStaleE2EShifts(request, admin.access_token);
-    const departmentId = await getTestDepartmentId(request, coordAccess);
+    const departmentId = await getTestDepartmentId(request, coordAccess, coord.user.id);
     shiftDate = uniqueShiftDate(SHIFT_DATE_OFFSET_DAYS);
     uniqueTitle = `E2E-BookFlow-${Date.now()}`;
     const shift = await createShift(request, coordAccess, {

--- a/tests/e2e/02-waitlist-promotion.spec.ts
+++ b/tests/e2e/02-waitlist-promotion.spec.ts
@@ -71,7 +71,7 @@ test.describe.skip("Waitlist promotion lifecycle", () => {
     // Clean up orphaned E2E shifts using ADMIN token
     const adminForCleanup = await signInAsRole(request, "admin");
     await cleanupStaleE2EShifts(request, adminForCleanup.access_token);
-    const departmentId = await getTestDepartmentId(request, coordAccess);
+    const departmentId = await getTestDepartmentId(request, coordAccess, coord.user.id);
     const shiftDate = uniqueShiftDate(SHIFT_DATE_OFFSET_DAYS);
     const shift = await createShift(request, coordAccess, {
       department_id: departmentId,

--- a/tests/e2e/03-coordinator-confirms-attendance.spec.ts
+++ b/tests/e2e/03-coordinator-confirms-attendance.spec.ts
@@ -60,7 +60,7 @@ test.describe("Coordinator confirms attendance", () => {
     // Clean up orphaned E2E shifts using ADMIN token
     const adminForCleanup = await signInAsRole(request, "admin");
     await cleanupStaleE2EShifts(request, adminForCleanup.access_token);
-    const departmentId = await getTestDepartmentId(request, coordAccess);
+    const departmentId = await getTestDepartmentId(request, coordAccess, coord.user.id);
     const pastDate = uniquePastShiftDate(PAST_DATE_OFFSET_DAYS);
     const shift = await createShift(request, coordAccess, {
       department_id: departmentId,

--- a/tests/e2e/04-admin-delete-shift.spec.ts
+++ b/tests/e2e/04-admin-delete-shift.spec.ts
@@ -52,7 +52,8 @@ test.describe("Admin hard-deletes shift with bookings", () => {
     await cleanupStaleE2EShifts(request, adminForCleanup.access_token);
     const departmentId = await getTestDepartmentId(
       request,
-      coord.access_token
+      coord.access_token,
+      coord.user.id
     );
     const shiftDate = uniqueShiftDate(SHIFT_DATE_OFFSET_DAYS);
     const shift = await createShift(request, coord.access_token, {

--- a/tests/e2e/05-shift-lifecycle.spec.ts
+++ b/tests/e2e/05-shift-lifecycle.spec.ts
@@ -63,7 +63,7 @@ test.describe("Past shift placement in admin list", () => {
     const admin = await signInAsRole(request, "admin");
     adminAccess = admin.access_token;
     await cleanupStaleE2EShifts(request, adminAccess);
-    const departmentId = await getTestDepartmentId(request, adminAccess);
+    const departmentId = await getTestDepartmentId(request, adminAccess, admin.user.id);
     const pastDate = uniquePastShiftDate(PAST_OFFSET_DAYS);
     const uniqueTitle = `E2E-Lifecycle-${Date.now()}`;
     const shift = await createShift(request, adminAccess, {
@@ -141,7 +141,7 @@ test.describe("Past shift placement in admin list", () => {
     const admin = await signInAsRole(request, "admin");
     adminAccess = admin.access_token;
     await cleanupStaleE2EShifts(request, adminAccess);
-    const departmentId = await getTestDepartmentId(request, adminAccess);
+    const departmentId = await getTestDepartmentId(request, adminAccess, admin.user.id);
     const pastDate = uniquePastShiftDate(PAST_OFFSET_DAYS);
     const originalTitle = `E2E-Immutability-${Date.now()}`;
     const shift = await createShift(request, adminAccess, {

--- a/tests/e2e/fixtures/db.ts
+++ b/tests/e2e/fixtures/db.ts
@@ -281,29 +281,54 @@ export async function countBy(
 }
 
 /**
- * Pick a department the test coordinator is assigned to. In the
- * production DB this is the "Adult Day Program (Life Club)"
- * department. Falls back to the first department visible to the
- * coordinator if that name changes.
+ * Pick a department the caller is authorized to create shifts in.
+ *
+ * For coordinators: returns one of their `department_coordinators`
+ * assignments. For admins (who typically have no row in that table):
+ * falls back to any active department, since `shifts` RLS lets admins
+ * insert regardless of department assignment.
+ *
+ * Why the `callerUserId` arg matters:
+ *   The `dept_coords: coord read` RLS policy lets ANY coordinator or
+ *   admin SELECT ALL rows in `department_coordinators`. An earlier
+ *   version of this helper queried with `limit=1` and no filter, so
+ *   PostgREST returned an arbitrary row — in multi-coordinator DBs,
+ *   often some OTHER coordinator's assignment. Passing that unrelated
+ *   `department_id` into `createShift` then triggered the 403 on
+ *   `shifts` INSERT (the `EXISTS` check in the shifts policy requires
+ *   `coordinator_id = auth.uid()`). Filtering by `callerUserId`
+ *   guarantees we pick one of the caller's own departments.
  */
 export async function getTestDepartmentId(
   request: APIRequestContext,
-  accessToken: string
+  accessToken: string,
+  callerUserId: string
 ): Promise<string> {
-  const res = await request.get(
-    `${SUPABASE_URL}/rest/v1/department_coordinators?select=department_id,departments(name)&limit=1`,
+  // Coordinator path: filter to the caller's own assignments.
+  const mine = await request.get(
+    `${SUPABASE_URL}/rest/v1/department_coordinators?select=department_id&coordinator_id=eq.${callerUserId}&limit=1`,
     { headers: headers(accessToken) }
   );
-  if (!res.ok()) {
-    throw new Error(`getTestDepartmentId: ${res.status()} ${await res.text()}`);
+  if (mine.ok()) {
+    const rows = await mine.json();
+    if (rows && rows.length > 0) return rows[0].department_id;
   }
-  const rows = await res.json();
+
+  // Admin fallback: admins typically have no department_coordinators
+  // row. They can insert shifts into any department per RLS, so any
+  // active department works.
+  const any = await request.get(
+    `${SUPABASE_URL}/rest/v1/departments?select=id&is_active=eq.true&limit=1`,
+    { headers: headers(accessToken) }
+  );
+  if (!any.ok()) {
+    throw new Error(`getTestDepartmentId: ${any.status()} ${await any.text()}`);
+  }
+  const rows = await any.json();
   if (!rows || rows.length === 0) {
-    throw new Error(
-      "No department_coordinators row found for test coordinator"
-    );
+    throw new Error("No active departments available for test");
   }
-  return rows[0].department_id;
+  return rows[0].id;
 }
 
 /**


### PR DESCRIPTION
## Root cause

Playwright E2E started failing with 403 on every \`createShift\` call after the \`TEST_PASSWORD\` rotation restored auth. The coordinator authenticated cleanly, but the subsequent shift insert hit:

\`\`\`
403 {"code":"42501","message":"new row violates row-level security policy for table \"shifts\""}
\`\`\`

\`getTestDepartmentId()\` was querying \`department_coordinators?limit=1\` with **no filter on \`coordinator_id\`**. The RLS policy \`dept_coords: coord read\` lets any coordinator SELECT all rows — so PostgREST returned whichever row happened to come first, often belonging to a **different** coordinator. The returned \`department_id\` was then rejected by \`shifts\`'s INSERT policy:

\`\`\`sql
is_admin() OR (is_coordinator_or_admin() AND EXISTS (
  SELECT 1 FROM department_coordinators dc
  WHERE dc.department_id = shifts.department_id
    AND dc.coordinator_id = auth.uid()
))
\`\`\`

Test coord **is** a coordinator (✓ first clause), but the EXISTS check on the random \`department_id\` against \`auth.uid()\` failed.

## Why it was green before and fails now

Latent bug the whole time. \`department_coordinators\` row ordering without an \`ORDER BY\` is implementation-defined — typically physical insertion order. As long as the test coordinator's rows happened to come first, \`limit=1\` always returned one of theirs and the whole chain passed. Adding new coordinators to prod recently pushed different rows to the front, flipping the coin the other way.

## Fix

Add \`callerUserId\` as a third arg to \`getTestDepartmentId\` and filter by it:

\`\`\`ts
// Before
await request.get(\`.../department_coordinators?select=department_id&limit=1\`, ...);

// After
await request.get(\`.../department_coordinators?select=department_id&coordinator_id=eq.\${callerUserId}&limit=1\`, ...);
\`\`\`

With an admin fallback (admins have no \`department_coordinators\` row but can insert shifts into any department per RLS) that falls back to the first active department.

All 7 call sites across 5 spec files updated to pass \`coord.user.id\` or \`admin.user.id\` accordingly. \`signInAsRole\` already returns \`user.id\` — it's just an extra arg on the existing call.

## Impact

- **No production change** (this is a pure test-side fix)
- **No RLS change** (security policy unchanged; we align the tests to it)
- **No test-intent change** (every spec still creates a shift in a department the caller is authorized to manage — just now picks the correct one deterministically)

## Files changed

| File | Change |
|------|--------|
| \`tests/e2e/fixtures/db.ts\` | Helper: add \`callerUserId\` param, filter query, add admin fallback |
| \`tests/e2e/01-volunteer-books-shift.spec.ts\` | Pass \`coord.user.id\` |
| \`tests/e2e/02-waitlist-promotion.spec.ts\` | Pass \`coord.user.id\` |
| \`tests/e2e/03-coordinator-confirms-attendance.spec.ts\` | Pass \`coord.user.id\` |
| \`tests/e2e/04-admin-delete-shift.spec.ts\` | Pass \`coord.user.id\` |
| \`tests/e2e/05-shift-lifecycle.spec.ts\` | Pass \`admin.user.id\` (both call sites) |

Diff: 46 insertions, 20 deletions across 6 files.

## Verification

- \`npx tsc --noEmit\` — clean ✅
- \`npx vitest run\` — **103/103** ✅
- \`npm run lint\` — 0 errors (1 pre-existing warning unrelated)
- Playwright local run not attempted (prod-only harness); CI will confirm on this PR

## Related

- PR #89 (recalculate_points guard) is blocked on CI clearing; this fix unblocks that and every future PR that runs Playwright.
- After this merges and main is green, PR #89 should pass its next CI run normally.

## Do not merge without review

🤖 Generated with [Claude Code](https://claude.com/claude-code)