### PR TITLE
fix: close strict-mode runtime bugs (#94, #96, #97, #98)

### DIFF
--- a/src/components/CoverageAlert.tsx
+++ b/src/components/CoverageAlert.tsx
@@ -193,14 +193,11 @@ export default function CoverageAlert() {
       user_id: volId,
       type: "shift_invitation",
       title: "You're invited to volunteer!",
-      body: `A shift on ${inviteShift.shift_date} (${inviteShift.start_time?.slice(0, 5)}–${inviteShift.end_time?.slice(0, 5)}) in ${inviteShift.department_name} needs coverage.`,
+      message: `A shift on ${inviteShift.shift_date} (${inviteShift.start_time?.slice(0, 5)}–${inviteShift.end_time?.slice(0, 5)}) in ${inviteShift.department_name} needs coverage.`,
       link: `/shifts?book=${inviteShift.id}`,
-      read: false,
+      is_read: false,
     }));
 
-    // @ts-expect-error TODO(#94): notifications insert uses wrong column names
-    // (body/read instead of message/is_read). Latent runtime failure — see
-    // https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/94
     const { error } = await supabase.from("notifications").insert(notifications);
 
     setSending(false);

--- a/src/components/ShiftSlotTimeline.tsx
+++ b/src/components/ShiftSlotTimeline.tsx
@@ -41,15 +41,11 @@ export function ShiftSlotTimeline({ shiftId, totalSlots }: Props) {
         .order("slot_start"),
       supabase
         .from("shift_bookings")
-        .select("id, time_slot_id, booking_status, volunteer_id, profiles(full_name)")
+        .select("id, time_slot_id, booking_status, volunteer_id, profiles!shift_bookings_volunteer_id_fkey(full_name)")
         .eq("shift_id", shiftId)
         .in("booking_status", ["confirmed", "waitlisted"]),
     ]).then(([{ data: slotData }, { data: bookingData }]) => {
       setSlots((slotData || []) as SlotInfo[]);
-      // @ts-expect-error TODO(#97): profiles join is ambiguous — shift_bookings
-      // has multiple FKs to profiles. Query returns SelectQueryError at runtime
-      // instead of profile rows. See
-      // https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/97
       setBookings((bookingData || []) as BookingInfo[]);
       setLoading(false);
     });

--- a/src/pages/AdminDepartments.tsx
+++ b/src/pages/AdminDepartments.tsx
@@ -147,13 +147,14 @@ export default function AdminDepartments() {
     };
 
     const { error } = editingId
-      // @ts-expect-error TODO(#95): payload has min_age: null but the generated
-      // Update type declares `min_age?: number | undefined`. Same root cause
-      // as the INSERT branch below (see issue).
+      // @ts-expect-error TODO(#119): payload has min_age: null but the schema is
+      // NOT NULL with a default; clearing the field via the dialog 500s. Fix
+      // tracked alongside the INSERT bug below — see issue.
       ? await supabase.from("departments").update(payload).eq("id", editingId)
-      // @ts-expect-error TODO(#95): insert payload missing required location_id.
-      // Department creation via this form is broken until fixed. See
-      // https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/95
+      // @ts-expect-error TODO(#119): insert payload missing required location_id.
+      // Department creation via this form has never worked — needs a location
+      // dropdown before it can succeed. See
+      // https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/119
       : await supabase.from("departments").insert(payload);
 
     setSaving(false);

--- a/src/pages/AdminDisputes.tsx
+++ b/src/pages/AdminDisputes.tsx
@@ -126,19 +126,15 @@ export default function AdminDisputes() {
           confirmation_status: "confirmed",
           final_hours: resolveTarget.volunteer_reported_hours || 0,
           hours_source: "dispute_admin_resolved",
-        }
+        } as const
       : {
           confirmation_status: "no_show",
           final_hours: 0,
           hours_source: "dispute_admin_resolved",
-        };
+        } as const;
 
     await supabase
       .from("shift_bookings")
-      // @ts-expect-error TODO(#98): bookingUpdate's confirmation_status widens to
-      // string — schema wants a restricted union. Today's code is correct; fix
-      // to prevent future regressions. See
-      // https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/98
       .update(bookingUpdate)
       .eq("id", resolveTarget.booking_id);
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger,
 } from "@/components/ui/dialog";
@@ -824,9 +825,6 @@ export default function Settings() {
                 print them, or store them in a secure location.
               </div>
               <div className="flex items-center gap-2">
-                {/* TODO(#96): Checkbox not imported; renders crash at runtime.
-                    See https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/96 */}
-                {/* @ts-expect-error see TODO(#96) above — Checkbox is not imported in this file */}
                 <Checkbox
                   id="backup-ack"
                   checked={backupCodesAcknowledged}


### PR DESCRIPTION
## Summary

Four runtime bugs surfaced by Sprint 2 Phase 1 strict-mode work, each previously hidden behind a \`@ts-expect-error\` directive. Each fix is the minimum change to remove the directive correctly — no \`any\` widening.

| Issue | File | Bug | Fix |
|---|---|---|---|
| [#94](https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/94) | \`src/components/CoverageAlert.tsx\` | Notifications insert used \`body\`/\`read\` (schema is \`message\`/\`is_read\`). Shift-invitation notifications failed silently at the DB. | Renamed the two property keys. |
| [#96](https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/96) | \`src/pages/Settings.tsx\` | \`Checkbox\` rendered but never imported — MFA backup-codes modal crashed on open. | Added the missing import. |
| [#97](https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/97) | \`src/components/ShiftSlotTimeline.tsx\` | \`profiles(full_name)\` join ambiguous — \`shift_bookings\` has multiple FKs to \`profiles\`. PostgREST returned \`SelectQueryError\` so volunteer names didn't render. | Disambiguated with \`profiles!shift_bookings_volunteer_id_fkey(full_name)\`. |
| [#98](https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/98) | \`src/pages/AdminDisputes.tsx\` | \`bookingUpdate.confirmation_status\` widened to \`string\` via the ternary. No runtime bug today, but the schema's enum guard wouldn't catch a future regression. | Added \`as const\` to both branches so TS preserves the literal types. |

## #95 reclassified

[#95](https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/95) was originally filed as a type error during Phase 1, but on inspection the underlying issue is **feature-level**: department creation has never worked through the AdminDepartments dialog because the form has no \`location_id\` field (schema requires NOT NULL). #95 was closed; refiled as [#119](https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/119) with the runtime-bug summary and the ~25-line minimum correct fix (new dropdown + locations fetch + interface extension).

The two \`@ts-expect-error\` directives in \`AdminDepartments.tsx\` are **left in place** in this PR but updated to reference #119 instead of #95. They'll be removed when #119 ships.

## Test plan

- [x] \`npx tsc --build\` — clean
- [x] \`npx eslint . --max-warnings=0\` — clean
- [x] \`npx vitest run\` — 103/103 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)