### PR TITLE
fix(db): recalculate_points guard — check auth.users, not profiles

### DIFF
--- a/supabase/migrations/20260423_000001_recalculate_points_guard_auth_users.sql
+++ b/supabase/migrations/20260423_000001_recalculate_points_guard_auth_users.sql
@@ -1,0 +1,57 @@
+-- Supersedes 20260423000000_guard_recalculate_points_during_delete.sql.
+--
+-- That previous guard checked `EXISTS (SELECT 1 FROM profiles WHERE id = volunteer_uuid)`,
+-- which was the wrong table. During the cascading delete of a user:
+--   - auth.users row is deleted first
+--   - CASCADE on profiles.id_fkey queues the profiles row for deletion
+--   - BEFORE DELETE trigger cancel_bookings_on_profile_delete fires — at this
+--     point the profiles row is STILL VISIBLE in-transaction, so the
+--     `EXISTS (profiles)` guard returned TRUE and the UPDATE proceeded
+--   - The UPDATE triggered an FK recheck against profiles_id_fkey → auth.users
+--   - auth.users parent row is already gone → FK violation (ERROR: 23503)
+--
+-- The correct check is `EXISTS (SELECT 1 FROM auth.users WHERE id = volunteer_uuid)`.
+-- When auth.users is gone, the cascade is underway and any UPDATE on the child
+-- profile row will fail FK recheck — so we must skip it.
+--
+-- Everything else (signature, SECURITY DEFINER, search_path, calculation
+-- logic, error messages) preserved byte-for-byte from the previous version.
+
+CREATE OR REPLACE FUNCTION public.recalculate_points(volunteer_uuid uuid)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_catalog
+  AS $$
+DECLARE
+  pts integer := 0;
+  shift_pts integer := 0;
+  rating_pts integer := 0;
+  milestone_pts integer := 0;
+BEGIN
+  SELECT COALESCE(SUM(COALESCE(final_hours, 0)) * 10, 0)::integer INTO shift_pts
+  FROM shift_bookings
+  WHERE volunteer_id = volunteer_uuid
+    AND booking_status = 'confirmed'
+    AND confirmation_status = 'confirmed';
+
+  SELECT COALESCE(COUNT(*) * 5, 0)::integer INTO rating_pts
+  FROM volunteer_shift_reports vsr
+  JOIN shift_bookings sb ON vsr.booking_id = sb.id
+  WHERE sb.volunteer_id = volunteer_uuid AND vsr.star_rating = 5;
+
+  SELECT COALESCE(floor(total_hours / 10) * 25, 0)::integer INTO milestone_pts
+  FROM profiles WHERE id = volunteer_uuid;
+
+  pts := shift_pts + rating_pts + milestone_pts;
+
+  -- Guard: skip the UPDATE when the auth.users parent row is gone. This is
+  -- the signal that a cascading delete is underway — the profile row itself
+  -- is still visible in-transaction (BEFORE DELETE trigger context), but any
+  -- write to it would fail the FK recheck against the missing parent.
+  -- See the file header for the full diagnosis.
+  IF EXISTS (SELECT 1 FROM auth.users WHERE id = volunteer_uuid) THEN
+    UPDATE profiles SET volunteer_points = pts WHERE id = volunteer_uuid;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Root cause

The previous guard in \`20260423000000_guard_recalculate_points_during_delete.sql\` checked the **wrong table**. It guarded on \`EXISTS (profiles)\`, but the FK violation during a user-delete cascade is \`profiles_id_fkey → auth.users\`. At BEFORE DELETE trigger time, the profile row is **still visible in-transaction** — so \`EXISTS (profiles)\` returns TRUE, the guard passes, the UPDATE runs, and the FK recheck against the already-deleted \`auth.users\` parent fails with the same \`ERROR: 23503\` we started with.

## Fix

Switch the guard to check \`auth.users\` instead:

\`\`\`sql
IF EXISTS (SELECT 1 FROM auth.users WHERE id = volunteer_uuid) THEN
  UPDATE profiles SET volunteer_points = pts WHERE id = volunteer_uuid;
END IF;
\`\`\`

When \`auth.users\` is gone, the cascade is underway; skipping the UPDATE is the correct no-op. When \`auth.users\` is present (normal booking-status/admin-hours-edit paths), the UPDATE runs exactly as before.

## Cascade chain, annotated

\`\`\`
DELETE auth.users
  └─ ON DELETE CASCADE via profiles.id_fkey
     └─ BEFORE DELETE trigger: cancel_bookings_on_profile_delete
        └─ UPDATE shift_bookings SET booking_status='cancelled'
           └─ AFTER UPDATE trigger: trg_recalculate_points_fn
              └─ PERFORM recalculate_points(volunteer_id)
                 └─ UPDATE profiles SET volunteer_points = pts
                    ↓
                    OLD guard: EXISTS (profiles) → TRUE (row still visible)    → UPDATE → 💥 FK violation
                    NEW guard: EXISTS (auth.users) → FALSE (parent already gone) → skip → ✅
\`\`\`

## What's preserved

Everything except the guard expression:

- Signature: \`public.recalculate_points(volunteer_uuid uuid) RETURNS void\`
- \`LANGUAGE plpgsql SECURITY DEFINER\`
- \`SET search_path = public, pg_catalog\` — unchanged; \`auth.users\` is explicitly schema-qualified so no search_path update needed
- Calculation logic for \`shift_pts\`, \`rating_pts\`, \`milestone_pts\`
- Error message wording (none changed — the guard just skips silently)
- Owner (\`postgres\`) and GRANTs — preserved automatically by \`CREATE OR REPLACE\`

## Verification

- \`npx supabase db push --dry-run --linked\` — accepted; orders correctly after the existing \`20260423000000\` migration ✅
- \`npx vitest run\` — 103/103 (no TS-side behavior change) ✅

## Deployment note

**Apply to prod immediately after merge** via:

\`\`\`bash
npx supabase db push --linked
\`\`\`

Until then, the manual workaround from PR #89 still applies (cancel bookings first, then delete the user). The previous migration \`20260423000000\` is already on prod — this follow-up simply replaces the function body in place.

## Why a second migration instead of amending the first

The first migration is already applied on production (merged + pushed with PR #89). Editing it in-place would desync local state from remote. A forward-only follow-up is the standard workflow — same pattern Sprint 1's security-advisor patches used (000001 → 000002 → 000003 layering ALTER-style fixes over the baseline).

## Related patterns still flagged for Sprint 2

Per PR #89's note, these two functions follow the same "trigger → RPC → UPDATE on child row during cascade" shape. Neither observed failing yet, but both deserve the same \`EXISTS (auth.users)\` audit during Sprint 2 hardening:

- \`trg_recalculate_consistency_fn\` → \`recalculate_consistency()\`
- \`trg_update_preferences_on_interaction\` → \`update_volunteer_preferences()\`

Not touched in this PR.

## Do not merge without review

🤖 Generated with [Claude Code](https://claude.com/claude-code)