### PR TITLE
fix(db): FK cascade audit on profiles.id — resolves user deletion cascade failures

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -196,7 +196,10 @@ export default function AdminDashboard() {
       .limit(1000);
     if (!allBookings) return;
     const csvData = allBookings.map((b: any) => ({
-      Volunteer: b.profiles?.full_name || "",
+      // Deleted users leave their booking history intact via the SET NULL FK
+      // cascade; the embedded profiles() returns null for those rows. Use a
+      // clear sentinel so the CSV is readable rather than silently blank.
+      Volunteer: b.profiles?.full_name || "[deleted user]",
       Email: b.profiles?.email || "",
       Shift: b.shifts?.title || "",
       Date: b.shifts?.shift_date || "",
@@ -289,7 +292,7 @@ export default function AdminDashboard() {
                         {s.booked_slots}/{s.total_slots}
                       </span>
                       {s.profiles?.full_name && (
-                        <span className="text-xs">by {s.profiles.full_name}</span>
+                        <span className="text-xs">by {s.profiles?.full_name}</span>
                       )}
                     </div>
                   </div>

--- a/src/pages/CoordinatorDashboard.tsx
+++ b/src/pages/CoordinatorDashboard.tsx
@@ -217,7 +217,9 @@ export default function CoordinatorDashboard() {
       .map((b) => {
         const shift = shifts.find((s) => s.id === b.shift_id);
         return {
-          Volunteer: b.profiles?.full_name || "",
+          // See note in AdminDashboard's handleExportAll — profiles() is
+          // null for deleted users thanks to the SET NULL FK cascade.
+          Volunteer: b.profiles?.full_name || "[deleted user]",
           Email: b.profiles?.email || "",
           "Shift Date": shift?.shift_date || "",
           Shift: shift?.title || "",

--- a/supabase/migrations/20260423000002_profile_fk_cascade_audit.sql
+++ b/supabase/migrations/20260423000002_profile_fk_cascade_audit.sql
@@ -1,0 +1,264 @@
+-- FK cascade audit for profiles.id
+--
+-- Establishes consistent cascade semantics across all 33 FKs that
+-- reference public.profiles(id). Before this migration, 24 of those
+-- FKs had no explicit ON DELETE rule (default NO ACTION), producing
+-- cascade failures whenever an admin tried to delete a user with any
+-- related data. Most recently observed on Apr 23 attempting to delete
+-- anam@live.ca — `shift_bookings.volunteer_id` was the surfaced FK,
+-- but it was one of many that would fail in sequence.
+--
+-- Philosophy:
+--   CASCADE    — child rows are conceptually owned by the user and
+--                should vanish with them (ephemeral queues, user-
+--                owned settings, invitations-to-them, PII-scoped data)
+--   SET NULL   — child rows represent historical or audit events that
+--                must persist for reporting/accountability but whose
+--                user reference should be anonymized
+--   (unchanged) — 9 FKs already have the right rule (CASCADE); not
+--                touched
+--
+-- FK rule table (33 total, 24 touched here):
+--   Unchanged (9): conversation_participants, department_coordinators,
+--     department_restrictions.volunteer_id, mfa_backup_codes,
+--     notifications, parental_consents, shift_invitations.volunteer_id,
+--     volunteer_documents.volunteer_id, volunteer_private_notes.volunteer_id
+--   CASCADE     (1): confirmation_reminders.recipient_id
+--   SET NULL   (23): see ALTER TABLE block below
+--
+-- 18 of the 23 SET NULL targets are currently NOT NULL. Those columns
+-- need `ALTER COLUMN ... DROP NOT NULL` before the FK rule can become
+-- SET NULL. Verified against the Apr 19 production schema dump.
+--
+-- Trigger update: cancel_bookings_on_profile_delete() previously only
+-- cancelled 'confirmed' bookings. Extending to 'waitlisted' closes the
+-- gap where a deleted user's waitlist offers would linger orphaned.
+--
+-- No frontend-visible behavior change for live users. After a user
+-- deletion, historical rows (bookings, messages, notes, etc.) persist
+-- with NULL user refs. Any reports/views must handle NULL gracefully —
+-- see companion frontend fixes in the same PR.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. DROP NOT NULL (18 columns)
+-- ---------------------------------------------------------------------
+-- admin_action_log
+ALTER TABLE public.admin_action_log ALTER COLUMN admin_id DROP NOT NULL;
+ALTER TABLE public.admin_action_log ALTER COLUMN volunteer_id DROP NOT NULL;
+
+-- attendance_disputes (admin_decided_by already nullable; skip)
+ALTER TABLE public.attendance_disputes ALTER COLUMN coordinator_id DROP NOT NULL;
+ALTER TABLE public.attendance_disputes ALTER COLUMN volunteer_id DROP NOT NULL;
+
+-- conversations
+ALTER TABLE public.conversations ALTER COLUMN created_by DROP NOT NULL;
+
+-- department_restrictions (volunteer_id stays NOT NULL — still CASCADE)
+ALTER TABLE public.department_restrictions ALTER COLUMN restricted_by DROP NOT NULL;
+
+-- document_types
+ALTER TABLE public.document_types ALTER COLUMN created_by DROP NOT NULL;
+
+-- event_registrations
+ALTER TABLE public.event_registrations ALTER COLUMN volunteer_id DROP NOT NULL;
+
+-- events
+ALTER TABLE public.events ALTER COLUMN created_by DROP NOT NULL;
+
+-- messages
+ALTER TABLE public.messages ALTER COLUMN sender_id DROP NOT NULL;
+
+-- private_note_access_log
+ALTER TABLE public.private_note_access_log ALTER COLUMN admin_user_id DROP NOT NULL;
+ALTER TABLE public.private_note_access_log ALTER COLUMN volunteer_id DROP NOT NULL;
+
+-- shift_attachments
+ALTER TABLE public.shift_attachments ALTER COLUMN uploader_id DROP NOT NULL;
+
+-- shift_bookings (confirmed_by, coordinator_actioned_by already nullable; skip)
+-- volunteer_id is the one that surfaced the production bug.
+ALTER TABLE public.shift_bookings ALTER COLUMN volunteer_id DROP NOT NULL;
+
+-- shift_invitations (volunteer_id already nullable; skip — it's also CASCADE)
+ALTER TABLE public.shift_invitations ALTER COLUMN invited_by DROP NOT NULL;
+
+-- shift_notes
+ALTER TABLE public.shift_notes ALTER COLUMN author_id DROP NOT NULL;
+
+-- shift_recurrence_rules
+ALTER TABLE public.shift_recurrence_rules ALTER COLUMN created_by DROP NOT NULL;
+
+-- shifts
+ALTER TABLE public.shifts ALTER COLUMN created_by DROP NOT NULL;
+
+-- volunteer_documents (reviewed_by already nullable; skip. volunteer_id stays CASCADE.)
+-- volunteer_shift_reports
+ALTER TABLE public.volunteer_shift_reports ALTER COLUMN volunteer_id DROP NOT NULL;
+
+-- ---------------------------------------------------------------------
+-- 2. Change 23 FKs to ON DELETE SET NULL
+-- ---------------------------------------------------------------------
+-- admin_action_log
+ALTER TABLE public.admin_action_log
+  DROP CONSTRAINT admin_action_log_admin_id_fkey,
+  ADD  CONSTRAINT admin_action_log_admin_id_fkey
+    FOREIGN KEY (admin_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+ALTER TABLE public.admin_action_log
+  DROP CONSTRAINT admin_action_log_volunteer_id_fkey,
+  ADD  CONSTRAINT admin_action_log_volunteer_id_fkey
+    FOREIGN KEY (volunteer_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- attendance_disputes
+ALTER TABLE public.attendance_disputes
+  DROP CONSTRAINT attendance_disputes_admin_decided_by_fkey,
+  ADD  CONSTRAINT attendance_disputes_admin_decided_by_fkey
+    FOREIGN KEY (admin_decided_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+ALTER TABLE public.attendance_disputes
+  DROP CONSTRAINT attendance_disputes_coordinator_id_fkey,
+  ADD  CONSTRAINT attendance_disputes_coordinator_id_fkey
+    FOREIGN KEY (coordinator_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+ALTER TABLE public.attendance_disputes
+  DROP CONSTRAINT attendance_disputes_volunteer_id_fkey,
+  ADD  CONSTRAINT attendance_disputes_volunteer_id_fkey
+    FOREIGN KEY (volunteer_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- conversations
+ALTER TABLE public.conversations
+  DROP CONSTRAINT conversations_created_by_fkey,
+  ADD  CONSTRAINT conversations_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- department_restrictions (only restricted_by; volunteer_id stays CASCADE)
+ALTER TABLE public.department_restrictions
+  DROP CONSTRAINT department_restrictions_restricted_by_fkey,
+  ADD  CONSTRAINT department_restrictions_restricted_by_fkey
+    FOREIGN KEY (restricted_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- document_types
+ALTER TABLE public.document_types
+  DROP CONSTRAINT document_types_created_by_fkey,
+  ADD  CONSTRAINT document_types_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- event_registrations
+ALTER TABLE public.event_registrations
+  DROP CONSTRAINT event_registrations_volunteer_id_fkey,
+  ADD  CONSTRAINT event_registrations_volunteer_id_fkey
+    FOREIGN KEY (volunteer_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- events
+ALTER TABLE public.events
+  DROP CONSTRAINT events_created_by_fkey,
+  ADD  CONSTRAINT events_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- messages
+ALTER TABLE public.messages
+  DROP CONSTRAINT messages_sender_id_fkey,
+  ADD  CONSTRAINT messages_sender_id_fkey
+    FOREIGN KEY (sender_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- private_note_access_log
+ALTER TABLE public.private_note_access_log
+  DROP CONSTRAINT private_note_access_log_admin_user_id_fkey,
+  ADD  CONSTRAINT private_note_access_log_admin_user_id_fkey
+    FOREIGN KEY (admin_user_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+ALTER TABLE public.private_note_access_log
+  DROP CONSTRAINT private_note_access_log_volunteer_id_fkey,
+  ADD  CONSTRAINT private_note_access_log_volunteer_id_fkey
+    FOREIGN KEY (volunteer_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- shift_attachments
+ALTER TABLE public.shift_attachments
+  DROP CONSTRAINT shift_attachments_uploader_id_fkey,
+  ADD  CONSTRAINT shift_attachments_uploader_id_fkey
+    FOREIGN KEY (uploader_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- shift_bookings
+ALTER TABLE public.shift_bookings
+  DROP CONSTRAINT shift_bookings_confirmed_by_fkey,
+  ADD  CONSTRAINT shift_bookings_confirmed_by_fkey
+    FOREIGN KEY (confirmed_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+ALTER TABLE public.shift_bookings
+  DROP CONSTRAINT shift_bookings_coordinator_actioned_by_fkey,
+  ADD  CONSTRAINT shift_bookings_coordinator_actioned_by_fkey
+    FOREIGN KEY (coordinator_actioned_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+ALTER TABLE public.shift_bookings
+  DROP CONSTRAINT shift_bookings_volunteer_id_fkey,
+  ADD  CONSTRAINT shift_bookings_volunteer_id_fkey
+    FOREIGN KEY (volunteer_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- shift_invitations (only invited_by; volunteer_id stays CASCADE)
+ALTER TABLE public.shift_invitations
+  DROP CONSTRAINT shift_invitations_invited_by_fkey,
+  ADD  CONSTRAINT shift_invitations_invited_by_fkey
+    FOREIGN KEY (invited_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- shift_notes
+ALTER TABLE public.shift_notes
+  DROP CONSTRAINT shift_notes_author_id_fkey,
+  ADD  CONSTRAINT shift_notes_author_id_fkey
+    FOREIGN KEY (author_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- shift_recurrence_rules
+ALTER TABLE public.shift_recurrence_rules
+  DROP CONSTRAINT shift_recurrence_rules_created_by_fkey,
+  ADD  CONSTRAINT shift_recurrence_rules_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- shifts
+ALTER TABLE public.shifts
+  DROP CONSTRAINT shifts_created_by_fkey,
+  ADD  CONSTRAINT shifts_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- volunteer_documents (only reviewed_by; volunteer_id stays CASCADE)
+ALTER TABLE public.volunteer_documents
+  DROP CONSTRAINT volunteer_documents_reviewed_by_fkey,
+  ADD  CONSTRAINT volunteer_documents_reviewed_by_fkey
+    FOREIGN KEY (reviewed_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- volunteer_shift_reports
+ALTER TABLE public.volunteer_shift_reports
+  DROP CONSTRAINT volunteer_shift_reports_volunteer_id_fkey,
+  ADD  CONSTRAINT volunteer_shift_reports_volunteer_id_fkey
+    FOREIGN KEY (volunteer_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- ---------------------------------------------------------------------
+-- 3. Change 1 FK to ON DELETE CASCADE
+-- ---------------------------------------------------------------------
+-- confirmation_reminders: queue entries for a deleted user are moot
+ALTER TABLE public.confirmation_reminders
+  DROP CONSTRAINT confirmation_reminders_recipient_id_fkey,
+  ADD  CONSTRAINT confirmation_reminders_recipient_id_fkey
+    FOREIGN KEY (recipient_id) REFERENCES public.profiles(id) ON DELETE CASCADE;
+
+-- ---------------------------------------------------------------------
+-- 4. Extend cancel_bookings_on_profile_delete() to cover waitlisted
+-- ---------------------------------------------------------------------
+-- Previously only cancelled 'confirmed' bookings. 'waitlisted' offers
+-- would survive the delete and stay as orphaned waitlist entries. With
+-- shift_bookings.volunteer_id now SET NULL on cascade, those would
+-- become "waitlisted by nobody" — coherent enough structurally, but
+-- the right behavior is to cancel them first so waitlist notifications
+-- and the slot state are consistent.
+CREATE OR REPLACE FUNCTION public.cancel_bookings_on_profile_delete()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  IF old.role = 'volunteer' THEN
+    UPDATE public.shift_bookings
+    SET booking_status = 'cancelled',
+        cancelled_at = now(),
+        updated_at = now()
+    WHERE volunteer_id = old.id
+      AND booking_status IN ('confirmed', 'waitlisted');
+  END IF;
+  RETURN old;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Root cause

33 FKs reference \`public.profiles(id)\`. **24 of them had no explicit ON DELETE rule** (default \`NO ACTION\`), so every admin attempt to delete a user with any related data triggered a cascade failure. \`shift_bookings.volunteer_id\` was the top-of-stack error most recently observed (Apr 23, deleting \`anam@live.ca\`) — but the underlying problem is systemic, not one FK.

This migration fixes all 24 at once. The earlier \`recalculate_points\` fixes (PR #89 + #91) addressed the *function-level* side of the cascade chain; this PR addresses the *constraint-level* side.

## Audit table (33 FKs, final state)

### Unchanged — already CASCADE (9)

| Table.col | Reason |
|-----------|--------|
| \`conversation_participants.user_id\` | Can't participate once deleted |
| \`department_coordinators.coordinator_id\` | No longer a coordinator |
| \`department_restrictions.volunteer_id\` | Restriction on a deleted user is moot |
| \`mfa_backup_codes.user_id\` | User-owned secret material |
| \`notifications.user_id\` | User-owned feed |
| \`parental_consents.volunteer_id\` | PII — purge with user |
| \`shift_invitations.volunteer_id\` | Invitation moot if invitee gone |
| \`volunteer_documents.volunteer_id\` | PII (background-check) — purge with user |
| \`volunteer_private_notes.volunteer_id\` | PII about the volunteer — purge |

### Changed to CASCADE (1)

| Table.col | Reason |
|-----------|--------|
| \`confirmation_reminders.recipient_id\` | Queue entry for deleted user is undeliverable |

### Changed to SET NULL (23)

All preserve their row for reports/audit; user reference becomes NULL.

| Table.col | Column was | Purpose |
|-----------|:-:|---------|
| \`admin_action_log.admin_id\` | NOT NULL → nullable | Audit trail |
| \`admin_action_log.volunteer_id\` | NOT NULL → nullable | Audit trail |
| \`attendance_disputes.admin_decided_by\` | already nullable | Dispute history |
| \`attendance_disputes.coordinator_id\` | NOT NULL → nullable | Dispute history |
| \`attendance_disputes.volunteer_id\` | NOT NULL → nullable | Dispute history |
| \`conversations.created_by\` | NOT NULL → nullable | Preserve thread |
| \`department_restrictions.restricted_by\` | NOT NULL → nullable | Audit trail |
| \`document_types.created_by\` | NOT NULL → nullable | Shared config outlives creator |
| \`event_registrations.volunteer_id\` | NOT NULL → nullable | Preserve attendance count |
| \`events.created_by\` | NOT NULL → nullable | Event outlives creator |
| \`messages.sender_id\` | NOT NULL → nullable | Preserve conversation |
| \`private_note_access_log.admin_user_id\` | NOT NULL → nullable | Access audit |
| \`private_note_access_log.volunteer_id\` | NOT NULL → nullable | Access audit |
| \`shift_attachments.uploader_id\` | NOT NULL → nullable | Attachment still valid |
| \`shift_bookings.confirmed_by\` | already nullable | Audit of who confirmed |
| \`shift_bookings.coordinator_actioned_by\` | already nullable | Audit of who actioned |
| **\`shift_bookings.volunteer_id\`** | **NOT NULL → nullable** | **Booking history for reports — this is the FK that triggered the production bug** |
| \`shift_invitations.invited_by\` | NOT NULL → nullable | Invitation audit |
| \`shift_notes.author_id\` | NOT NULL → nullable | Preserve the note |
| \`shift_recurrence_rules.created_by\` | NOT NULL → nullable | Rule outlives creator |
| \`shifts.created_by\` | NOT NULL → nullable | Shift outlives creator |
| \`volunteer_documents.reviewed_by\` | already nullable | Reviewer audit |
| \`volunteer_shift_reports.volunteer_id\` | NOT NULL → nullable | Report history |

## Trigger change

\`cancel_bookings_on_profile_delete()\` previously only cancelled \`confirmed\` bookings. Extended to include \`waitlisted\` — otherwise a deleted user's waitlist offers would survive the cascade as orphaned rows. Now they're cancelled before the FK cascade sets their \`volunteer_id\` to NULL. End state: \`status = 'cancelled'\`, \`volunteer_id = NULL\`, \`cancelled_at = now()\`. Coherent.

## Frontend companion changes

Audit of every \`.profiles.\` access pattern across \`src/\` found **one** unguarded access (\`AdminDashboard.tsx\` line 292). It was already protected by a parent \`?.\` conditional on the previous line, so runtime-safe — but I tightened it to use \`?.\` for consistency and TS-strict forward compatibility.

Also changed both CSV export fallbacks (\`AdminDashboard.handleExportAll\` and \`CoordinatorDashboard.handleExportHours\`) from empty string to \`\"[deleted user]\"\` so historical rows from deleted volunteers are clearly flagged rather than silently blank.

**No \`!inner\` PostgREST joins exist** — all profile embeds are implicit LEFT JOIN, so null-profile rows stay in result sets instead of being dropped. No risk of rows disappearing from reports.

## Verification

- \`npx supabase db push --dry-run --linked\` — queues this migration + the still-pending \`20260423_000001\` from PR #91 (merged but not applied); both accepted ✅
- \`npx tsc --noEmit\` — clean ✅
- \`npm run lint\` — 0 errors (15 pre-existing warnings untouched) ✅
- \`npx vitest run\` — 103/103 ✅

## Known impact

- Deleting a user no longer fails on FK violations — the original production bug is fixed end-to-end
- Historical rows (bookings, messages, notes, shift/event metadata, audit logs, etc.) persist with \`user_id = NULL\` after user deletion
- CSV exports show \`\"[deleted user]\"\` for those rows
- UI renders that already used \`?.\` continue to work; the one tightened access was already runtime-safe
- No \`!inner\` joins, so no silent row drops from reports

## Deployment

**Must be applied to production immediately after merge:**

\`\`\`bash
npx supabase db push --linked
\`\`\`

This will apply both the still-pending \`20260423_000001_recalculate_points_guard_auth_users.sql\` (from PR #91) AND the new \`20260423000002_profile_fk_cascade_audit.sql\` in one push. Together they close out the user-deletion cascade bug cluster from the last two weeks.

## Do not merge without review

Per workflow — branch pushed, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)