### PR TITLE
refactor: split VolunteerDashboard into focused sub-components (Phase 4)

### DIFF
--- a/src/components/volunteer/DashboardAlerts.tsx
+++ b/src/components/volunteer/DashboardAlerts.tsx
@@ -1,0 +1,75 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertTriangle, XCircle } from "lucide-react";
+
+/**
+ * Profile fields the alert panel reads. The `is_minor` and
+ * `has_active_consent` columns aren't picked up by the supabase type
+ * generator yet, so the page passes them via this extension type rather
+ * than scattering `(profile as any)` access points.
+ */
+export interface AlertProfile {
+  bg_check_status: string | null;
+  booking_privileges: boolean | null;
+  emergency_contact_name: string | null;
+  emergency_contact_phone: string | null;
+  is_minor?: boolean;
+  has_active_consent?: boolean;
+}
+
+interface Props {
+  profile: AlertProfile;
+}
+
+/**
+ * Stack of dashboard banners — privileges suspended, BG check failed/expired,
+ * missing emergency contact, minor parental-consent state. Renders nothing
+ * if all conditions are clear.
+ */
+export function DashboardAlerts({ profile }: Props) {
+  const privilegesSuspended = profile.booking_privileges === false;
+  const bgFailed = profile.bg_check_status === "failed" || profile.bg_check_status === "expired";
+  const missingEmergencyContact = !profile.emergency_contact_name || !profile.emergency_contact_phone;
+  return (
+    <>
+      {privilegesSuspended && (
+        <Alert variant="destructive">
+          <XCircle className="h-4 w-4" />
+          <AlertTitle>Booking Privileges Suspended</AlertTitle>
+          <AlertDescription>Your booking privileges have been suspended. Please contact your coordinator.</AlertDescription>
+        </Alert>
+      )}
+
+      {!privilegesSuspended && bgFailed && (
+        <Alert className="border-warning/50 bg-warning/10 text-warning-foreground">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Background Check {profile.bg_check_status === "expired" ? "Expired" : "Failed"}</AlertTitle>
+          <AlertDescription>Your background check status is {profile.bg_check_status}. You cannot book shifts that require a background check until this is resolved.</AlertDescription>
+        </Alert>
+      )}
+
+      {missingEmergencyContact && (
+        <Alert className="border-warning/50 bg-warning/10">
+          <AlertTriangle className="h-4 w-4 text-warning" />
+          <AlertTitle>Emergency Contact Required</AlertTitle>
+          <AlertDescription>
+            Please add an emergency contact before booking shifts. This is required for insurance and liability.{" "}
+            <a href="/settings" className="text-primary font-medium underline">Go to Settings →</a>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {profile.is_minor && (
+        <Alert className={profile.has_active_consent ? "border-primary/50 bg-primary/5" : "border-destructive/50 bg-destructive/10"}>
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>{profile.has_active_consent ? "Parental Consent on File" : "Parental Consent Required"}</AlertTitle>
+          <AlertDescription>
+            {profile.has_active_consent
+              ? "Your parent/guardian's consent is on file. You're cleared to book shifts."
+              : <>Volunteers under 18 need parental consent before booking shifts. <a href="/settings" className="text-primary font-medium underline">Go to Settings →</a></>
+            }
+          </AlertDescription>
+        </Alert>
+      )}
+    </>
+  );
+}

--- a/src/components/volunteer/DashboardStats.tsx
+++ b/src/components/volunteer/DashboardStats.tsx
@@ -1,0 +1,59 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Award } from "lucide-react";
+
+const MILESTONE_BADGES = [10, 25, 50, 100];
+
+interface Props {
+  upcomingCount: number;
+  hours: number;
+  consistencyScore: number | null;
+  points: number;
+}
+
+/**
+ * 4-card KPI grid: upcoming shifts, total hours (with milestone badges),
+ * consistency score, and points.
+ */
+export function DashboardStats({ upcomingCount, hours, consistencyScore, points }: Props) {
+  return (
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+      <Card>
+        <CardContent className="pt-6">
+          <div className="text-2xl font-bold">{upcomingCount}</div>
+          <p className="text-sm text-muted-foreground">Upcoming Shifts</p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="pt-6">
+          <div className="text-2xl font-bold">{hours}</div>
+          <p className="text-sm text-muted-foreground">Total Hours</p>
+          <div className="flex gap-1 mt-2">
+            {MILESTONE_BADGES.map((m) => (
+              <Badge key={m} variant={hours >= m ? "default" : "secondary"} className="text-[10px]">
+                {hours >= m && <Award className="h-2.5 w-2.5 mr-0.5" />}{m}h
+              </Badge>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="pt-6">
+          <div className="text-2xl font-bold">
+            {consistencyScore != null ? `${consistencyScore}%` : "—"}
+          </div>
+          <p className="text-sm text-muted-foreground">Consistency Score</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            {consistencyScore != null ? "Based on last 5 shifts" : "Complete 5 shifts to see your score"}
+          </p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="pt-6">
+          <div className="text-2xl font-bold">{points}</div>
+          <p className="text-sm text-muted-foreground">Points</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/volunteer/InvitationConflictDialog.tsx
+++ b/src/components/volunteer/InvitationConflictDialog.tsx
@@ -1,0 +1,77 @@
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { AlertTriangle } from "lucide-react";
+import type { ShiftInvitation } from "@/hooks/useShiftInvitations";
+
+export interface InvitationConflict {
+  invitation: ShiftInvitation;
+  conflictBookingId: string;
+  conflictShift: {
+    id: string;
+    title: string;
+    shift_date: string;
+    start_time: string | null;
+    end_time: string | null;
+    department_id: string;
+    departments: { name: string } | null;
+  };
+}
+
+interface Props {
+  conflict: InvitationConflict | null;
+  onOpenChange: (open: boolean) => void;
+  /** "Cancel my existing booking and accept the invited one." */
+  onAcceptWithCancel: (conflict: InvitationConflict) => void;
+  /** "Keep my existing booking and decline the invitation." */
+  onDeclineForConflict: (conflict: InvitationConflict) => void;
+}
+
+/**
+ * Modal that surfaces when accepting an invitation conflicts with an
+ * existing confirmed booking. Caller drives both branches.
+ */
+export function InvitationConflictDialog({ conflict, onOpenChange, onAcceptWithCancel, onDeclineForConflict }: Props) {
+  return (
+    <AlertDialog open={!!conflict} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" /> Scheduling Conflict
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3">
+              <p>Accepting this shift will conflict with your existing booking:</p>
+              {conflict?.conflictShift && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
+                  <strong>{conflict.conflictShift.title}</strong> on{" "}
+                  {conflict.conflictShift.shift_date} from{" "}
+                  {conflict.conflictShift.start_time?.slice(0, 5)} to{" "}
+                  {conflict.conflictShift.end_time?.slice(0, 5)}
+                </div>
+              )}
+              <p>Would you like to cancel your existing booking and accept this invitation?</p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-col sm:flex-row gap-2">
+          <AlertDialogCancel
+            onClick={() => {
+              if (conflict) onDeclineForConflict(conflict);
+            }}
+          >
+            Keep My Existing Booking &amp; Decline
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => {
+              if (conflict) onAcceptWithCancel(conflict);
+            }}
+          >
+            Cancel Existing &amp; Accept Invitation
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/volunteer/InvitationsList.tsx
+++ b/src/components/volunteer/InvitationsList.tsx
@@ -1,0 +1,81 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Calendar, Clock, MapPin, Mail, CheckCircle, Loader2 } from "lucide-react";
+import { format } from "date-fns";
+import type { ShiftInvitation } from "@/hooks/useShiftInvitations";
+
+interface Props {
+  invitations: ShiftInvitation[];
+  /** id of an invitation whose accept/decline is mid-flight; disables both buttons on that row. */
+  actioningId: string | null;
+  onAccept: (inv: ShiftInvitation) => void;
+  onDecline: (inv: ShiftInvitation) => void;
+}
+
+/**
+ * "Shift Invitations" card. Shows per-row accept/decline; the parent owns the
+ * conflict-modal flow that may open mid-accept.
+ */
+export function InvitationsList({ invitations, actioningId, onAccept, onDecline }: Props) {
+  if (invitations.length === 0) return null;
+  return (
+    <Card className="border-primary/30">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Mail className="h-4 w-4 text-primary" /> Shift Invitations
+        </CardTitle>
+        <CardDescription className="text-xs">
+          An admin has invited you to the following shift{invitations.length !== 1 ? "s" : ""}. Respond before the shift starts.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {invitations.map((inv) => {
+          const s = inv.shifts;
+          if (!s) return null;
+          const isActioning = actioningId === inv.id;
+          return (
+            <div key={inv.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 py-3 px-3 rounded-md bg-primary/5 border border-primary/10">
+              <div className="space-y-1 min-w-0">
+                <p className="font-medium text-sm">{s.title}</p>
+                <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <Calendar className="h-3 w-3" />
+                    {format(new Date(s.shift_date + "T00:00:00"), "MMM d, yyyy")}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {s.start_time?.slice(0, 5)} – {s.end_time?.slice(0, 5)}
+                  </span>
+                  {s.departments?.name && (
+                    <span className="flex items-center gap-1">
+                      <MapPin className="h-3 w-3" />
+                      {s.departments.name}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="flex gap-2 shrink-0">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isActioning}
+                  onClick={() => onDecline(inv)}
+                >
+                  Decline
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={isActioning}
+                  onClick={() => onAccept(inv)}
+                >
+                  {isActioning ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : <CheckCircle className="h-4 w-4 mr-1" />}
+                  Accept
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/volunteer/PassiveWaitlistList.tsx
+++ b/src/components/volunteer/PassiveWaitlistList.tsx
@@ -1,0 +1,50 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Clock } from "lucide-react";
+import { format } from "date-fns";
+import type { VolunteerBooking } from "@/hooks/useVolunteerBookings";
+
+interface Props {
+  items: VolunteerBooking[];
+  onLeave: (bookingId: string) => void;
+}
+
+/**
+ * "Your Waitlist" card listing shifts the volunteer is waitlisted on
+ * without an active offer. Offers a "Leave Waitlist" button per row.
+ */
+export function PassiveWaitlistList({ items, onLeave }: Props) {
+  if (items.length === 0) return null;
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Clock className="h-4 w-4 text-muted-foreground" /> Your Waitlist
+        </CardTitle>
+        <CardDescription className="text-xs">
+          You'll be notified if a spot opens up on any of these shifts.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {items.map((w) => {
+          const s = w.shifts;
+          return (
+            <div key={w.id} className="flex items-center justify-between gap-3 py-2 px-3 rounded-md bg-muted/50">
+              <div className="min-w-0">
+                <p className="font-medium text-sm truncate">{s?.title}</p>
+                <p className="text-xs text-muted-foreground">
+                  {s && format(new Date(s.shift_date + "T00:00:00"), "MMM d, yyyy")}
+                  {s?.departments?.name ? ` · ${s.departments.name}` : ""}
+                  {s && ` · ${s.booked_slots}/${s.total_slots} filled`}
+                </p>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => onLeave(w.id)}>
+                Leave Waitlist
+              </Button>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/volunteer/PendingConfirmationsBanner.tsx
+++ b/src/components/volunteer/PendingConfirmationsBanner.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent } from "@/components/ui/card";
+import type { PendingConfirmation } from "@/hooks/useVolunteerBookings";
+
+interface Props {
+  pendingConfirmations: PendingConfirmation[];
+}
+
+/**
+ * Banner shown above the upcoming-shifts list when the volunteer has
+ * one or more shifts awaiting self-confirmation. Deeplinks to the first
+ * one's confirmation page.
+ */
+export function PendingConfirmationsBanner({ pendingConfirmations }: Props) {
+  if (pendingConfirmations.length === 0) return null;
+  const count = pendingConfirmations.length;
+  const firstBookingId = pendingConfirmations[0]?.booking_id;
+  return (
+    <Card className="border-primary/30 bg-primary/5">
+      <CardContent className="pt-4 pb-4">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <p className="text-sm font-medium">
+            You have <span className="font-bold text-primary">{count}</span> shift{count !== 1 ? "s" : ""} awaiting your confirmation.
+          </p>
+          <a href={`/my-shifts/confirm/${firstBookingId}`} className="text-sm font-medium text-primary hover:underline">
+            Confirm now →
+          </a>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/volunteer/UpcomingShiftCard.tsx
+++ b/src/components/volunteer/UpcomingShiftCard.tsx
@@ -1,0 +1,119 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Calendar, Clock, MapPin, Shield } from "lucide-react";
+import { format } from "date-fns";
+import { downloadICS, googleCalendarUrl, timeLabel } from "@/lib/calendar-utils";
+import { getEffectiveTimes, isCheckInOpen } from "@/lib/shift-time";
+import { BookedSlotsDisplay } from "@/components/BookedSlotsDisplay";
+import { InviteFriendModal } from "@/components/InviteFriendModal";
+import type { VolunteerBooking } from "@/hooks/useVolunteerBookings";
+
+/**
+ * Shape of a shift as needed by the parent's check-in / cancel handlers.
+ * The full `shifts` object on a VolunteerBooking has more fields than this
+ * type, but the union of what the two handlers read is captured here so
+ * the component is self-contained.
+ */
+export type ShiftActionTarget = {
+  shift_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  time_type: string | null;
+  title: string;
+  department_id: string;
+};
+
+interface Props {
+  /** All bookings for this single shift (one if no time slots, multiple for slot bookings). */
+  bookings: VolunteerBooking[];
+  today: string;
+  userId: string | undefined;
+  onCheckIn: (bookingId: string, shift: ShiftActionTarget) => void;
+  onCancel: (bookingId: string, shift: ShiftActionTarget) => void;
+}
+
+/**
+ * One upcoming-shift card. Handles both single bookings and the
+ * grouped per-slot case (where the volunteer booked multiple slots
+ * within the same shift). The slot-by-slot cancel sub-list and the
+ * "Cancel All Slots" confirm flow live here.
+ */
+export function UpcomingShiftCard({ bookings, today, userId, onCheckIn, onCancel }: Props) {
+  const firstBooking = bookings[0];
+  const s = firstBooking.shifts!;
+  const isToday = s.shift_date === today;
+  const { start: shiftStart } = getEffectiveTimes(s);
+  const shiftStartMs = shiftStart.getTime();
+  const nowMs = Date.now();
+  const checkInOpen = isToday && isCheckInOpen(s, new Date(nowMs));
+  const anyCheckedIn = bookings.some((b) => !!b.checked_in_at);
+
+  return (
+    <Card>
+      <CardContent className="pt-4 pb-4">
+        <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3">
+          <div className="space-y-1 flex-1">
+            <div className="font-medium">{s.title}</div>
+            <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+              <span className="flex items-center gap-1"><Calendar className="h-3 w-3" />{format(new Date(s.shift_date + "T00:00:00"), "MMM d, yyyy")}</span>
+              <span className="flex items-center gap-1"><Clock className="h-3 w-3" />{timeLabel(s)}</span>
+              <span className="flex items-center gap-1"><MapPin className="h-3 w-3" />{s.departments?.name}</span>
+            </div>
+            <div className="flex gap-2">
+              {s.requires_bg_check && <Badge variant="outline" className="text-xs"><Shield className="h-3 w-3 mr-1" />BG Check</Badge>}
+            </div>
+            {/* Per-slot bookings */}
+            <BookedSlotsDisplay shiftId={s.id} volunteerId={userId} />
+
+            {/* Individual slot actions */}
+            {bookings.length > 1 && (
+              <div className="space-y-1 mt-2 pl-2 border-l-2 border-muted">
+                {bookings.map((b) => (
+                  <div key={b.id} className="flex items-center justify-between gap-2 text-xs">
+                    <span className="text-muted-foreground">
+                      {b.time_slot_id ? "Slot booking" : "Full shift"}
+                    </span>
+                    <Button variant="ghost" size="sm" className="h-6 text-xs text-destructive hover:text-destructive" onClick={() => onCancel(b.id, s)}>
+                      Cancel Slot
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col gap-2 sm:items-end">
+            {checkInOpen && !anyCheckedIn && (
+              <Button size="sm" onClick={() => onCheckIn(firstBooking.id, s)}>Check In</Button>
+            )}
+            {isToday && !anyCheckedIn && !checkInOpen && nowMs < shiftStartMs && (
+              <Badge variant="outline" className="text-xs">Check-in opens 30 min before start</Badge>
+            )}
+            {anyCheckedIn && <Badge className="text-xs bg-success text-success-foreground">Checked In</Badge>}
+            <div className="flex gap-1 flex-wrap">
+              <Button variant="ghost" size="sm" className="text-xs h-7" onClick={() => downloadICS(s)} aria-label="Download iCal">
+                📅 iCal
+              </Button>
+              <Button variant="ghost" size="sm" className="text-xs h-7" asChild>
+                <a href={googleCalendarUrl(s)} target="_blank" rel="noopener noreferrer" aria-label="Add to Google Calendar">
+                  📆 Google
+                </a>
+              </Button>
+              {!s.requires_bg_check && (
+                <InviteFriendModal shiftId={s.id} shiftTitle={s.title} shiftDate={s.shift_date} shiftTime={timeLabel(s)} />
+              )}
+            </div>
+            {bookings.length === 1 ? (
+              <Button variant="outline" size="sm" onClick={() => onCancel(firstBooking.id, s)}>Cancel</Button>
+            ) : (
+              <Button variant="outline" size="sm" onClick={() => {
+                const ok = window.confirm(`Cancel all ${bookings.length} slot bookings for ${s.title}?`);
+                if (ok) bookings.forEach((b) => onCancel(b.id, s));
+              }}>Cancel All Slots</Button>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/volunteer/UpcomingShiftsSection.tsx
+++ b/src/components/volunteer/UpcomingShiftsSection.tsx
@@ -1,0 +1,67 @@
+import { Card, CardContent } from "@/components/ui/card";
+import type { VolunteerBooking } from "@/hooks/useVolunteerBookings";
+import { UpcomingShiftCard, type ShiftActionTarget } from "./UpcomingShiftCard";
+
+interface Props {
+  loading: boolean;
+  privilegesSuspended: boolean;
+  eligibleBookings: VolunteerBooking[];
+  today: string;
+  userId: string | undefined;
+  onCheckIn: (bookingId: string, shift: ShiftActionTarget) => void;
+  onCancel: (bookingId: string, shift: ShiftActionTarget) => void;
+}
+
+/**
+ * "Upcoming Shifts" section: header + loading/empty/grouped-list states.
+ * Groups bookings by shift_id (one card per shift; multiple bookings per
+ * card when the volunteer booked individual slots).
+ */
+export function UpcomingShiftsSection({
+  loading,
+  privilegesSuspended,
+  eligibleBookings,
+  today,
+  userId,
+  onCheckIn,
+  onCancel,
+}: Props) {
+  return (
+    <div>
+      <h3 className="text-lg font-semibold mb-3">Upcoming Shifts</h3>
+      {loading ? (
+        <p className="text-muted-foreground">Loading...</p>
+      ) : eligibleBookings.length === 0 ? (
+        <Card>
+          <CardContent className="pt-6 text-center text-muted-foreground">
+            <p>{privilegesSuspended ? "Your booking privileges are suspended." : "No upcoming shifts."} <a href="/shifts" className="text-primary underline">Browse available shifts</a></p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-3">
+          {groupByShift(eligibleBookings).map((bookings) => (
+            <UpcomingShiftCard
+              key={bookings[0].shifts!.id}
+              bookings={bookings}
+              today={today}
+              userId={userId}
+              onCheckIn={onCheckIn}
+              onCancel={onCancel}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function groupByShift(bookings: VolunteerBooking[]): VolunteerBooking[][] {
+  const groupedMap = new Map<string, VolunteerBooking[]>();
+  for (const b of bookings) {
+    const sid = b.shifts?.id;
+    if (!sid) continue;
+    if (!groupedMap.has(sid)) groupedMap.set(sid, []);
+    groupedMap.get(sid)!.push(b);
+  }
+  return Array.from(groupedMap.values());
+}

--- a/src/components/volunteer/WaitlistOfferCard.tsx
+++ b/src/components/volunteer/WaitlistOfferCard.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, CheckCircle } from "lucide-react";
+import { format } from "date-fns";
+import type { VolunteerBooking } from "@/hooks/useVolunteerBookings";
+
+interface Props {
+  offer: VolunteerBooking;
+  onAccept: (bookingId: string) => void;
+  onDecline: (bookingId: string) => void;
+}
+
+/**
+ * One waitlist-offer card with the expiry countdown and accept/decline actions.
+ * Caller maps over `waitlistOffers` and renders one of these per offer.
+ */
+export function WaitlistOfferCard({ offer, onAccept, onDecline }: Props) {
+  const s = offer.shifts;
+  const expiresAt = new Date(offer.waitlist_offer_expires_at!);
+  const minutesLeft = Math.max(0, Math.round((expiresAt.getTime() - Date.now()) / 60000));
+  return (
+    <Card className="border-amber-500/50 bg-amber-500/10">
+      <CardContent className="pt-4 pb-4 space-y-3">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
+          <div className="flex-1 space-y-1">
+            <p className="font-semibold">Waitlist spot opened: {s?.title}</p>
+            <p className="text-sm text-muted-foreground">
+              {s && format(new Date(s.shift_date + "T00:00:00"), "MMMM d, yyyy")}
+              {s?.departments?.name ? ` · ${s.departments.name}` : ""}
+            </p>
+            <p className="text-xs text-amber-700">
+              You have {minutesLeft >= 60
+                ? `${Math.floor(minutesLeft / 60)}h ${minutesLeft % 60}m`
+                : `${minutesLeft} minute${minutesLeft !== 1 ? "s" : ""}`} to respond.
+              The offer forfeits at {format(expiresAt, "h:mm a")}.
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2 justify-end">
+          <Button variant="outline" size="sm" onClick={() => onDecline(offer.id)}>
+            Decline
+          </Button>
+          <Button size="sm" onClick={() => onAccept(offer.id)}>
+            <CheckCircle className="h-4 w-4 mr-2" /> Accept Shift
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useShiftInvitations.ts
+++ b/src/hooks/useShiftInvitations.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState, useCallback } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import type { User } from "@supabase/supabase-js";
+
+/**
+ * Shape of a shift_invitations row joined with its parent shift, as
+ * returned by the dashboard's invitation select. The `as any` boundary
+ * cast in fetchInvitations matches the documented pattern in
+ * eslint.config.js — PostgREST embedded selects don't survive the
+ * generated Database types cleanly.
+ */
+export interface ShiftInvitation {
+  id: string;
+  invited_by: string;
+  expires_at: string;
+  status: string;
+  shifts: {
+    id: string;
+    title: string;
+    shift_date: string;
+    start_time: string | null;
+    end_time: string | null;
+    total_slots: number;
+    booked_slots: number;
+    department_id: string;
+    departments: { name: string } | null;
+  } | null;
+}
+
+interface UseShiftInvitationsResult {
+  invitations: ShiftInvitation[];
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Loads pending shift invitations for the given user. Filters out invitations
+ * past `expires_at` client-side until the cron catches them.
+ */
+export function useShiftInvitations(user: User | null): UseShiftInvitationsResult {
+  const [invitations, setInvitations] = useState<ShiftInvitation[]>([]);
+
+  const refresh = useCallback(async () => {
+    if (!user) return;
+    const { data } = await supabase
+      .from("shift_invitations")
+      .select("*, shifts(id, title, shift_date, start_time, end_time, total_slots, booked_slots, department_id, departments(name))")
+      .eq("volunteer_id", user.id)
+      .eq("status", "pending")
+      .order("created_at", { ascending: false });
+    const now = new Date();
+    const fresh = ((data as any[]) || []).filter(
+      (inv: { expires_at: string }) => new Date(inv.expires_at) > now
+    ) as ShiftInvitation[];
+    setInvitations(fresh);
+  }, [user]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { invitations, refresh };
+}

--- a/src/hooks/useVolunteerBookings.ts
+++ b/src/hooks/useVolunteerBookings.ts
@@ -1,0 +1,168 @@
+import { useEffect, useState, useCallback } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { isUpcoming } from "@/lib/shift-lifecycle";
+import type { User } from "@supabase/supabase-js";
+
+/**
+ * The shape of a single shift_bookings row joined with its parent shift +
+ * department, as returned by the dashboard's combined PostgREST select.
+ *
+ * The supabase generated `Database` types don't model embedded selects
+ * cleanly, so the hook applies a single `as any` cast at the assignment
+ * boundary (see comment in fetchBookings). New code in this module is
+ * fully typed against this interface.
+ */
+export interface VolunteerBooking {
+  id: string;
+  booking_status: string;
+  confirmation_status: string;
+  checked_in_at: string | null;
+  waitlist_offer_expires_at: string | null;
+  created_at: string;
+  time_slot_id?: string | null;
+  shifts: {
+    id: string;
+    title: string;
+    shift_date: string;
+    time_type: string;
+    start_time: string | null;
+    end_time: string | null;
+    total_slots: number;
+    booked_slots: number;
+    requires_bg_check: boolean;
+    status: string;
+    allows_group: boolean;
+    department_id: string;
+    departments: { name: string; location_id: string; requires_bg_check?: boolean } | null;
+  } | null;
+}
+
+export interface PendingConfirmation {
+  id: string;
+  booking_id: string;
+  self_confirm_status: string;
+  shift_bookings: {
+    id: string;
+    shifts: { title: string; shift_date: string; departments: { name: string } | null } | null;
+  } | null;
+}
+
+interface UseVolunteerBookingsResult {
+  upcoming: VolunteerBooking[];
+  pendingConfirmations: PendingConfirmation[];
+  waitlistOffers: VolunteerBooking[];
+  waitlistPassive: VolunteerBooking[];
+  loading: boolean;
+  refresh: () => Promise<void>;
+  /** Drop a booking from `upcoming` without refetching (post-cancel). */
+  optimisticRemoveUpcoming: (bookingId: string) => void;
+  /** Patch one booking in `upcoming` (post-checkin). */
+  optimisticUpdateUpcoming: (bookingId: string, patch: Partial<VolunteerBooking>) => void;
+}
+
+/**
+ * Loads and partitions the bookings shown on VolunteerDashboard:
+ *   - upcoming: confirmed + future + not-cancelled (via isUpcoming())
+ *   - waitlistOffers: waitlisted with an active offer expiry
+ *   - waitlistPassive: waitlisted without an active offer, future date
+ *   - pendingConfirmations: separate volunteer_shift_reports query
+ *
+ * `today` is taken as a parameter (not computed inside) so callers can
+ * use the same LOCAL-date string used elsewhere — UTC drift in the evening
+ * Central time would otherwise drop today's shifts from the upcoming list.
+ */
+export function useVolunteerBookings(user: User | null, today: string): UseVolunteerBookingsResult {
+  const [upcoming, setUpcoming] = useState<VolunteerBooking[]>([]);
+  const [pendingConfirmations, setPendingConfirmations] = useState<PendingConfirmation[]>([]);
+  const [waitlistOffers, setWaitlistOffers] = useState<VolunteerBooking[]>([]);
+  const [waitlistPassive, setWaitlistPassive] = useState<VolunteerBooking[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    if (!user) return;
+    try {
+      // Avoiding PostgREST .or() with ISO timestamps because it silently fails
+      // on some special-character combinations. Single combined query, split
+      // client-side.
+      const [{ data, error: bookingsErr }, { data: pendingData }] = await Promise.all([
+        supabase
+          .from("shift_bookings")
+          .select("id, booking_status, confirmation_status, checked_in_at, waitlist_offer_expires_at, created_at, shifts(id, title, shift_date, time_type, start_time, end_time, total_slots, booked_slots, requires_bg_check, status, allows_group, department_id, departments(name, location_id))")
+          .eq("volunteer_id", user.id)
+          .in("booking_status", ["confirmed", "waitlisted"])
+          .order("created_at", { ascending: false }),
+        supabase
+          .from("volunteer_shift_reports")
+          .select("id, booking_id, self_confirm_status, shift_bookings(id, shifts(title, shift_date, departments(name)))")
+          .eq("volunteer_id", user.id)
+          .eq("self_confirm_status", "pending")
+          .is("submitted_at", null),
+      ]);
+      if (bookingsErr) {
+        console.error("useVolunteerBookings: fetch error:", bookingsErr);
+      }
+
+      // Single boundary cast — PostgREST embedded-select types vs generated
+      // Database types diverge here. Same pattern documented in
+      // eslint.config.js for (supabase as any).rpc().
+      const all: VolunteerBooking[] = ((data as any[]) || []) as VolunteerBooking[];
+      const nowMs = Date.now();
+
+      const upcomingNew = all.filter(
+        (b) =>
+          b.booking_status === "confirmed" &&
+          b.shifts &&
+          isUpcoming(b.shifts) &&
+          b.shifts.status !== "cancelled"
+      );
+
+      const offers = all.filter(
+        (b) =>
+          b.booking_status === "waitlisted" &&
+          b.waitlist_offer_expires_at &&
+          new Date(b.waitlist_offer_expires_at).getTime() > nowMs
+      );
+
+      const passive = all.filter(
+        (b) =>
+          b.booking_status === "waitlisted" &&
+          (!b.waitlist_offer_expires_at ||
+            new Date(b.waitlist_offer_expires_at).getTime() <= nowMs) &&
+          b.shifts &&
+          b.shifts.shift_date >= today
+      );
+
+      setUpcoming(upcomingNew);
+      setWaitlistOffers(offers);
+      setWaitlistPassive(passive);
+      setPendingConfirmations(((pendingData as any[]) || []) as PendingConfirmation[]);
+    } catch (e) {
+      console.error("useVolunteerBookings: fatal error:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, [user, today]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const optimisticRemoveUpcoming = useCallback((bookingId: string) => {
+    setUpcoming((prev) => prev.filter((b) => b.id !== bookingId));
+  }, []);
+
+  const optimisticUpdateUpcoming = useCallback((bookingId: string, patch: Partial<VolunteerBooking>) => {
+    setUpcoming((prev) => prev.map((b) => (b.id === bookingId ? { ...b, ...patch } : b)));
+  }, []);
+
+  return {
+    upcoming,
+    pendingConfirmations,
+    waitlistOffers,
+    waitlistPassive,
+    loading,
+    refresh,
+    optimisticRemoveUpcoming,
+    optimisticUpdateUpcoming,
+  };
+}

--- a/src/lib/booking-actions.ts
+++ b/src/lib/booking-actions.ts
@@ -1,0 +1,338 @@
+import { format } from "date-fns";
+import { supabase } from "@/integrations/supabase/client";
+import type { ShiftInvitation } from "@/hooks/useShiftInvitations";
+
+/**
+ * Service-layer functions for the dashboard booking + invitation flows.
+ *
+ * Conventions:
+ *  - These functions own the supabase calls + notification fan-out, but do
+ *    NOT call into React (no toasts, no setState). Callers translate the
+ *    return values into UI feedback.
+ *  - Each function returns a discriminated-union or `{ error }`-shaped result
+ *    so callers can branch deterministically without inspecting supabase
+ *    error shapes themselves.
+ */
+
+// Shape of one of "my" confirmed bookings as returned by the conflict probe.
+interface ConflictCandidateShift {
+  id: string;
+  title: string;
+  shift_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  department_id: string;
+  departments: { name: string } | null;
+}
+
+interface ConflictCandidate {
+  id: string;
+  shifts: ConflictCandidateShift | null;
+}
+
+export type InvitationAcceptPlan =
+  | { kind: "fully_booked" }
+  | { kind: "conflict"; conflictBookingId: string; conflictShift: ConflictCandidateShift }
+  | { kind: "ready" };
+
+/**
+ * Pre-flight check before completing an invitation accept.
+ *
+ *   - "fully_booked": the shift filled while the invitation sat in the inbox.
+ *     Caller should auto-decline the invitation and surface a friendly toast.
+ *   - "conflict": the volunteer already has a confirmed booking that overlaps
+ *     the invited shift. Caller should open a conflict-resolution modal.
+ *   - "ready": no blockers; proceed to acceptInvitation().
+ */
+export async function planInvitationAcceptance(
+  invitation: ShiftInvitation,
+  userId: string
+): Promise<InvitationAcceptPlan> {
+  const shift = invitation.shifts;
+  if (!shift) return { kind: "ready" };
+
+  const { data: freshShift } = await supabase
+    .from("shifts")
+    .select("booked_slots, total_slots")
+    .eq("id", shift.id)
+    .single();
+
+  if (freshShift && freshShift.booked_slots >= freshShift.total_slots) {
+    // Mark invitation as declined since they can't accept.
+    await supabase
+      .from("shift_invitations")
+      .update({ status: "declined" })
+      .eq("id", invitation.id);
+    return { kind: "fully_booked" };
+  }
+
+  // Look for an existing confirmed booking on the same date that overlaps.
+  const { data: myBookings } = await supabase
+    .from("shift_bookings")
+    .select("id, shifts(id, title, shift_date, start_time, end_time, department_id, departments(name))")
+    .eq("volunteer_id", userId)
+    .eq("booking_status", "confirmed");
+
+  const candidates = ((myBookings as any[]) || []) as ConflictCandidate[];
+  for (const b of candidates) {
+    const s = b.shifts;
+    if (!s || s.shift_date !== shift.shift_date) continue;
+    // String comparison works because times are HH:MM:SS lexically sortable.
+    if (
+      s.start_time && s.end_time && shift.start_time && shift.end_time &&
+      s.start_time < shift.end_time && s.end_time > shift.start_time
+    ) {
+      return { kind: "conflict", conflictBookingId: b.id, conflictShift: s };
+    }
+  }
+
+  return { kind: "ready" };
+}
+
+interface AcceptInvitationParams {
+  invitation: ShiftInvitation;
+  userId: string;
+  profileFullName: string | null;
+  /** When the volunteer chose "cancel existing & accept", these identify the booking to cancel. */
+  cancelBookingId?: string;
+  cancelledShift?: ConflictCandidateShift;
+}
+
+interface AcceptInvitationResult {
+  ok: boolean;
+  /** Set when ok=false to give the caller a hint for the toast message. */
+  error?: string;
+}
+
+/**
+ * Complete an invitation acceptance: optionally cancel a conflicting booking,
+ * book all time slots of the invited shift (or the shift itself if no slots),
+ * flip the invitation to accepted, and notify admin + coordinators.
+ */
+export async function acceptInvitation(
+  params: AcceptInvitationParams
+): Promise<AcceptInvitationResult> {
+  const { invitation, userId, profileFullName, cancelBookingId, cancelledShift } = params;
+  const shift = invitation.shifts;
+  if (!shift) return { ok: false, error: "Invitation has no shift" };
+
+  // 1. Cancel conflicting booking if requested.
+  if (cancelBookingId) {
+    await supabase
+      .from("shift_bookings")
+      .update({ booking_status: "cancelled", cancelled_at: new Date().toISOString() })
+      .eq("id", cancelBookingId);
+
+    if (cancelledShift) {
+      const { data: cancelCoords } = await supabase
+        .from("department_coordinators")
+        .select("coordinator_id")
+        .eq("department_id", cancelledShift.department_id);
+
+      const cancelNotifications = [
+        {
+          user_id: userId,
+          type: "booking_cancelled",
+          title: `Booking cancelled — ${cancelledShift.title}`,
+          message: `Your booking for "${cancelledShift.title}" on ${cancelledShift.shift_date} was cancelled to accept an invitation for "${shift.title}".`,
+          link: "/dashboard",
+        },
+        ...((cancelCoords as { coordinator_id: string }[] | null) || []).map((c) => ({
+          user_id: c.coordinator_id,
+          type: "booking_cancelled",
+          title: `Volunteer cancelled — ${cancelledShift.title}`,
+          message: `${profileFullName} cancelled their booking for "${cancelledShift.title}" on ${cancelledShift.shift_date} to accept an admin invitation for "${shift.title}".`,
+          link: "/coordinator",
+        })),
+      ];
+      await supabase.from("notifications").insert(cancelNotifications as never);
+    }
+  }
+
+  // 2. Book the invited shift — per slot if slots exist, else the shift itself.
+  const { data: slots } = await supabase
+    .from("shift_time_slots")
+    .select("id, total_slots, booked_slots")
+    .eq("shift_id", shift.id)
+    .order("slot_start", { ascending: true });
+
+  let bookingError = false;
+  if (slots && slots.length > 0) {
+    for (const slot of slots) {
+      const isFull = slot.booked_slots >= slot.total_slots;
+      const { error } = await supabase.from("shift_bookings").insert({
+        shift_id: shift.id,
+        volunteer_id: userId,
+        booking_status: isFull ? "waitlisted" : "confirmed",
+        time_slot_id: slot.id,
+      });
+      if (error) { bookingError = true; break; }
+    }
+  } else {
+    const { error } = await supabase.from("shift_bookings").insert({
+      shift_id: shift.id,
+      volunteer_id: userId,
+      booking_status: "confirmed",
+    });
+    if (error) bookingError = true;
+  }
+
+  if (bookingError) {
+    return { ok: false, error: "An error occurred while booking. Please try again." };
+  }
+
+  // 3. Flip invitation status.
+  await supabase
+    .from("shift_invitations")
+    .update({ status: "accepted" })
+    .eq("id", invitation.id);
+
+  // 4. Notify admin (the inviter) + non-inviter coordinators.
+  interface NotifRow {
+    user_id: string;
+    type: string;
+    title: string;
+    message: string;
+    data?: Record<string, unknown>;
+  }
+  const notifs: NotifRow[] = [
+    {
+      user_id: invitation.invited_by,
+      type: "shift_invitation",
+      title: `Invitation accepted — ${shift.title}`,
+      message: `${profileFullName} accepted the invitation to "${shift.title}" on ${shift.shift_date}.`,
+      data: { shift_id: shift.id, shift_title: shift.title, shift_date: shift.shift_date },
+    },
+  ];
+  const { data: coords } = await supabase
+    .from("department_coordinators")
+    .select("coordinator_id")
+    .eq("department_id", shift.department_id);
+  for (const c of ((coords as { coordinator_id: string }[] | null) || [])) {
+    if (c.coordinator_id !== invitation.invited_by) {
+      notifs.push({
+        user_id: c.coordinator_id,
+        type: "shift_invitation",
+        title: `Volunteer accepted invitation — ${shift.title}`,
+        message: `${profileFullName} accepted an invitation to "${shift.title}" on ${shift.shift_date}.`,
+        data: { shift_id: shift.id, shift_title: shift.title, shift_date: shift.shift_date },
+      });
+    }
+  }
+  await supabase.from("notifications").insert(notifs as never);
+
+  return { ok: true };
+}
+
+interface DeclineInvitationParams {
+  invitation: ShiftInvitation;
+  profileFullName: string | null;
+  reason?: string;
+}
+
+/** Mark invitation declined and notify the inviter. */
+export async function declineInvitation(params: DeclineInvitationParams): Promise<void> {
+  const { invitation, profileFullName, reason } = params;
+  await supabase
+    .from("shift_invitations")
+    .update({ status: "declined" })
+    .eq("id", invitation.id);
+
+  const shift = invitation.shifts;
+  await supabase.from("notifications").insert({
+    user_id: invitation.invited_by,
+    type: "shift_invitation",
+    title: `Invitation declined — ${shift?.title || "shift"}`,
+    message: `${profileFullName} declined the invitation to "${shift?.title}" on ${shift?.shift_date}.${reason ? ` Reason: ${reason}` : ""}`,
+    data: { shift_id: shift?.id, shift_title: shift?.title, shift_date: shift?.shift_date },
+  } as never);
+}
+
+// ---- Cancel booking ----
+
+export type CancelPrecheck =
+  | { kind: "missing" }
+  | { kind: "already_cancelled" }
+  | { kind: "ok" };
+
+/** Confirm the booking still exists and is still confirmed before cancelling. */
+export async function precheckCancel(bookingId: string): Promise<CancelPrecheck> {
+  const { data: existing, error: checkError } = await supabase
+    .from("shift_bookings")
+    .select("id, booking_status")
+    .eq("id", bookingId)
+    .maybeSingle();
+
+  if (checkError || !existing) return { kind: "missing" };
+  if (existing.booking_status !== "confirmed") return { kind: "already_cancelled" };
+  return { kind: "ok" };
+}
+
+interface CancelBookingShift {
+  shift_date: string;
+  start_time: string | null;
+  title: string;
+  department_id: string;
+}
+
+interface CancelBookingResult {
+  ok: boolean;
+  error?: string;
+  /** Cancellation within 48 hours of shift start — affects consistency score messaging. */
+  isLateCancel: boolean;
+}
+
+/**
+ * Cancel a confirmed booking and, if cancellation is within 12 hours of the
+ * shift start, fire late-cancellation notifications to all department
+ * coordinators. Notification failures don't block the cancel.
+ *
+ * Caller is expected to have run precheckCancel() first.
+ */
+export async function cancelBooking(
+  bookingId: string,
+  shift: CancelBookingShift,
+  profileFullName: string | null
+): Promise<CancelBookingResult> {
+  const startTime = shift.start_time || "08:00:00";
+  const shiftDatetime = new Date(`${shift.shift_date}T${startTime}`);
+  const now = new Date();
+  const hoursUntilShift = (shiftDatetime.getTime() - now.getTime()) / (1000 * 60 * 60);
+  const isLateCancel = hoursUntilShift < 48;
+  const isVeryLateCancel = hoursUntilShift <= 12;
+
+  const { error } = await supabase
+    .from("shift_bookings")
+    .update({
+      booking_status: "cancelled",
+      cancelled_at: new Date().toISOString(),
+      ...(isVeryLateCancel ? { late_cancel_notified: true } : {}),
+    })
+    .eq("id", bookingId);
+
+  if (error) return { ok: false, error: error.message, isLateCancel };
+
+  if (isVeryLateCancel) {
+    try {
+      const { data: coords } = await supabase
+        .from("department_coordinators")
+        .select("coordinator_id")
+        .eq("department_id", shift.department_id);
+
+      if (coords && coords.length > 0) {
+        const shiftDateFormatted = format(new Date(shift.shift_date), "MMM d, yyyy");
+        const notifications = coords.map((c) => ({
+          user_id: c.coordinator_id,
+          type: "late_cancellation",
+          title: "Late Cancellation Alert",
+          message: `${profileFullName} cancelled their booking for ${shift.title} on ${shiftDateFormatted} at ${startTime.slice(0, 5)} — less than 12 hours before the shift.`,
+        }));
+        await supabase.from("notifications").insert(notifications);
+      }
+    } catch {
+      // Don't block the cancellation flow if notification fails.
+    }
+  }
+
+  return { ok: true, isLateCancel };
+}

--- a/src/lib/shift-time.ts
+++ b/src/lib/shift-time.ts
@@ -1,0 +1,59 @@
+/**
+ * Time-window helpers for shift booking and check-in flows.
+ *
+ * The legacy data model lets `start_time` / `end_time` be NULL when the shift
+ * uses a preset `time_type` ("morning" / "afternoon" / "full_day" / "custom").
+ * Two places in VolunteerDashboard had bit-equivalent default-resolution logic
+ * (handleCheckIn around line 463 and the upcoming-shifts JSX around line 801);
+ * this module is the single source of truth.
+ *
+ * Defaults preserved verbatim from the original sites:
+ *   morning  → 09:00–12:00
+ *   afternoon → 13:00–16:00
+ *   anything else (including full_day / custom with NULL bounds) → 09:00–17:00
+ */
+
+export interface ShiftTimeInput {
+  shift_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  time_type: string | null;
+}
+
+/** Returns the effective start/end Date for a shift, applying time_type defaults. */
+export function getEffectiveTimes(shift: ShiftTimeInput): { start: Date; end: Date } {
+  const startStr =
+    shift.start_time ||
+    (shift.time_type === "morning"
+      ? "09:00:00"
+      : shift.time_type === "afternoon"
+      ? "13:00:00"
+      : "09:00:00");
+  const endStr =
+    shift.end_time ||
+    (shift.time_type === "morning"
+      ? "12:00:00"
+      : shift.time_type === "afternoon"
+      ? "16:00:00"
+      : "17:00:00");
+  return {
+    start: new Date(`${shift.shift_date}T${startStr}`),
+    end: new Date(`${shift.shift_date}T${endStr}`),
+  };
+}
+
+/**
+ * Whether check-in is open for a shift right now. Window is
+ * [start − 30 min, end] inclusive.
+ */
+export function isCheckInOpen(shift: ShiftTimeInput, now: Date = new Date()): boolean {
+  const { start, end } = getEffectiveTimes(shift);
+  const nowMs = now.getTime();
+  return nowMs >= start.getTime() - 30 * 60 * 1000 && nowMs <= end.getTime();
+}
+
+/** Minutes from `now` until the shift starts. Negative if the shift has already started. */
+export function minutesUntilStart(shift: ShiftTimeInput, now: Date = new Date()): number {
+  const { start } = getEffectiveTimes(shift);
+  return (start.getTime() - now.getTime()) / 60000;
+}

--- a/src/pages/VolunteerDashboard.tsx
+++ b/src/pages/VolunteerDashboard.tsx
@@ -1,334 +1,121 @@
-import { useEffect, useState, useCallback } from "react";
+import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Calendar, Clock, MapPin, Shield, Award, UserPlus, AlertTriangle, XCircle, ChevronDown, CheckCircle, Mail, Loader2 } from "lucide-react";
-import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
-import {
-  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
-  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { format, differenceInHours } from "date-fns";
-import { isUpcoming } from "@/lib/shift-lifecycle";
+import { ChevronDown } from "lucide-react";
+import { format } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
-import { OnboardingChecklist } from "@/components/OnboardingChecklist";
-import { downloadICS, googleCalendarUrl, timeLabel, generateICS } from "@/lib/calendar-utils";
-import { formatSlotRange, slotHours } from "@/lib/slot-utils";
-import { InviteFriendModal } from "@/components/InviteFriendModal";
-import { BookedSlotsDisplay } from "@/components/BookedSlotsDisplay";
-import { VolunteerImpactCharts } from "@/components/VolunteerImpactCharts";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { VolunteerImpactCharts } from "@/components/VolunteerImpactCharts";
+import { getEffectiveTimes, minutesUntilStart } from "@/lib/shift-time";
+import { useVolunteerBookings } from "@/hooks/useVolunteerBookings";
+import { useShiftInvitations, type ShiftInvitation } from "@/hooks/useShiftInvitations";
+import {
+  planInvitationAcceptance,
+  acceptInvitation as acceptInvitationAction,
+  declineInvitation as declineInvitationAction,
+  precheckCancel,
+  cancelBooking as cancelBookingAction,
+} from "@/lib/booking-actions";
+import { PendingConfirmationsBanner } from "@/components/volunteer/PendingConfirmationsBanner";
+import { WaitlistOfferCard } from "@/components/volunteer/WaitlistOfferCard";
+import { PassiveWaitlistList } from "@/components/volunteer/PassiveWaitlistList";
+import { InvitationConflictDialog, type InvitationConflict } from "@/components/volunteer/InvitationConflictDialog";
+import { InvitationsList } from "@/components/volunteer/InvitationsList";
+import { DashboardStats } from "@/components/volunteer/DashboardStats";
+import { DashboardAlerts, type AlertProfile } from "@/components/volunteer/DashboardAlerts";
+import { UpcomingShiftsSection } from "@/components/volunteer/UpcomingShiftsSection";
+import type { ShiftActionTarget } from "@/components/volunteer/UpcomingShiftCard";
 
 export default function VolunteerDashboard() {
   const { user, profile } = useAuth();
   const { toast } = useToast();
-  const [upcomingBookings, setUpcomingBookings] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [pendingConfirmations, setPendingConfirmations] = useState<any[]>([]);
-  const [waitlistOffers, setWaitlistOffers] = useState<any[]>([]);
-  const [waitlistPassive, setWaitlistPassive] = useState<any[]>([]);
-  const [invitations, setInvitations] = useState<any[]>([]);
   const [invitationActioning, setInvitationActioning] = useState<string | null>(null);
-  const [inviteConflict, setInviteConflict] = useState<{
-    invitation: any;
-    conflictBookingId: string;
-    conflictShift: any;
-  } | null>(null);
+  const [inviteConflict, setInviteConflict] = useState<InvitationConflict | null>(null);
 
   // Use LOCAL date, not UTC — otherwise in the evening Central time the UTC
   // rollover drops today's shifts from the filter and they disappear from the
   // dashboard until the next calendar day.
   const today = format(new Date(), "yyyy-MM-dd");
 
-  const fetchBookings = useCallback(async () => {
-    if (!user) return;
-    try {
-      // Fetch CONFIRMED and WAITLISTED bookings in a single query; we split
-      // them client-side. Avoiding PostgREST .or() with ISO timestamps
-      // because it silently fails on some special-character combinations.
-      const [{ data, error: bookingsErr }, { data: pendingData }] = await Promise.all([
-        supabase
-          .from("shift_bookings")
-          .select("id, booking_status, confirmation_status, checked_in_at, waitlist_offer_expires_at, created_at, shifts(id, title, shift_date, time_type, start_time, end_time, total_slots, booked_slots, requires_bg_check, status, allows_group, department_id, departments(name, location_id))")
-          .eq("volunteer_id", user.id)
-          .in("booking_status", ["confirmed", "waitlisted"])
-          .order("created_at", { ascending: false }),
-        supabase
-          .from("volunteer_shift_reports")
-          .select("id, booking_id, self_confirm_status, shift_bookings(id, shifts(title, shift_date, departments(name)))")
-          .eq("volunteer_id", user.id)
-          .eq("self_confirm_status", "pending")
-          .is("submitted_at", null),
-      ]);
-      if (bookingsErr) {
-        console.error("fetchBookings error:", bookingsErr);
-      }
+  const {
+    upcoming: upcomingBookings,
+    pendingConfirmations,
+    waitlistOffers,
+    waitlistPassive,
+    loading,
+    refresh: fetchBookings,
+    optimisticRemoveUpcoming,
+    optimisticUpdateUpcoming,
+  } = useVolunteerBookings(user, today);
 
-      const all = (data as any[]) || [];
-      const nowMs = Date.now();
+  const { invitations, refresh: fetchInvitations } = useShiftInvitations(user);
 
-      // Upcoming (confirmed) bookings: parent shift's end time is still
-      // in the future, and the shift is not admin-cancelled. `shift_date
-      // >= today` was too permissive — today's already-ended shifts
-      // stayed in the list until midnight. `isUpcoming()` is the shared
-      // definition used by admin/coordinator/calendar views.
-      const upcoming = all.filter(
-        (b) =>
-          b.booking_status === "confirmed" &&
-          b.shifts &&
-          isUpcoming(b.shifts) &&
-          b.shifts.status !== "cancelled"
-      );
-
-      // Active waitlist offers
-      const offers = all.filter(
-        (b) =>
-          b.booking_status === "waitlisted" &&
-          b.waitlist_offer_expires_at &&
-          new Date(b.waitlist_offer_expires_at).getTime() > nowMs
-      );
-
-      // Passive waitlist (no active offer) for future shifts
-      const passive = all.filter(
-        (b) =>
-          b.booking_status === "waitlisted" &&
-          (!b.waitlist_offer_expires_at ||
-            new Date(b.waitlist_offer_expires_at).getTime() <= nowMs) &&
-          b.shifts &&
-          b.shifts.shift_date >= today
-      );
-
-      setUpcomingBookings(upcoming);
-      setWaitlistOffers(offers);
-      setWaitlistPassive(passive);
-      setPendingConfirmations((pendingData as any) || []);
-    } catch (e) {
-      console.error("fetchBookings fatal error:", e);
-    } finally {
-      setLoading(false);
-    }
-  }, [user, today]);
-
-  useEffect(() => {
-    fetchBookings();
-  }, [fetchBookings]);
-
-  // Fetch pending invitations
-  const fetchInvitations = useCallback(async () => {
-    if (!user) return;
-    const { data } = await supabase
-      .from("shift_invitations")
-      .select("*, shifts(id, title, shift_date, start_time, end_time, total_slots, booked_slots, department_id, departments(name))")
-      .eq("volunteer_id", user.id)
-      .eq("status", "pending")
-      .order("created_at", { ascending: false });
-    // Filter out expired invitations client-side until the cron catches them
-    const now = new Date();
-    setInvitations(
-      (data || []).filter((inv: any) => new Date(inv.expires_at) > now)
-    );
-  }, [user]);
-
-  useEffect(() => {
-    fetchInvitations();
-  }, [fetchInvitations]);
-
-  // Accept invitation
-  const handleInvitationAccept = async (inv: any) => {
-    if (!user) return;
-    const shift = inv.shifts;
-    if (!shift) return;
+  const handleInvitationAccept = async (inv: ShiftInvitation) => {
+    if (!user || !inv.shifts) return;
     setInvitationActioning(inv.id);
 
-    // Check if shift still has slots
-    const { data: freshShift } = await supabase
-      .from("shifts")
-      .select("booked_slots, total_slots")
-      .eq("id", shift.id)
-      .single();
-
-    if (freshShift && freshShift.booked_slots >= freshShift.total_slots) {
+    const plan = await planInvitationAcceptance(inv, user.id);
+    if (plan.kind === "fully_booked") {
       toast({
         title: "Shift fully booked",
         description: "This shift is now fully booked. Thank you for being available to help fill this spot.",
       });
-      // Mark as declined since they can't accept
-      await supabase
-        .from("shift_invitations")
-        .update({ status: "declined" })
-        .eq("id", inv.id);
       setInvitationActioning(null);
       fetchInvitations();
       return;
     }
-
-    // Check for conflicting bookings
-    const { data: myBookings } = await supabase
-      .from("shift_bookings")
-      .select("id, shifts(id, title, shift_date, start_time, end_time, department_id, departments(name))")
-      .eq("volunteer_id", user.id)
-      .eq("booking_status", "confirmed");
-
-    let conflictBooking: any = null;
-    for (const b of (myBookings || []) as any[]) {
-      const s = b.shifts;
-      if (!s || s.shift_date !== shift.shift_date) continue;
-      if (s.start_time < shift.end_time && s.end_time > shift.start_time) {
-        conflictBooking = b;
-        break;
-      }
-    }
-
-    if (conflictBooking) {
+    if (plan.kind === "conflict") {
       setInviteConflict({
         invitation: inv,
-        conflictBookingId: conflictBooking.id,
-        conflictShift: conflictBooking.shifts,
+        conflictBookingId: plan.conflictBookingId,
+        conflictShift: plan.conflictShift,
       });
       setInvitationActioning(null);
       return;
     }
-
-    // No conflict — book directly
     await completeInvitationAccept(inv);
   };
 
-  const completeInvitationAccept = async (inv: any, cancelBookingId?: string, cancelledShift?: any) => {
-    if (!user) return;
-    const shift = inv.shifts;
+  const completeInvitationAccept = async (
+    inv: ShiftInvitation,
+    cancelBookingId?: string,
+    cancelledShift?: { id: string; title: string; shift_date: string; department_id: string; departments: { name: string } | null }
+  ) => {
+    if (!user || !inv.shifts) return;
     setInvitationActioning(inv.id);
 
-    // If cancelling a conflicting booking first
-    if (cancelBookingId) {
-      await supabase
-        .from("shift_bookings")
-        .update({ booking_status: "cancelled", cancelled_at: new Date().toISOString() })
-        .eq("id", cancelBookingId);
+    const result = await acceptInvitationAction({
+      invitation: inv,
+      userId: user.id,
+      profileFullName: profile?.full_name ?? null,
+      cancelBookingId,
+      cancelledShift: cancelledShift
+        ? { ...cancelledShift, start_time: null, end_time: null }
+        : undefined,
+    });
 
-      // Notify volunteer and coordinator about the cancelled shift
-      if (cancelledShift) {
-        const { data: coords } = await supabase
-          .from("department_coordinators")
-          .select("coordinator_id")
-          .eq("department_id", cancelledShift.department_id);
-
-        const notifications = [
-          {
-            user_id: user.id,
-            type: "booking_cancelled",
-            title: `Booking cancelled — ${cancelledShift.title}`,
-            message: `Your booking for "${cancelledShift.title}" on ${cancelledShift.shift_date} was cancelled to accept an invitation for "${shift.title}".`,
-            link: "/dashboard",
-          },
-          ...(coords || []).map((c: any) => ({
-            user_id: c.coordinator_id,
-            type: "booking_cancelled",
-            title: `Volunteer cancelled — ${cancelledShift.title}`,
-            message: `${profile?.full_name} cancelled their booking for "${cancelledShift.title}" on ${cancelledShift.shift_date} to accept an admin invitation for "${shift.title}".`,
-            link: "/coordinator",
-          })),
-        ];
-        await supabase.from("notifications").insert(notifications);
-      }
-    }
-
-    // Create the booking for the invited shift
-    // Fetch time slots for the shift and book all of them (full shift)
-    const { data: slots } = await supabase
-      .from("shift_time_slots")
-      .select("id, total_slots, booked_slots")
-      .eq("shift_id", shift.id)
-      .order("slot_start", { ascending: true });
-
-    let bookingError = false;
-    if (slots && slots.length > 0) {
-      for (const slot of slots) {
-        const isFull = slot.booked_slots >= slot.total_slots;
-        const { error } = await supabase.from("shift_bookings").insert({
-          shift_id: shift.id,
-          volunteer_id: user.id,
-          booking_status: isFull ? "waitlisted" : "confirmed",
-          time_slot_id: slot.id,
-        });
-        if (error) { bookingError = true; break; }
-      }
-    } else {
-      // Fallback: shift without time slots
-      const { error } = await supabase.from("shift_bookings").insert({
-        shift_id: shift.id,
-        volunteer_id: user.id,
-        booking_status: "confirmed",
-      });
-      if (error) bookingError = true;
-    }
-
-    if (bookingError) {
-      toast({ title: "Could not book shift", description: "An error occurred while booking. Please try again.", variant: "destructive" });
+    if (!result.ok) {
+      toast({ title: "Could not book shift", description: result.error, variant: "destructive" });
       setInvitationActioning(null);
       return;
     }
 
-    // Update invitation status
-    await supabase
-      .from("shift_invitations")
-      .update({ status: "accepted" })
-      .eq("id", inv.id);
-
-    // Notify admin and coordinator that invitation was accepted
-    const notifs: any[] = [
-      {
-        user_id: inv.invited_by,
-        type: "shift_invitation",
-        title: `Invitation accepted — ${shift.title}`,
-        message: `${profile?.full_name} accepted the invitation to "${shift.title}" on ${shift.shift_date}.`,
-        data: { shift_id: shift.id, shift_title: shift.title, shift_date: shift.shift_date },
-      },
-    ];
-    const { data: coords } = await supabase
-      .from("department_coordinators")
-      .select("coordinator_id")
-      .eq("department_id", shift.department_id);
-    for (const c of (coords || [])) {
-      if (c.coordinator_id !== inv.invited_by) {
-        notifs.push({
-          user_id: c.coordinator_id,
-          type: "shift_invitation",
-          title: `Volunteer accepted invitation — ${shift.title}`,
-          message: `${profile?.full_name} accepted an invitation to "${shift.title}" on ${shift.shift_date}.`,
-          data: { shift_id: shift.id, shift_title: shift.title, shift_date: shift.shift_date },
-        });
-      }
-    }
-    await supabase.from("notifications").insert(notifs);
-
     setInvitationActioning(null);
     setInviteConflict(null);
-    toast({ title: "Shift confirmed!", description: `You're booked for ${shift.title}.` });
+    toast({ title: "Shift confirmed!", description: `You're booked for ${inv.shifts.title}.` });
     fetchInvitations();
     fetchBookings();
   };
 
-  // Decline invitation
-  const handleInvitationDecline = async (inv: any, reason?: string) => {
+  const handleInvitationDecline = async (inv: ShiftInvitation, reason?: string) => {
     setInvitationActioning(inv.id);
-
-    await supabase
-      .from("shift_invitations")
-      .update({ status: "declined" })
-      .eq("id", inv.id);
-
-    // Notify admin
-    const shift = inv.shifts;
-    await supabase.from("notifications").insert({
-      user_id: inv.invited_by,
-      type: "shift_invitation",
-      title: `Invitation declined — ${shift?.title || "shift"}`,
-      message: `${profile?.full_name} declined the invitation to "${shift?.title}" on ${shift?.shift_date}.${reason ? ` Reason: ${reason}` : ""}`,
-      data: { shift_id: shift?.id, shift_title: shift?.title, shift_date: shift?.shift_date },
+    await declineInvitationAction({
+      invitation: inv,
+      profileFullName: profile?.full_name ?? null,
+      reason,
     });
-
     setInvitationActioning(null);
     setInviteConflict(null);
     toast({ title: "Invitation declined" });
@@ -372,114 +159,48 @@ export default function VolunteerDashboard() {
     fetchBookings();
   };
 
-  const handleCancel = async (bookingId: string, shift: any) => {
-    const shiftDate = shift.shift_date;
-    const startTime = shift.start_time || "08:00:00";
-    const shiftDatetime = new Date(`${shiftDate}T${startTime}`);
-    const now = new Date();
-    const hoursUntilShift = (shiftDatetime.getTime() - now.getTime()) / (1000 * 60 * 60);
-    const isLateCancel = hoursUntilShift < 48;
-    const isVeryLateCancel = hoursUntilShift <= 12;
-
-    // Verify the booking still exists before trying to cancel — if admin
-    // hard-deleted the shift, the booking was cascaded away and any update
-    // would silently match 0 rows.
-    const { data: existing, error: checkError } = await supabase
-      .from("shift_bookings")
-      .select("id, booking_status")
-      .eq("id", bookingId)
-      .maybeSingle();
-
-    if (checkError || !existing) {
+  const handleCancel = async (bookingId: string, shift: ShiftActionTarget) => {
+    const precheck = await precheckCancel(bookingId);
+    if (precheck.kind === "missing") {
       toast({
         title: "Shift no longer exists",
         description: "This shift was removed by an administrator. Refreshing your list.",
         variant: "destructive",
       });
-      // Drop the stale row from state so the UI matches reality
-      setUpcomingBookings((prev) => prev.filter((b) => b.id !== bookingId));
+      optimisticRemoveUpcoming(bookingId);
+      return;
+    }
+    if (precheck.kind === "already_cancelled") {
+      toast({ title: "Already cancelled", description: "This booking is no longer active." });
+      optimisticRemoveUpcoming(bookingId);
       return;
     }
 
-    if (existing.booking_status !== "confirmed") {
-      toast({
-        title: "Already cancelled",
-        description: "This booking is no longer active.",
-      });
-      setUpcomingBookings((prev) => prev.filter((b) => b.id !== bookingId));
+    const result = await cancelBookingAction(bookingId, shift, profile?.full_name ?? null);
+    if (!result.ok) {
+      toast({ title: "Error", description: result.error, variant: "destructive" });
       return;
     }
 
-    const { error } = await supabase
-      .from("shift_bookings")
-      .update({
-        booking_status: "cancelled",
-        cancelled_at: new Date().toISOString(),
-        ...(isVeryLateCancel ? { late_cancel_notified: true } : {}),
-      })
-      .eq("id", bookingId);
-    if (error) {
-      toast({ title: "Error", description: error.message, variant: "destructive" });
-      return;
-    }
-
-    // Late cancellation notifications (within 12 hours)
-    if (isVeryLateCancel) {
-      try {
-        // Find coordinators for this shift's department
-        const { data: coords } = await supabase
-          .from("department_coordinators")
-          .select("coordinator_id")
-          .eq("department_id", shift.department_id);
-
-        if (coords && coords.length > 0) {
-          const shiftDateFormatted = format(new Date(shiftDate), "MMM d, yyyy");
-          const notifications = coords.map((c) => ({
-            user_id: c.coordinator_id,
-            type: "late_cancellation",
-            title: "Late Cancellation Alert",
-            message: `${profile?.full_name} cancelled their booking for ${shift.title} on ${shiftDateFormatted} at ${startTime.slice(0, 5)} — less than 12 hours before the shift.`,
-          }));
-          await supabase.from("notifications").insert(notifications);
-        }
-      } catch (e) {
-        // Don't block the cancellation flow if notification fails
-      }
-    }
-
-    setUpcomingBookings((prev) => prev.filter((b) => b.id !== bookingId));
+    optimisticRemoveUpcoming(bookingId);
     toast({
       title: "Shift cancelled",
-      description: isLateCancel ? "Late cancellation (within 48 hours) may affect your consistency score." : "Cancelled successfully.",
+      description: result.isLateCancel
+        ? "Late cancellation (within 48 hours) may affect your consistency score."
+        : "Cancelled successfully.",
     });
   };
 
-  const handleCheckIn = async (bookingId: string, shift: any) => {
+  const handleCheckIn = async (bookingId: string, shift: ShiftActionTarget) => {
     if (shift?.shift_date !== today) {
       toast({ title: "Not today", description: "You can only check in on the day of your shift.", variant: "destructive" });
       return;
     }
 
     // Only allow check-in within the 30-minute pre-shift window (or later).
-    // Use time_type defaults when start_time is null.
-    const startStr =
-      shift.start_time ||
-      (shift.time_type === "morning"
-        ? "09:00:00"
-        : shift.time_type === "afternoon"
-        ? "13:00:00"
-        : "09:00:00");
-    const shiftStart = new Date(`${shift.shift_date}T${startStr}`);
-    const endStr =
-      shift.end_time ||
-      (shift.time_type === "morning"
-        ? "12:00:00"
-        : shift.time_type === "afternoon"
-        ? "16:00:00"
-        : "17:00:00");
-    const shiftEnd = new Date(`${shift.shift_date}T${endStr}`);
     const now = new Date();
-    const minutesToStart = (shiftStart.getTime() - now.getTime()) / 60000;
+    const { end: shiftEnd } = getEffectiveTimes(shift);
+    const minutesToStart = minutesUntilStart(shift, now);
     if (minutesToStart > 30) {
       toast({
         title: "Too early",
@@ -504,7 +225,7 @@ export default function VolunteerDashboard() {
     if (error) {
       toast({ title: "Error", description: error.message, variant: "destructive" });
     } else {
-      setUpcomingBookings((prev) => prev.map((b) => b.id === bookingId ? { ...b, checked_in_at: new Date().toISOString() } : b));
+      optimisticUpdateUpcoming(bookingId, { checked_in_at: new Date().toISOString() });
       toast({ title: "Checked in!" });
     }
   };
@@ -522,362 +243,63 @@ export default function VolunteerDashboard() {
     );
   }
 
-  const milestoneBadges = [10, 25, 50, 100];
   const hours = profile?.total_hours ?? 0;
+  const privilegesSuspended = profile?.booking_privileges === false;
+  const bgFailed = profile?.bg_check_status === "failed" || profile?.bg_check_status === "expired";
 
-    const privilegesSuspended = profile?.booking_privileges === false;
-    const bgFailed = profile?.bg_check_status === "failed" || profile?.bg_check_status === "expired";
+  // Filter upcoming bookings based on eligibility
+  const eligibleBookings = upcomingBookings.filter((b) => {
+    if (!b.shifts) return false;
+    if (privilegesSuspended) return false;
+    if (bgFailed && (b.shifts.requires_bg_check || b.shifts.departments?.requires_bg_check)) return false;
+    return true;
+  });
 
-    // Filter upcoming bookings based on eligibility
-    const eligibleBookings = upcomingBookings.filter(b => {
-      if (!b.shifts) return false;
-      if (privilegesSuspended) return false;
-      if (bgFailed && (b.shifts.requires_bg_check || b.shifts.departments?.requires_bg_check)) return false;
-      return true;
-    });
-
-    return (
+  return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div>
         <h2 className="text-2xl font-bold">Welcome back, {profile?.full_name?.split(" ")[0]}</h2>
         <p className="text-muted-foreground">Here are your upcoming shifts</p>
       </div>
 
-      {privilegesSuspended && (
-        <Alert variant="destructive">
-          <XCircle className="h-4 w-4" />
-          <AlertTitle>Booking Privileges Suspended</AlertTitle>
-          <AlertDescription>Your booking privileges have been suspended. Please contact your coordinator.</AlertDescription>
-        </Alert>
-      )}
+      <DashboardAlerts profile={profile as unknown as AlertProfile} />
 
-      {!privilegesSuspended && bgFailed && (
-        <Alert className="border-warning/50 bg-warning/10 text-warning-foreground">
-          <AlertTriangle className="h-4 w-4" />
-          <AlertTitle>Background Check {profile?.bg_check_status === "expired" ? "Expired" : "Failed"}</AlertTitle>
-          <AlertDescription>Your background check status is {profile?.bg_check_status}. You cannot book shifts that require a background check until this is resolved.</AlertDescription>
-        </Alert>
-      )}
+      <PendingConfirmationsBanner pendingConfirmations={pendingConfirmations} />
 
-      {!(profile as any)?.emergency_contact_name || !(profile as any)?.emergency_contact_phone ? (
-        <Alert className="border-warning/50 bg-warning/10">
-          <AlertTriangle className="h-4 w-4 text-warning" />
-          <AlertTitle>Emergency Contact Required</AlertTitle>
-          <AlertDescription>
-            Please add an emergency contact before booking shifts. This is required for insurance and liability.{" "}
-            <a href="/settings" className="text-primary font-medium underline">Go to Settings →</a>
-          </AlertDescription>
-        </Alert>
-      ) : null}
+      {waitlistOffers.map((offer) => (
+        <WaitlistOfferCard
+          key={offer.id}
+          offer={offer}
+          onAccept={handleWaitlistAccept}
+          onDecline={handleWaitlistDecline}
+        />
+      ))}
 
-      {(profile as any)?.is_minor && (
-        <Alert className={(profile as any)?.has_active_consent ? "border-primary/50 bg-primary/5" : "border-destructive/50 bg-destructive/10"}>
-          <AlertTriangle className="h-4 w-4" />
-          <AlertTitle>{(profile as any)?.has_active_consent ? "Parental Consent on File" : "Parental Consent Required"}</AlertTitle>
-          <AlertDescription>
-            {(profile as any)?.has_active_consent
-              ? "Your parent/guardian's consent is on file. You're cleared to book shifts."
-              : <>Volunteers under 18 need parental consent before booking shifts. <a href="/settings" className="text-primary font-medium underline">Go to Settings →</a></>
-            }
-          </AlertDescription>
-        </Alert>
-      )}
+      <PassiveWaitlistList items={waitlistPassive} onLeave={handleLeaveWaitlist} />
 
+      <InvitationsList
+        invitations={invitations}
+        actioningId={invitationActioning}
+        onAccept={handleInvitationAccept}
+        onDecline={handleInvitationDecline}
+      />
 
+      <DashboardStats
+        upcomingCount={eligibleBookings.length}
+        hours={hours}
+        consistencyScore={profile?.consistency_score ?? null}
+        points={profile?.volunteer_points || 0}
+      />
 
-      {pendingConfirmations.length > 0 && (
-        <Card className="border-primary/30 bg-primary/5">
-          <CardContent className="pt-4 pb-4">
-            <div className="flex items-center justify-between gap-3 flex-wrap">
-              <p className="text-sm font-medium">
-                You have <span className="font-bold text-primary">{pendingConfirmations.length}</span> shift{pendingConfirmations.length !== 1 ? "s" : ""} awaiting your confirmation.
-              </p>
-              <a href={`/my-shifts/confirm/${pendingConfirmations[0]?.booking_id}`} className="text-sm font-medium text-primary hover:underline">
-                Confirm now →
-              </a>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {waitlistOffers.length > 0 && waitlistOffers.map((offer) => {
-        const s = offer.shifts;
-        const expiresAt = new Date(offer.waitlist_offer_expires_at);
-        const minutesLeft = Math.max(0, Math.round((expiresAt.getTime() - Date.now()) / 60000));
-        return (
-          <Card key={offer.id} className="border-amber-500/50 bg-amber-500/10">
-            <CardContent className="pt-4 pb-4 space-y-3">
-              <div className="flex items-start gap-3">
-                <AlertTriangle className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
-                <div className="flex-1 space-y-1">
-                  <p className="font-semibold">Waitlist spot opened: {s?.title}</p>
-                  <p className="text-sm text-muted-foreground">
-                    {s && format(new Date(s.shift_date + "T00:00:00"), "MMMM d, yyyy")}
-                    {s?.departments?.name ? ` · ${s.departments.name}` : ""}
-                  </p>
-                  <p className="text-xs text-amber-700">
-                    You have {minutesLeft >= 60
-                      ? `${Math.floor(minutesLeft / 60)}h ${minutesLeft % 60}m`
-                      : `${minutesLeft} minute${minutesLeft !== 1 ? "s" : ""}`} to respond.
-                    The offer forfeits at {format(expiresAt, "h:mm a")}.
-                  </p>
-                </div>
-              </div>
-              <div className="flex gap-2 justify-end">
-                <Button variant="outline" size="sm" onClick={() => handleWaitlistDecline(offer.id)}>
-                  Decline
-                </Button>
-                <Button size="sm" onClick={() => handleWaitlistAccept(offer.id)}>
-                  <CheckCircle className="h-4 w-4 mr-2" /> Accept Shift
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        );
-      })}
-
-      {waitlistPassive.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2">
-              <Clock className="h-4 w-4 text-muted-foreground" /> Your Waitlist
-            </CardTitle>
-            <CardDescription className="text-xs">
-              You'll be notified if a spot opens up on any of these shifts.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            {waitlistPassive.map((w) => {
-              const s = w.shifts;
-              return (
-                <div key={w.id} className="flex items-center justify-between gap-3 py-2 px-3 rounded-md bg-muted/50">
-                  <div className="min-w-0">
-                    <p className="font-medium text-sm truncate">{s?.title}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {s && format(new Date(s.shift_date + "T00:00:00"), "MMM d, yyyy")}
-                      {s?.departments?.name ? ` · ${s.departments.name}` : ""}
-                      {s && ` · ${s.booked_slots}/${s.total_slots} filled`}
-                    </p>
-                  </div>
-                  <Button variant="outline" size="sm" onClick={() => handleLeaveWaitlist(w.id)}>
-                    Leave Waitlist
-                  </Button>
-                </div>
-              );
-            })}
-          </CardContent>
-        </Card>
-      )}
-
-      {invitations.length > 0 && (
-        <Card className="border-primary/30">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2">
-              <Mail className="h-4 w-4 text-primary" /> Shift Invitations
-            </CardTitle>
-            <CardDescription className="text-xs">
-              An admin has invited you to the following shift{invitations.length !== 1 ? "s" : ""}. Respond before the shift starts.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {invitations.map((inv) => {
-              const s = inv.shifts;
-              if (!s) return null;
-              const isActioning = invitationActioning === inv.id;
-              return (
-                <div key={inv.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 py-3 px-3 rounded-md bg-primary/5 border border-primary/10">
-                  <div className="space-y-1 min-w-0">
-                    <p className="font-medium text-sm">{s.title}</p>
-                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                      <span className="flex items-center gap-1">
-                        <Calendar className="h-3 w-3" />
-                        {format(new Date(s.shift_date + "T00:00:00"), "MMM d, yyyy")}
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <Clock className="h-3 w-3" />
-                        {s.start_time?.slice(0, 5)} – {s.end_time?.slice(0, 5)}
-                      </span>
-                      {s.departments?.name && (
-                        <span className="flex items-center gap-1">
-                          <MapPin className="h-3 w-3" />
-                          {s.departments.name}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  <div className="flex gap-2 shrink-0">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={isActioning}
-                      onClick={() => handleInvitationDecline(inv)}
-                    >
-                      Decline
-                    </Button>
-                    <Button
-                      size="sm"
-                      disabled={isActioning}
-                      onClick={() => handleInvitationAccept(inv)}
-                    >
-                      {isActioning ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : <CheckCircle className="h-4 w-4 mr-1" />}
-                      Accept
-                    </Button>
-                  </div>
-                </div>
-              );
-            })}
-          </CardContent>
-        </Card>
-      )}
-
-      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{eligibleBookings.length}</div>
-            <p className="text-sm text-muted-foreground">Upcoming Shifts</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{hours}</div>
-            <p className="text-sm text-muted-foreground">Total Hours</p>
-            <div className="flex gap-1 mt-2">
-              {milestoneBadges.map((m) => (
-                <Badge key={m} variant={hours >= m ? "default" : "secondary"} className="text-[10px]">
-                  {hours >= m && <Award className="h-2.5 w-2.5 mr-0.5" />}{m}h
-                </Badge>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold">
-              {profile?.consistency_score != null ? `${profile.consistency_score}%` : "—"}
-            </div>
-            <p className="text-sm text-muted-foreground">Consistency Score</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              {profile?.consistency_score != null
-                ? "Based on last 5 shifts"
-                : "Complete 5 shifts to see your score"}
-            </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{profile?.volunteer_points || 0}</div>
-            <p className="text-sm text-muted-foreground">Points</p>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div>
-        <h3 className="text-lg font-semibold mb-3">Upcoming Shifts</h3>
-        {loading ? (
-          <p className="text-muted-foreground">Loading...</p>
-        ) : eligibleBookings.length === 0 ? (
-          <Card>
-            <CardContent className="pt-6 text-center text-muted-foreground">
-              <p>{privilegesSuspended ? "Your booking privileges are suspended." : "No upcoming shifts."} <a href="/shifts" className="text-primary underline">Browse available shifts</a></p>
-            </CardContent>
-          </Card>
-        ) : (() => {
-          // Group bookings by shift_id for per-slot display
-          const groupedMap = new Map<string, any[]>();
-          for (const b of eligibleBookings) {
-            const sid = b.shifts?.id;
-            if (!sid) continue;
-            if (!groupedMap.has(sid)) groupedMap.set(sid, []);
-            groupedMap.get(sid)!.push(b);
-          }
-          const groups = Array.from(groupedMap.values());
-
-          return (
-            <div className="grid gap-3">
-              {groups.map((bookings) => {
-                const firstBooking = bookings[0];
-                const s = firstBooking.shifts!;
-                const isToday = s.shift_date === today;
-                const startStr = s.start_time || (s.time_type === "morning" ? "09:00:00" : s.time_type === "afternoon" ? "13:00:00" : "09:00:00");
-                const endStr = s.end_time || (s.time_type === "morning" ? "12:00:00" : s.time_type === "afternoon" ? "16:00:00" : "17:00:00");
-                const shiftStartMs = new Date(`${s.shift_date}T${startStr}`).getTime();
-                const shiftEndMs = new Date(`${s.shift_date}T${endStr}`).getTime();
-                const nowMs = Date.now();
-                const checkInOpen = isToday && nowMs >= shiftStartMs - 30 * 60 * 1000 && nowMs <= shiftEndMs;
-                const anyCheckedIn = bookings.some((b: any) => !!b.checked_in_at);
-
-                return (
-                  <Card key={s.id}>
-                    <CardContent className="pt-4 pb-4">
-                      <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3">
-                        <div className="space-y-1 flex-1">
-                          <div className="font-medium">{s.title}</div>
-                          <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
-                            <span className="flex items-center gap-1"><Calendar className="h-3 w-3" />{format(new Date(s.shift_date + "T00:00:00"), "MMM d, yyyy")}</span>
-                            <span className="flex items-center gap-1"><Clock className="h-3 w-3" />{timeLabel(s)}</span>
-                            <span className="flex items-center gap-1"><MapPin className="h-3 w-3" />{s.departments?.name}</span>
-                          </div>
-                          <div className="flex gap-2">
-                            {s.requires_bg_check && <Badge variant="outline" className="text-xs"><Shield className="h-3 w-3 mr-1" />BG Check</Badge>}
-                          </div>
-                          {/* Per-slot bookings */}
-                          <BookedSlotsDisplay shiftId={s.id} volunteerId={user?.id} />
-
-                          {/* Individual slot actions */}
-                          {bookings.length > 1 && (
-                            <div className="space-y-1 mt-2 pl-2 border-l-2 border-muted">
-                              {bookings.map((b: any) => (
-                                <div key={b.id} className="flex items-center justify-between gap-2 text-xs">
-                                  <span className="text-muted-foreground">
-                                    {b.time_slot_id ? "Slot booking" : "Full shift"}
-                                  </span>
-                                  <Button variant="ghost" size="sm" className="h-6 text-xs text-destructive hover:text-destructive" onClick={() => handleCancel(b.id, s)}>
-                                    Cancel Slot
-                                  </Button>
-                                </div>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                        <div className="flex flex-col gap-2 sm:items-end">
-                          {checkInOpen && !anyCheckedIn && (
-                            <Button size="sm" onClick={() => handleCheckIn(firstBooking.id, s)}>Check In</Button>
-                          )}
-                          {isToday && !anyCheckedIn && !checkInOpen && nowMs < shiftStartMs && (
-                            <Badge variant="outline" className="text-xs">Check-in opens 30 min before start</Badge>
-                          )}
-                          {anyCheckedIn && <Badge className="text-xs bg-success text-success-foreground">Checked In</Badge>}
-                          <div className="flex gap-1 flex-wrap">
-                            <Button variant="ghost" size="sm" className="text-xs h-7" onClick={() => downloadICS(s)} aria-label="Download iCal">
-                              📅 iCal
-                            </Button>
-                            <Button variant="ghost" size="sm" className="text-xs h-7" asChild>
-                              <a href={googleCalendarUrl(s)} target="_blank" rel="noopener noreferrer" aria-label="Add to Google Calendar">
-                                📆 Google
-                              </a>
-                            </Button>
-                            {!s.requires_bg_check && (
-                              <InviteFriendModal shiftId={s.id} shiftTitle={s.title} shiftDate={s.shift_date} shiftTime={timeLabel(s)} />
-                            )}
-                          </div>
-                          {bookings.length === 1 ? (
-                            <Button variant="outline" size="sm" onClick={() => handleCancel(firstBooking.id, s)}>Cancel</Button>
-                          ) : (
-                            <Button variant="outline" size="sm" onClick={() => {
-                              const ok = window.confirm(`Cancel all ${bookings.length} slot bookings for ${s.title}?`);
-                              if (ok) bookings.forEach((b: any) => handleCancel(b.id, s));
-                            }}>Cancel All Slots</Button>
-                          )}
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                );
-              })}
-            </div>
-          );
-        })()}
-      </div>
+      <UpcomingShiftsSection
+        loading={loading}
+        privilegesSuspended={privilegesSuspended}
+        eligibleBookings={eligibleBookings}
+        today={today}
+        userId={user?.id}
+        onCheckIn={handleCheckIn}
+        onCancel={handleCancel}
+      />
 
       <Collapsible>
         <CollapsibleTrigger asChild>
@@ -888,54 +310,12 @@ export default function VolunteerDashboard() {
         </CollapsibleContent>
       </Collapsible>
 
-      {/* Invitation conflict resolution dialog */}
-      <AlertDialog open={!!inviteConflict} onOpenChange={(open) => { if (!open) setInviteConflict(null); }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-amber-500" /> Scheduling Conflict
-            </AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div className="space-y-3">
-                <p>Accepting this shift will conflict with your existing booking:</p>
-                {inviteConflict?.conflictShift && (
-                  <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
-                    <strong>{inviteConflict.conflictShift.title}</strong> on{" "}
-                    {inviteConflict.conflictShift.shift_date} from{" "}
-                    {inviteConflict.conflictShift.start_time?.slice(0, 5)} to{" "}
-                    {inviteConflict.conflictShift.end_time?.slice(0, 5)}
-                  </div>
-                )}
-                <p>Would you like to cancel your existing booking and accept this invitation?</p>
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter className="flex-col sm:flex-row gap-2">
-            <AlertDialogCancel
-              onClick={() => {
-                if (inviteConflict) {
-                  handleInvitationDecline(inviteConflict.invitation, "scheduling conflict");
-                }
-              }}
-            >
-              Keep My Existing Booking &amp; Decline
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (inviteConflict) {
-                  completeInvitationAccept(
-                    inviteConflict.invitation,
-                    inviteConflict.conflictBookingId,
-                    inviteConflict.conflictShift
-                  );
-                }
-              }}
-            >
-              Cancel Existing &amp; Accept Invitation
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <InvitationConflictDialog
+        conflict={inviteConflict}
+        onOpenChange={(open) => { if (!open) setInviteConflict(null); }}
+        onAcceptWithCancel={(c) => completeInvitationAccept(c.invitation, c.conflictBookingId, c.conflictShift)}
+        onDeclineForConflict={(c) => handleInvitationDecline(c.invitation, "scheduling conflict")}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

VolunteerDashboard was a 941-line god component mixing data fetching, business logic, state, and presentation. This PR keeps the page as a thin orchestrator and moves ~700 lines of logic into 13 focused files. **Behavior is unchanged** — the existing 103 vitest tests all pass.

## Before / after

| Metric | Before | After |
|---|---|---|
| `src/pages/VolunteerDashboard.tsx` | **941** lines | **321** lines (-66%) |
| Total lines (page + new files) | 941 | 1,558 (+617 net) |
| Logic moved out of the page | — | ~700 lines |

## New files

| File | Lines | Role |
|---|---|---|
| `src/hooks/useVolunteerBookings.ts` | 168 | Bookings + waitlist partitioning, optimistic state setters |
| `src/hooks/useShiftInvitations.ts` | 62 | Pending invitations |
| `src/lib/booking-actions.ts` | 338 | Service-layer fns: `planInvitationAcceptance`, `acceptInvitation`, `declineInvitation`, `precheckCancel`, `cancelBooking` |
| `src/lib/shift-time.ts` | 59 | Time-default + check-in-window helpers |
| `src/components/volunteer/DashboardAlerts.tsx` | 75 | Privileges / BG / emergency / consent banner stack |
| `src/components/volunteer/DashboardStats.tsx` | 59 | 4-card KPI grid |
| `src/components/volunteer/InvitationConflictDialog.tsx` | 77 | Conflict-resolution modal |
| `src/components/volunteer/InvitationsList.tsx` | 81 | Invitations card |
| `src/components/volunteer/PassiveWaitlistList.tsx` | 50 | Passive-waitlist list |
| `src/components/volunteer/PendingConfirmationsBanner.tsx` | 31 | Pending-confirmation banner |
| `src/components/volunteer/UpcomingShiftCard.tsx` | 119 | One shift's card (incl. per-slot cancel sub-list) |
| `src/components/volunteer/UpcomingShiftsSection.tsx` | 67 | List with grouping logic |
| `src/components/volunteer/WaitlistOfferCard.tsx` | 51 | One waitlist-offer card |

## Why the page is still 321 not 190

My Phase 1 estimate of ~190 didn't account for: toast strings being UI concerns that belong with the orchestrator (≈30 lines for `handleCheckIn` alone), 8 thin handler wrappers each needing 8–15 lines of toast/refresh boilerplate (≈90 lines), and the action-plan branching in `handleInvitationAccept` being inherently page logic.

| Section | Lines | Notes |
|---|---|---|
| Imports | ~30 | One import per logical group; unavoidable |
| State + hooks wiring | ~25 | `useState` × 2, `useVolunteerBookings`, `useShiftInvitations` destructure |
| `handleInvitationAccept` | ~25 | Plan → branch on `kind` → modal/decline/proceed |
| `completeInvitationAccept` | ~30 | Calls `acceptInvitationAction` + toast + refresh |
| `handleInvitationDecline` | ~12 | Thin wrapper |
| 3 waitlist handlers | ~32 | `confirm()` + RPC + toast each — single-file orchestration |
| `handleCancel` | ~30 | Precheck + cancel action + toast |
| `handleCheckIn` | ~38 | Window-validation toasts live here (UI strings) + supabase update |
| Account-pending early return | ~12 | Standalone path |
| Derived values | ~9 | `hours`, `privilegesSuspended`, `bgFailed`, `eligibleBookings` |
| Top-level JSX | ~60 | Layout + 9 sub-component invocations + Collapsible |
| Blank lines / comments | ~18 | |

The remaining 321 lines are real orchestration — wiring hooks → handlers → sub-components plus toast UX. Discussed with the maintainer (option (a) accepted): a 321-line orchestrator wiring 9 sub-components is not a god component; forcing it under 300 would extract a hook with a 6-arg dependency interface, which is worse than slightly-over-line-target.

## `shift-time.ts` — unification status

✅ **Unified.** The two duplicated time-default sites in `handleCheckIn` (lines 463–479 of the original) and the upcoming-shifts JSX (lines 801–806) were bit-equivalent. They've been replaced with calls to `getEffectiveTimes()`, `isCheckInOpen()`, and `minutesUntilStart()`. No follow-up issue needed.

## Type debt — `as` casts that landed in new code

Per the directive, the full surface so you can see it at a glance:

| Location | Cast | Why |
|---|---|---|
| `useVolunteerBookings.ts:108` | `((data as any[]) \|\| []) as VolunteerBooking[]` | PostgREST embedded-select boundary |
| `useVolunteerBookings.ts:138` | `((pendingData as any[]) \|\| []) as PendingConfirmation[]` | PostgREST embedded-select boundary |
| `useShiftInvitations.ts:51` | `((data as any[]) \|\| []).filter(...) as ShiftInvitation[]` | PostgREST embedded-select boundary |
| `booking-actions.ts:76` | `((myBookings as any[]) \|\| []) as ConflictCandidate[]` | PostgREST embedded-select boundary |
| `booking-actions.ts:148` | `notifications.insert(cancelNotifications as never)` | Supabase generated `Json` type narrower than literal object types |
| `booking-actions.ts:222` | `notifications.insert(notifs as never)` | Same as above |
| `booking-actions.ts:248` | `notifications.insert({...} as never)` | Same as above |
| `VolunteerDashboard.tsx:265` | `profile as unknown as AlertProfile` | Bridge generated `Profile` ↔ `AlertProfile` extension type for unmodelled `is_minor` / `has_active_consent` columns |

All 8 are at supabase type-system boundaries. The 4 `as any[]` casts match the rationale documented in `eslint.config.js` (the same pattern as `(supabase as any).rpc()` for untyped RPCs). The 3 `as never` casts are the inverse direction — narrowing past a too-narrow generated `Json` type. The single `as unknown as` bridges the un-generated profile extension columns.

## Verification

- [x] `npx tsc --build` — clean
- [x] `npx eslint . --max-warnings=0` — clean
- [x] `npx vitest run` — 103/103 passing
- [ ] Playwright E2E — runs in CI on this PR

## Phase 4 status

**First of several Phase 4 god-component refactors. Settings.tsx (904 lines) is next.** Same template:
1. Phase 1 analysis → maintainer approval before edits.
2. Incremental extraction with typecheck+lint+test after each step.
3. Hooks first, helpers second, components last (smallest first).
4. Narrow types in new files; don't touch existing `(profile as any)` globals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)