### PR TITLE
refactor: split CheckIn into focused sub-components (Phase 4)

### DIFF
--- a/src/components/checkin/CheckinHeader.tsx
+++ b/src/components/checkin/CheckinHeader.tsx
@@ -1,0 +1,17 @@
+import { Leaf } from "lucide-react";
+
+/**
+ * Shared header for every state of the CheckIn page. Consistent branding
+ * across validating / login / matching / confirm / success.
+ */
+export function CheckinHeader() {
+  return (
+    <div className="text-center space-y-2">
+      <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary">
+        <Leaf className="h-7 w-7 text-primary-foreground" />
+      </div>
+      <h1 className="text-2xl font-bold">Easterseals Iowa</h1>
+      <p className="text-muted-foreground">Volunteer Check-In</p>
+    </div>
+  );
+}

--- a/src/components/checkin/CheckinStateScreens.tsx
+++ b/src/components/checkin/CheckinStateScreens.tsx
@@ -1,0 +1,98 @@
+import { Link } from "react-router-dom";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Loader2, AlertTriangle, CheckCircle, Calendar } from "lucide-react";
+
+/**
+ * Group of small per-state cards for the CheckIn page. Each renders a
+ * single Card with no internal state; the page's state machine decides
+ * which one to mount.
+ */
+
+export function ValidatingState() {
+  return (
+    <Card>
+      <CardContent className="pt-6 flex flex-col items-center gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <p className="text-muted-foreground">Validating check-in code...</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function InvalidTokenState() {
+  return (
+    <Card className="border-destructive">
+      <CardContent className="pt-6 text-center space-y-3">
+        <AlertTriangle className="h-10 w-10 text-destructive mx-auto" />
+        <h3 className="font-semibold text-lg">Invalid Check-In Code</h3>
+        <p className="text-sm text-muted-foreground">
+          This QR code is expired or invalid. Please ask a staff member for a valid check-in code.
+        </p>
+        <Button variant="outline" asChild>
+          <Link to="/auth">Go to Login</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MatchingState() {
+  return (
+    <Card>
+      <CardContent className="pt-6 flex flex-col items-center gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <p className="text-muted-foreground">Finding your shift...</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface NamedProps {
+  volunteerName: string;
+}
+
+export function NoShiftState({ volunteerName }: NamedProps) {
+  return (
+    <Card>
+      <CardContent className="pt-6 text-center space-y-3">
+        <Calendar className="h-10 w-10 text-muted-foreground mx-auto" />
+        <h3 className="font-semibold text-lg">No Shift Found</h3>
+        <p className="text-sm text-muted-foreground">
+          Hi {volunteerName}, you don't have any upcoming shifts scheduled for today. If you believe this is an error, please contact your coordinator.
+        </p>
+        <Button variant="outline" asChild>
+          <Link to="/dashboard">Go to Dashboard</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AlreadyCheckedInState({ volunteerName }: NamedProps) {
+  return (
+    <Card className="border-green-500">
+      <CardContent className="pt-6 text-center space-y-3">
+        <CheckCircle className="h-10 w-10 text-green-600 mx-auto" />
+        <h3 className="font-semibold text-lg">Already Checked In</h3>
+        <p className="text-sm text-muted-foreground">
+          Hi {volunteerName}, you've already checked in for all your shifts today. Thank you for volunteering!
+        </p>
+        <Button variant="outline" asChild>
+          <Link to="/dashboard">Go to Dashboard</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function CheckinProgressState() {
+  return (
+    <Card>
+      <CardContent className="pt-6 flex flex-col items-center gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <p className="text-muted-foreground">Checking you in...</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/checkin/ConfirmCheckinScreen.tsx
+++ b/src/components/checkin/ConfirmCheckinScreen.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle, Calendar, Clock, MapPin } from "lucide-react";
+import { format } from "date-fns";
+import type { MatchedShift } from "@/lib/checkin-actions";
+
+interface Props {
+  volunteerName: string;
+  shifts: MatchedShift[];
+  onCheckIn: (shift: MatchedShift) => void;
+  onCheckInAll: () => void;
+}
+
+/**
+ * Confirm-check-in screen. One tappable card per matched shift; if the
+ * volunteer has multiple slots today, also shows a "Check In to All"
+ * button at the bottom.
+ */
+export function ConfirmCheckinScreen({ volunteerName, shifts, onCheckIn, onCheckInAll }: Props) {
+  return (
+    <Card>
+      <CardHeader className="text-center">
+        <CardTitle>Confirm Check-In</CardTitle>
+        <CardDescription>
+          Welcome, {volunteerName}! {shifts.length === 1
+            ? "Please confirm your shift check-in."
+            : `You have ${shifts.length} slots today. Select one or check in to all.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {shifts.map((shift) => (
+          <button
+            key={shift.bookingId}
+            onClick={() => onCheckIn(shift)}
+            className="w-full text-left rounded-lg border p-4 hover:bg-muted transition-colors space-y-2"
+          >
+            <div className="flex items-center justify-between">
+              <p className="font-medium">{shift.title}</p>
+              <Badge variant="outline" className="text-xs">
+                <MapPin className="h-3 w-3 mr-1" />
+                {shift.departmentName}
+              </Badge>
+            </div>
+            <div className="flex gap-4 text-sm text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <Calendar className="h-3 w-3" />
+                {format(new Date(shift.shiftDate + "T00:00:00"), "MMM d, yyyy")}
+              </span>
+              <span className="flex items-center gap-1">
+                <Clock className="h-3 w-3" />
+                {shift.startTime} - {shift.endTime}
+              </span>
+            </div>
+            <div className="text-xs text-primary font-medium">Tap to check in</div>
+          </button>
+        ))}
+
+        {shifts.length > 1 && (
+          <Button className="w-full" onClick={onCheckInAll}>
+            <CheckCircle className="h-4 w-4 mr-2" />
+            Check In to All {shifts.length} Slots
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/checkin/LoginForm.tsx
+++ b/src/components/checkin/LoginForm.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import type { User } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Lock, User as UserIcon, Loader2, LogIn } from "lucide-react";
+import { Turnstile } from "@marsidev/react-turnstile";
+import { useToast } from "@/hooks/use-toast";
+import { resolveLoginIdentifierToEmail } from "@/lib/checkin-actions";
+
+const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY || "1x00000000000000000000AA";
+
+interface Props {
+  /** Called after successful sign-in with the resolved Supabase user. */
+  onLoginSuccess: (user: User) => void;
+}
+
+/**
+ * Login card for the CheckIn flow. Owns its own form state, Turnstile
+ * token, and the full login sequence:
+ *
+ *   1. Resolve username → email (if no `@`) via RPC
+ *   2. signInWithPassword with the captcha token
+ *   3. Check MFA assurance level — if step-up is required, refuse and
+ *      direct the user to the main site (no MFA verification UI here)
+ *
+ * The MFA gate stays here because it's the second half of the auth
+ * transaction; splitting it across files would change the unit.
+ */
+export function LoginForm({ onLoginSuccess }: Props) {
+  const { toast } = useToast();
+  const [identifier, setIdentifier] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!turnstileToken) {
+      toast({ title: "Verification required", description: "Please complete the security check.", variant: "destructive" });
+      return;
+    }
+    setLoading(true);
+
+    // Resolve identifier (email vs username)
+    let emailToUse = identifier.trim();
+    if (!emailToUse.includes("@")) {
+      const resolved = await resolveLoginIdentifierToEmail(emailToUse);
+      if (!resolved) {
+        setLoading(false);
+        setTurnstileToken(null);
+        toast({ title: "Login failed", description: "Invalid credentials.", variant: "destructive" });
+        return;
+      }
+      emailToUse = resolved;
+    }
+
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email: emailToUse,
+      password,
+      options: { captchaToken: turnstileToken },
+    });
+    setTurnstileToken(null);
+
+    if (error) {
+      setLoading(false);
+      toast({ title: "Login failed", description: "Invalid credentials.", variant: "destructive" });
+      return;
+    }
+
+    // MFA gate — if step-up is required, push the user back to the main
+    // site rather than handling MFA verification here.
+    const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+    if (aal?.nextLevel === "aal2" && aal.nextLevel !== aal.currentLevel) {
+      setLoading(false);
+      toast({
+        title: "MFA Required",
+        description: "Please complete MFA verification on the main site first, then scan the QR code again.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setLoading(false);
+    if (data.session?.user) {
+      onLoginSuccess(data.session.user);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="text-center">
+        <CardTitle className="flex items-center justify-center gap-2">
+          <LogIn className="h-5 w-5" /> Sign In to Check In
+        </CardTitle>
+        <CardDescription>
+          Enter your credentials to check in for your shift.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="checkin-identifier">Email or Username</Label>
+            <div className="relative">
+              <UserIcon className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input
+                id="checkin-identifier"
+                type="text"
+                autoComplete="username"
+                className="pl-10"
+                value={identifier}
+                onChange={(e) => setIdentifier(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="checkin-password">Password</Label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input
+                id="checkin-password"
+                type="password"
+                autoComplete="current-password"
+                className="pl-10"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+          <div className="flex justify-center">
+            <Turnstile
+              siteKey={TURNSTILE_SITE_KEY}
+              onSuccess={(t) => setTurnstileToken(t)}
+              onExpire={() => setTurnstileToken(null)}
+              options={{ theme: "light", size: "normal" }}
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={loading || !turnstileToken}>
+            {loading ? (
+              <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Signing in...</>
+            ) : !turnstileToken ? (
+              "Verifying..."
+            ) : (
+              "Sign In & Check In"
+            )}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/checkin/SuccessScreen.tsx
+++ b/src/components/checkin/SuccessScreen.tsx
@@ -1,0 +1,53 @@
+import { Link } from "react-router-dom";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CheckCircle } from "lucide-react";
+import { format } from "date-fns";
+import type { MatchedShift } from "@/lib/checkin-actions";
+
+interface Props {
+  volunteerName: string;
+  /** Single shift checked in to (or null if multi-slot). */
+  shift: MatchedShift | null;
+  /** Total slots checked in to when multi-slot (used when `shift` is null). */
+  multiSlotCount: number;
+}
+
+/**
+ * Success screen shown after a successful check-in. Displays the single
+ * shift's detail OR the "checked in to N slots" summary.
+ */
+export function SuccessScreen({ volunteerName, shift, multiSlotCount }: Props) {
+  return (
+    <Card className="border-green-500">
+      <CardContent className="pt-6 text-center space-y-4">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+          <CheckCircle className="h-10 w-10 text-green-600" />
+        </div>
+        <h3 className="text-xl font-bold text-green-700">You're Checked In!</h3>
+        <p className="text-muted-foreground">
+          Thank you, {volunteerName}! Your check-in has been recorded.
+        </p>
+        {shift && (
+          <div className="rounded-md border bg-muted/50 p-3 text-sm space-y-1">
+            <p className="font-medium">{shift.title}</p>
+            <p className="text-muted-foreground">
+              {shift.startTime} - {shift.endTime} | {shift.departmentName}
+            </p>
+          </div>
+        )}
+        {!shift && multiSlotCount > 1 && (
+          <div className="rounded-md border bg-muted/50 p-3 text-sm">
+            <p className="font-medium">Checked in to {multiSlotCount} slots</p>
+          </div>
+        )}
+        <p className="text-xs text-muted-foreground">
+          Checked in at {format(new Date(), "h:mm a")}
+        </p>
+        <Button variant="outline" asChild>
+          <Link to="/dashboard">Go to Dashboard</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/checkin-actions.ts
+++ b/src/lib/checkin-actions.ts
@@ -1,0 +1,221 @@
+import { supabase } from "@/integrations/supabase/client";
+import { isWithinPostShiftGrace } from "./shift-time";
+
+/**
+ * Service-layer functions for the QR check-in flow.
+ *
+ * The functions are exposed individually rather than wrapped into a single
+ * "do the whole flow" helper so the page can preserve the explicit
+ * sensitive-ops sequence:
+ *
+ *   1. validateCheckinToken
+ *   2. (session check happens at page level)
+ *   3. login (only if needed) — stays inside LoginForm because it's the
+ *      second half of the auth transaction
+ *   4. fetchTodaysMatchedShifts
+ *   5. recordCheckin (per shift)
+ *   6. notifyCoordinatorsOfCheckin
+ *
+ * No React, no toast, no useState. Page handlers translate results into
+ * step transitions + UI feedback.
+ */
+
+export interface MatchedShift {
+  bookingId: string;
+  shiftId: string;
+  title: string;
+  shiftDate: string;
+  startTime: string;
+  endTime: string;
+  departmentName: string;
+  timeSlotId: string | null;
+  slotStart: string | null;
+  slotEnd: string | null;
+}
+
+const POST_SHIFT_GRACE_MINUTES = 30;
+
+/** Validate the QR token via the `validate_checkin_token` RPC. */
+export async function validateCheckinToken(token: string): Promise<boolean> {
+  const { data, error } = await supabase.rpc("validate_checkin_token", { p_token: token });
+  if (error) return false;
+  return Boolean(data);
+}
+
+/**
+ * Resolve a username (no `@`) to its email via the `get_email_by_username` RPC.
+ * Returns null if not found. Email-as-identifier short-circuits — the caller
+ * decides whether to call this based on whether the input contains `@`.
+ */
+export async function resolveLoginIdentifierToEmail(identifier: string): Promise<string | null> {
+  const { data } = await supabase.rpc("get_email_by_username", { p_username: identifier });
+  return (data as string | null) ?? null;
+}
+
+export type ShiftMatchResult =
+  | { kind: "no_shift"; volunteerName: string }
+  | { kind: "already"; volunteerName: string }
+  | { kind: "matched"; volunteerName: string; shifts: MatchedShift[] };
+
+interface BookingRow {
+  id: string;
+  shift_id: string;
+  checked_in: boolean | null;
+  checked_in_at: string | null;
+  time_slot_id: string | null;
+  shifts: {
+    id: string;
+    title: string;
+    shift_date: string;
+    start_time: string;
+    end_time: string;
+    departments: { name: string } | null;
+  } | null;
+}
+
+/**
+ * Fetch today's confirmed bookings for the volunteer, fetch slot times for
+ * any slot-bookings, filter out shifts that ended more than 30 minutes ago,
+ * and return a discriminated-union result.
+ *
+ * Boundary cast applied once at the supabase response. Coordinator
+ * notification is a separate function.
+ */
+export async function fetchTodaysMatchedShifts(userId: string, currentTime: string): Promise<ShiftMatchResult> {
+  // Volunteer name first — used in every downstream UI screen.
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name")
+    .eq("id", userId)
+    .single();
+  const volunteerName = profile?.full_name || "Volunteer";
+
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data } = await supabase
+    .from("shift_bookings")
+    .select(`
+      id,
+      shift_id,
+      checked_in,
+      checked_in_at,
+      time_slot_id,
+      shifts!inner(
+        id, title, shift_date, start_time, end_time,
+        departments(name)
+      )
+    `)
+    .eq("volunteer_id", userId)
+    .eq("booking_status", "confirmed")
+    .eq("shifts.shift_date", today);
+
+  const bookings = ((data as any[]) || []) as BookingRow[];
+
+  if (bookings.length === 0) {
+    return { kind: "no_shift", volunteerName };
+  }
+
+  // All-already-checked-in short-circuit.
+  const unchecked = bookings.filter((b) => !b.checked_in && !b.checked_in_at);
+  if (unchecked.length === 0) {
+    return { kind: "already", volunteerName };
+  }
+
+  const matched: MatchedShift[] = [];
+  for (const b of unchecked) {
+    const s = b.shifts;
+    if (!s) continue;
+    let slotStart: string | null = null;
+    let slotEnd: string | null = null;
+
+    if (b.time_slot_id) {
+      const { data: slot } = await supabase
+        .from("shift_time_slots")
+        .select("slot_start, slot_end")
+        .eq("id", b.time_slot_id)
+        .single();
+      if (slot) {
+        slotStart = slot.slot_start;
+        slotEnd = slot.slot_end;
+      }
+    }
+
+    // Apply post-shift 30-min grace filter — drop shifts that ended more
+    // than 30 minutes ago.
+    const effectiveEnd = slotEnd || s.end_time;
+    if (effectiveEnd && !isWithinPostShiftGrace(effectiveEnd, currentTime, POST_SHIFT_GRACE_MINUTES)) {
+      continue;
+    }
+
+    matched.push({
+      bookingId: b.id,
+      shiftId: s.id,
+      title: s.title,
+      shiftDate: s.shift_date,
+      startTime: (slotStart || s.start_time)?.slice(0, 5),
+      endTime: (slotEnd || s.end_time)?.slice(0, 5),
+      departmentName: s.departments?.name || "Unknown",
+      timeSlotId: b.time_slot_id,
+      slotStart,
+      slotEnd,
+    });
+  }
+
+  if (matched.length === 0) {
+    return { kind: "no_shift", volunteerName };
+  }
+
+  return { kind: "matched", volunteerName, shifts: matched };
+}
+
+/** Mark one booking as checked in. */
+export async function recordCheckin(bookingId: string): Promise<{ ok: boolean; error?: string }> {
+  const { error } = await supabase
+    .from("shift_bookings")
+    .update({
+      checked_in: true,
+      checked_in_at: new Date().toISOString(),
+    })
+    .eq("id", bookingId);
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}
+
+interface NotifyArgs {
+  shiftId: string;
+  title: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Fan-out coordinator notifications for a check-in. Looks up the shift's
+ * department, fetches all coordinators for that department, inserts one
+ * notification per coordinator. Failures don't throw — caller can ignore.
+ */
+export async function notifyCoordinatorsOfCheckin({ shiftId, title, message, data }: NotifyArgs): Promise<void> {
+  const { data: shiftInfo } = await supabase
+    .from("shifts")
+    .select("department_id")
+    .eq("id", shiftId)
+    .single();
+  if (!shiftInfo) return;
+
+  const { data: coords } = await supabase
+    .from("department_coordinators")
+    .select("coordinator_id")
+    .eq("department_id", shiftInfo.department_id);
+
+  const coordRows = ((coords as { coordinator_id: string }[] | null) || []);
+  if (coordRows.length === 0) return;
+
+  const notifications = coordRows.map((c) => ({
+    user_id: c.coordinator_id,
+    type: "volunteer_checked_in",
+    title,
+    message,
+    link: "/coordinator",
+    ...(data ? { data } : {}),
+  }));
+  await supabase.from("notifications").insert(notifications as never);
+}

--- a/src/lib/shift-time.ts
+++ b/src/lib/shift-time.ts
@@ -57,3 +57,27 @@ export function minutesUntilStart(shift: ShiftTimeInput, now: Date = new Date())
   const { start } = getEffectiveTimes(shift);
   return (start.getTime() - now.getTime()) / 60000;
 }
+
+/**
+ * QR check-in post-shift grace window. Operates on time-of-day strings
+ * (HH:MM:SS), distinct from `isCheckInOpen` which is a pre-shift gate
+ * on Date objects:
+ *
+ *   isCheckInOpen  : window is [start − 30min, end] — Dashboard "Check In"
+ *                    button (no late check-in past end).
+ *   isWithinPostShiftGrace : window is [..., end + grace] — QR check-in
+ *                            page (allows late check-in for `grace` minutes
+ *                            past the shift end; no pre-shift gate because
+ *                            the QR is given out at the venue).
+ *
+ * Returns true if check-in is still allowed at `currentTime`.
+ */
+export function isWithinPostShiftGrace(endTime: string, currentTime: string, graceMinutes: number): boolean {
+  // Lex compare works because times are HH:MM:SS sortable.
+  if (endTime >= currentTime) return true; // shift hasn't ended yet
+  const [h, m] = endTime.split(":").map(Number);
+  const endMins = h * 60 + m + graceMinutes;
+  const [ch, cm] = currentTime.split(":").map(Number);
+  const currentMins = ch * 60 + cm;
+  return currentMins <= endMins;
+}

--- a/src/pages/CheckIn.tsx
+++ b/src/pages/CheckIn.tsx
@@ -1,579 +1,184 @@
-import { useState, useEffect, useCallback } from "react";
-import { useSearchParams, Link } from "react-router-dom";
+import { useEffect, useState, useCallback } from "react";
+import type { User } from "@supabase/supabase-js";
+import { useSearchParams } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Leaf, Lock, User, Loader2, CheckCircle, Calendar, Clock, MapPin, AlertTriangle, LogIn } from "lucide-react";
-import { Turnstile } from "@marsidev/react-turnstile";
-import { format } from "date-fns";
+import {
+  validateCheckinToken,
+  fetchTodaysMatchedShifts,
+  recordCheckin,
+  notifyCoordinatorsOfCheckin,
+  type MatchedShift,
+} from "@/lib/checkin-actions";
+import { CheckinHeader } from "@/components/checkin/CheckinHeader";
+import {
+  ValidatingState,
+  InvalidTokenState,
+  MatchingState,
+  NoShiftState,
+  AlreadyCheckedInState,
+  CheckinProgressState,
+} from "@/components/checkin/CheckinStateScreens";
+import { LoginForm } from "@/components/checkin/LoginForm";
+import { ConfirmCheckinScreen } from "@/components/checkin/ConfirmCheckinScreen";
+import { SuccessScreen } from "@/components/checkin/SuccessScreen";
 
-const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY || "1x00000000000000000000AA";
+type Step =
+  | "validating"
+  | "invalid"
+  | "login"
+  | "matching"
+  | "confirm"
+  | "checking_in"
+  | "success"
+  | "already"
+  | "no_shift";
 
-type Step = "validating" | "invalid" | "login" | "matching" | "confirm" | "checking_in" | "success" | "already" | "no_shift";
-
-interface MatchedShift {
-  bookingId: string;
-  shiftId: string;
-  title: string;
-  shiftDate: string;
-  startTime: string;
-  endTime: string;
-  departmentName: string;
-  timeSlotId: string | null;
-  slotStart: string | null;
-  slotEnd: string | null;
-}
-
+/**
+ * Volunteer check-in flow driven by a state machine on `step`. The page is
+ * the orchestrator: each transition is an explicit page-level call into
+ * `checkin-actions.ts`, which preserves the sensitive-ops sequence
+ * (token validate → session check → login if needed → fetch today's
+ * shifts with grace filter → record → notify coordinators).
+ */
 export default function CheckIn() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token") || "";
   const { toast } = useToast();
 
   const [step, setStep] = useState<Step>("validating");
-  const [user, setUser] = useState<any>(null);
+  const [, setUser] = useState<User | null>(null);
   const [volunteerName, setVolunteerName] = useState("");
   const [matchedShifts, setMatchedShifts] = useState<MatchedShift[]>([]);
   const [selectedShift, setSelectedShift] = useState<MatchedShift | null>(null);
 
-  // Login form state
-  const [loginIdentifier, setLoginIdentifier] = useState("");
-  const [loginPassword, setLoginPassword] = useState("");
-  const [loginLoading, setLoginLoading] = useState(false);
-  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  // Step 3: shift matching. Defined before the validation effect so the
+  // effect can call into it once the session is known.
+  const matchShifts = useCallback(async (userId: string) => {
+    setStep("matching");
+    const currentTime = new Date().toTimeString().slice(0, 8);
+    const result = await fetchTodaysMatchedShifts(userId, currentTime);
+    setVolunteerName(result.volunteerName);
+    if (result.kind === "no_shift") {
+      setStep("no_shift");
+      return;
+    }
+    if (result.kind === "already") {
+      setStep("already");
+      return;
+    }
+    setMatchedShifts(result.shifts);
+    if (result.shifts.length === 1) {
+      setSelectedShift(result.shifts[0]);
+    }
+    setStep("confirm");
+  }, []);
 
-  // ── Step 1: Validate the QR token ──────────────────────────
+  // Step 1: validate the QR token, then check session and either skip to
+  // shift matching or send the user through login.
   useEffect(() => {
     if (!token) {
       setStep("invalid");
       return;
     }
     (async () => {
-      const { data: valid, error } = await supabase.rpc("validate_checkin_token", {
-        p_token: token,
-      });
-      if (error || !valid) {
+      const valid = await validateCheckinToken(token);
+      if (!valid) {
         setStep("invalid");
         return;
       }
-      // Token is valid — check if user is already logged in
       const { data: { session } } = await supabase.auth.getSession();
       if (session?.user) {
         setUser(session.user);
-        // Skip login, go to shift matching
         await matchShifts(session.user.id);
       } else {
         setStep("login");
       }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token]);
+  }, [token, matchShifts]);
 
-  // ── Step 2: Handle login ───────────────────────────────────
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!turnstileToken) {
-      toast({ title: "Verification required", description: "Please complete the security check.", variant: "destructive" });
-      return;
-    }
-    setLoginLoading(true);
-
-    // Resolve identifier
-    let emailToUse = loginIdentifier.trim();
-    if (!emailToUse.includes("@")) {
-      const { data: resolvedEmail } = await supabase.rpc("get_email_by_username", {
-        p_username: emailToUse,
-      });
-      if (!resolvedEmail) {
-        setLoginLoading(false);
-        setTurnstileToken(null);
-        toast({ title: "Login failed", description: "Invalid credentials.", variant: "destructive" });
-        return;
-      }
-      emailToUse = resolvedEmail as string;
-    }
-
-    const { data, error } = await supabase.auth.signInWithPassword({
-      email: emailToUse,
-      password: loginPassword,
-      options: { captchaToken: turnstileToken },
-    });
-    setTurnstileToken(null);
-
-    if (error) {
-      setLoginLoading(false);
-      toast({ title: "Login failed", description: "Invalid credentials.", variant: "destructive" });
-      return;
-    }
-
-    // MFA check
-    const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-    if (aal?.nextLevel === "aal2" && aal.nextLevel !== aal.currentLevel) {
-      setLoginLoading(false);
-      toast({
-        title: "MFA Required",
-        description: "Please complete MFA verification on the main site first, then scan the QR code again.",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    setUser(data.session?.user);
-    setLoginLoading(false);
-    await matchShifts(data.session!.user.id);
+  // Step 2: login success handler — LoginForm owns its own form state and
+  // performs the actual sign-in / MFA gate; we just take the resolved user
+  // and continue the flow.
+  const handleLoginSuccess = async (signedInUser: User) => {
+    setUser(signedInUser);
+    await matchShifts(signedInUser.id);
   };
 
-  // ── Step 3: Match volunteer to today's shift(s) ────────────
-  const matchShifts = useCallback(async (userId: string) => {
-    setStep("matching");
-
-    // Get volunteer name
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("full_name")
-      .eq("id", userId)
-      .single();
-    setVolunteerName(profile?.full_name || "Volunteer");
-
-    const today = new Date().toISOString().split("T")[0];
-    const now = new Date();
-    // Format current time as HH:MM:SS for comparison
-    const currentTime = now.toTimeString().slice(0, 8);
-
-    // Find confirmed bookings for today that haven't been checked in
-    const { data: bookings } = await supabase
-      .from("shift_bookings")
-      .select(`
-        id,
-        shift_id,
-        checked_in,
-        checked_in_at,
-        time_slot_id,
-        shifts!inner(
-          id, title, shift_date, start_time, end_time,
-          departments(name)
-        )
-      `)
-      .eq("volunteer_id", userId)
-      .eq("booking_status", "confirmed")
-      .eq("shifts.shift_date", today);
-
-    if (!bookings || bookings.length === 0) {
-      setStep("no_shift");
-      return;
-    }
-
-    // Check if ALL are already checked in
-    const unchecked = bookings.filter((b: any) => !b.checked_in && !b.checked_in_at);
-    if (unchecked.length === 0) {
-      setStep("already");
-      return;
-    }
-
-    // Build matched shifts with slot times if applicable
-    const matched: MatchedShift[] = [];
-    for (const b of unchecked as any[]) {
-      const s = b.shifts;
-      let slotStart: string | null = null;
-      let slotEnd: string | null = null;
-
-      if (b.time_slot_id) {
-        const { data: slot } = await supabase
-          .from("shift_time_slots")
-          .select("slot_start, slot_end")
-          .eq("id", b.time_slot_id)
-          .single();
-        if (slot) {
-          slotStart = slot.slot_start;
-          slotEnd = slot.slot_end;
-        }
-      }
-
-      // Only include shifts that haven't ended yet (with 30-min grace)
-      const effectiveEnd = slotEnd || s.end_time;
-      if (effectiveEnd && effectiveEnd < currentTime) {
-        // Shift already ended, skip — but allow 30 min grace
-        const [h, m] = effectiveEnd.split(":").map(Number);
-        const endMins = h * 60 + m + 30;
-        const [ch, cm] = currentTime.split(":").map(Number);
-        const currentMins = ch * 60 + cm;
-        if (currentMins > endMins) continue;
-      }
-
-      matched.push({
-        bookingId: b.id,
-        shiftId: s.id,
-        title: s.title,
-        shiftDate: s.shift_date,
-        startTime: (slotStart || s.start_time)?.slice(0, 5),
-        endTime: (slotEnd || s.end_time)?.slice(0, 5),
-        departmentName: s.departments?.name || "Unknown",
-        timeSlotId: b.time_slot_id,
-        slotStart,
-        slotEnd,
-      });
-    }
-
-    if (matched.length === 0) {
-      setStep("no_shift");
-      return;
-    }
-
-    setMatchedShifts(matched);
-
-    // If exactly one shift, auto-select
-    if (matched.length === 1) {
-      setSelectedShift(matched[0]);
-      setStep("confirm");
-    } else {
-      setStep("confirm");
-    }
-  }, []);
-
-  // ── Step 4: Perform check-in ──────────────────────────────
+  // Step 4: single-shift check-in. Validation order: record first, then
+  // notify coordinators. If record fails, surface the error and stay on
+  // confirm; coordinator notification is best-effort.
   const handleCheckIn = async (shift: MatchedShift) => {
     setStep("checking_in");
-
-    const { error } = await supabase
-      .from("shift_bookings")
-      .update({
-        checked_in: true,
-        checked_in_at: new Date().toISOString(),
-      })
-      .eq("id", shift.bookingId);
-
-    if (error) {
-      toast({ title: "Check-in failed", description: error.message, variant: "destructive" });
+    const result = await recordCheckin(shift.bookingId);
+    if (!result.ok) {
+      toast({ title: "Check-in failed", description: result.error, variant: "destructive" });
       setStep("confirm");
       return;
     }
-
-    // Send notification to coordinator(s) of the shift's department
-    const { data: shiftInfo } = await supabase
-      .from("shifts")
-      .select("department_id")
-      .eq("id", shift.shiftId)
-      .single();
-
-    if (shiftInfo) {
-      const { data: coords } = await supabase
-        .from("department_coordinators")
-        .select("coordinator_id")
-        .eq("department_id", shiftInfo.department_id);
-
-      if (coords && coords.length > 0) {
-        const notifications = coords.map((c: any) => ({
-          user_id: c.coordinator_id,
-          type: "volunteer_checked_in",
-          title: `${volunteerName} checked in`,
-          message: `${volunteerName} has checked in for "${shift.title}" (${shift.startTime} - ${shift.endTime}).`,
-          link: "/coordinator",
-          data: {
-            shift_id: shift.shiftId,
-            booking_id: shift.bookingId,
-            volunteer_name: volunteerName,
-          },
-        }));
-        await supabase.from("notifications").insert(notifications);
-      }
-    }
-
+    await notifyCoordinatorsOfCheckin({
+      shiftId: shift.shiftId,
+      title: `${volunteerName} checked in`,
+      message: `${volunteerName} has checked in for "${shift.title}" (${shift.startTime} - ${shift.endTime}).`,
+      data: {
+        shift_id: shift.shiftId,
+        booking_id: shift.bookingId,
+        volunteer_name: volunteerName,
+      },
+    });
     setSelectedShift(shift);
     setStep("success");
   };
 
-  // ── Step 5: Check in all shifts at once ────────────────────
+  // Step 5: multi-slot check-in. Records all matched shifts, then sends a
+  // single notification to coordinators of the first shift's department.
   const handleCheckInAll = async () => {
     setStep("checking_in");
-
     for (const shift of matchedShifts) {
-      const { error } = await supabase
-        .from("shift_bookings")
-        .update({
-          checked_in: true,
-          checked_in_at: new Date().toISOString(),
-        })
-        .eq("id", shift.bookingId);
-
-      if (error) {
-        toast({ title: "Check-in failed", description: error.message, variant: "destructive" });
+      const result = await recordCheckin(shift.bookingId);
+      if (!result.ok) {
+        toast({ title: "Check-in failed", description: result.error, variant: "destructive" });
         setStep("confirm");
         return;
       }
     }
-
-    // Notify coordinator for first shift (covers the department)
     if (matchedShifts.length > 0) {
       const first = matchedShifts[0];
-      const { data: shiftInfo } = await supabase
-        .from("shifts")
-        .select("department_id")
-        .eq("id", first.shiftId)
-        .single();
-
-      if (shiftInfo) {
-        const { data: coords } = await supabase
-          .from("department_coordinators")
-          .select("coordinator_id")
-          .eq("department_id", shiftInfo.department_id);
-
-        if (coords && coords.length > 0) {
-          const notifications = coords.map((c: any) => ({
-            user_id: c.coordinator_id,
-            type: "volunteer_checked_in",
-            title: `${volunteerName} checked in`,
-            message: `${volunteerName} has checked in for ${matchedShifts.length} slot(s) today.`,
-            link: "/coordinator",
-          }));
-          await supabase.from("notifications").insert(notifications);
-        }
-      }
+      await notifyCoordinatorsOfCheckin({
+        shiftId: first.shiftId,
+        title: `${volunteerName} checked in`,
+        message: `${volunteerName} has checked in for ${matchedShifts.length} slot(s) today.`,
+      });
     }
-
     setStep("success");
   };
 
-  // ── Render ─────────────────────────────────────────────────
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-md space-y-4">
-        {/* Header */}
-        <div className="text-center space-y-2">
-          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary">
-            <Leaf className="h-7 w-7 text-primary-foreground" />
-          </div>
-          <h1 className="text-2xl font-bold">Easterseals Iowa</h1>
-          <p className="text-muted-foreground">Volunteer Check-In</p>
-        </div>
+        <CheckinHeader />
 
-        {/* Validating token */}
-        {step === "validating" && (
-          <Card>
-            <CardContent className="pt-6 flex flex-col items-center gap-3">
-              <Loader2 className="h-8 w-8 animate-spin text-primary" />
-              <p className="text-muted-foreground">Validating check-in code...</p>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Invalid token */}
-        {step === "invalid" && (
-          <Card className="border-destructive">
-            <CardContent className="pt-6 text-center space-y-3">
-              <AlertTriangle className="h-10 w-10 text-destructive mx-auto" />
-              <h3 className="font-semibold text-lg">Invalid Check-In Code</h3>
-              <p className="text-sm text-muted-foreground">
-                This QR code is expired or invalid. Please ask a staff member for a valid check-in code.
-              </p>
-              <Button variant="outline" asChild>
-                <Link to="/auth">Go to Login</Link>
-              </Button>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Login form */}
-        {step === "login" && (
-          <Card>
-            <CardHeader className="text-center">
-              <CardTitle className="flex items-center justify-center gap-2">
-                <LogIn className="h-5 w-5" /> Sign In to Check In
-              </CardTitle>
-              <CardDescription>
-                Enter your credentials to check in for your shift.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <form onSubmit={handleLogin} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="checkin-identifier">Email or Username</Label>
-                  <div className="relative">
-                    <User className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-                    <Input
-                      id="checkin-identifier"
-                      type="text"
-                      autoComplete="username"
-                      className="pl-10"
-                      value={loginIdentifier}
-                      onChange={(e) => setLoginIdentifier(e.target.value)}
-                      required
-                      autoFocus
-                    />
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="checkin-password">Password</Label>
-                  <div className="relative">
-                    <Lock className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-                    <Input
-                      id="checkin-password"
-                      type="password"
-                      autoComplete="current-password"
-                      className="pl-10"
-                      value={loginPassword}
-                      onChange={(e) => setLoginPassword(e.target.value)}
-                      required
-                    />
-                  </div>
-                </div>
-                <div className="flex justify-center">
-                  <Turnstile
-                    siteKey={TURNSTILE_SITE_KEY}
-                    onSuccess={(t) => setTurnstileToken(t)}
-                    onExpire={() => setTurnstileToken(null)}
-                    options={{ theme: "light", size: "normal" }}
-                  />
-                </div>
-                <Button type="submit" className="w-full" disabled={loginLoading || !turnstileToken}>
-                  {loginLoading ? (
-                    <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Signing in...</>
-                  ) : !turnstileToken ? (
-                    "Verifying..."
-                  ) : (
-                    "Sign In & Check In"
-                  )}
-                </Button>
-              </form>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Matching shifts */}
-        {step === "matching" && (
-          <Card>
-            <CardContent className="pt-6 flex flex-col items-center gap-3">
-              <Loader2 className="h-8 w-8 animate-spin text-primary" />
-              <p className="text-muted-foreground">Finding your shift...</p>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* No shift found */}
-        {step === "no_shift" && (
-          <Card>
-            <CardContent className="pt-6 text-center space-y-3">
-              <Calendar className="h-10 w-10 text-muted-foreground mx-auto" />
-              <h3 className="font-semibold text-lg">No Shift Found</h3>
-              <p className="text-sm text-muted-foreground">
-                Hi {volunteerName}, you don't have any upcoming shifts scheduled for today. If you believe this is an error, please contact your coordinator.
-              </p>
-              <Button variant="outline" asChild>
-                <Link to="/dashboard">Go to Dashboard</Link>
-              </Button>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Already checked in */}
-        {step === "already" && (
-          <Card className="border-green-500">
-            <CardContent className="pt-6 text-center space-y-3">
-              <CheckCircle className="h-10 w-10 text-green-600 mx-auto" />
-              <h3 className="font-semibold text-lg">Already Checked In</h3>
-              <p className="text-sm text-muted-foreground">
-                Hi {volunteerName}, you've already checked in for all your shifts today. Thank you for volunteering!
-              </p>
-              <Button variant="outline" asChild>
-                <Link to="/dashboard">Go to Dashboard</Link>
-              </Button>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Confirm check-in */}
+        {step === "validating" && <ValidatingState />}
+        {step === "invalid" && <InvalidTokenState />}
+        {step === "login" && <LoginForm onLoginSuccess={handleLoginSuccess} />}
+        {step === "matching" && <MatchingState />}
+        {step === "no_shift" && <NoShiftState volunteerName={volunteerName} />}
+        {step === "already" && <AlreadyCheckedInState volunteerName={volunteerName} />}
         {step === "confirm" && (
-          <Card>
-            <CardHeader className="text-center">
-              <CardTitle>Confirm Check-In</CardTitle>
-              <CardDescription>
-                Welcome, {volunteerName}! {matchedShifts.length === 1
-                  ? "Please confirm your shift check-in."
-                  : `You have ${matchedShifts.length} slots today. Select one or check in to all.`}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {matchedShifts.map((shift) => (
-                <button
-                  key={shift.bookingId}
-                  onClick={() => handleCheckIn(shift)}
-                  className="w-full text-left rounded-lg border p-4 hover:bg-muted transition-colors space-y-2"
-                >
-                  <div className="flex items-center justify-between">
-                    <p className="font-medium">{shift.title}</p>
-                    <Badge variant="outline" className="text-xs">
-                      <MapPin className="h-3 w-3 mr-1" />
-                      {shift.departmentName}
-                    </Badge>
-                  </div>
-                  <div className="flex gap-4 text-sm text-muted-foreground">
-                    <span className="flex items-center gap-1">
-                      <Calendar className="h-3 w-3" />
-                      {format(new Date(shift.shiftDate + "T00:00:00"), "MMM d, yyyy")}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Clock className="h-3 w-3" />
-                      {shift.startTime} - {shift.endTime}
-                    </span>
-                  </div>
-                  <div className="text-xs text-primary font-medium">Tap to check in</div>
-                </button>
-              ))}
-
-              {matchedShifts.length > 1 && (
-                <Button className="w-full" onClick={handleCheckInAll}>
-                  <CheckCircle className="h-4 w-4 mr-2" />
-                  Check In to All {matchedShifts.length} Slots
-                </Button>
-              )}
-            </CardContent>
-          </Card>
+          <ConfirmCheckinScreen
+            volunteerName={volunteerName}
+            shifts={matchedShifts}
+            onCheckIn={handleCheckIn}
+            onCheckInAll={handleCheckInAll}
+          />
         )}
-
-        {/* Checking in... */}
-        {step === "checking_in" && (
-          <Card>
-            <CardContent className="pt-6 flex flex-col items-center gap-3">
-              <Loader2 className="h-8 w-8 animate-spin text-primary" />
-              <p className="text-muted-foreground">Checking you in...</p>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Success */}
+        {step === "checking_in" && <CheckinProgressState />}
         {step === "success" && (
-          <Card className="border-green-500">
-            <CardContent className="pt-6 text-center space-y-4">
-              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
-                <CheckCircle className="h-10 w-10 text-green-600" />
-              </div>
-              <h3 className="text-xl font-bold text-green-700">You're Checked In!</h3>
-              <p className="text-muted-foreground">
-                Thank you, {volunteerName}! Your check-in has been recorded.
-              </p>
-              {selectedShift && (
-                <div className="rounded-md border bg-muted/50 p-3 text-sm space-y-1">
-                  <p className="font-medium">{selectedShift.title}</p>
-                  <p className="text-muted-foreground">
-                    {selectedShift.startTime} - {selectedShift.endTime} | {selectedShift.departmentName}
-                  </p>
-                </div>
-              )}
-              {!selectedShift && matchedShifts.length > 1 && (
-                <div className="rounded-md border bg-muted/50 p-3 text-sm">
-                  <p className="font-medium">Checked in to {matchedShifts.length} slots</p>
-                </div>
-              )}
-              <p className="text-xs text-muted-foreground">
-                Checked in at {format(new Date(), "h:mm a")}
-              </p>
-              <Button variant="outline" asChild>
-                <Link to="/dashboard">Go to Dashboard</Link>
-              </Button>
-            </CardContent>
-          </Card>
+          <SuccessScreen
+            volunteerName={volunteerName}
+            shift={selectedShift}
+            multiSlotCount={matchedShifts.length}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

CheckIn was a 581-line page mixing token validation + login + MFA gate + shift matching with grace-window filtering + check-in mutation + coordinator notification fan-out + 9 different per-state UI blocks. This PR keeps the page as a thin **state-machine orchestrator** and moves the rest into 7 focused files. **Behavior is unchanged** — the existing 103 vitest tests all pass.

State-machine-driven pattern: page owns the `Step` union + supporting fields, network actions live in \`checkin-actions.ts\`, per-state UI is in component files, login form owns its own state. The existing `Step` union is preserved verbatim — no reshape into a discriminated-union state type. That cleaner shape is a Phase-5+ concern.

## Before / after

| Metric | Before | After |
|---|---|---|
| \`src/pages/CheckIn.tsx\` | **581** lines | **186** lines (-68%) |
| Total lines (page + new files) | 581 | 882 (+301 net) |
| Logic moved out of the page | — | ~400 lines |

## New files

| File | Lines | Role |
|---|---|---|
| \`src/lib/shift-time.ts\` (additions) | +25 | New `isWithinPostShiftGrace` helper as a **peer** to `isCheckInOpen` (not a replacement — different windows) |
| \`src/lib/checkin-actions.ts\` | 221 | Service functions: \`validateCheckinToken\`, \`resolveLoginIdentifierToEmail\`, \`fetchTodaysMatchedShifts\`, \`recordCheckin\`, \`notifyCoordinatorsOfCheckin\` |
| \`src/components/checkin/CheckinHeader.tsx\` | 17 | Shared logo/title |
| \`src/components/checkin/CheckinStateScreens.tsx\` | 98 | Six small per-state cards (Validating / InvalidToken / Matching / NoShift / AlreadyCheckedIn / CheckinProgress) |
| \`src/components/checkin/LoginForm.tsx\` | 156 | Owns form state + Turnstile + signInWithPassword + MFA gate |
| \`src/components/checkin/ConfirmCheckinScreen.tsx\` | 68 | Shift picker + "Check In to All" button |
| \`src/components/checkin/SuccessScreen.tsx\` | 53 | Success card with shift detail or multi-slot summary |

## Sensitive-ops sequence preserved

The validation/write order is preserved as **page-level orchestration**. Each numbered step is a separate page-level call into \`checkin-actions.ts\`; no wrapper combines steps:

1. \`validateCheckinToken\` (RPC) — gate at mount
2. **session check** — if absent, transition to login
3. **login** (LoginForm) — \`signInWithPassword\` + MFA gate. *MFA gate stays inside LoginForm because it's the second half of the auth transaction; splitting it across files would change the unit.*
4. \`fetchTodaysMatchedShifts\` — applies post-shift 30-min grace filter
5. \`recordCheckin\` — supabase update first
6. \`notifyCoordinatorsOfCheckin\` — best-effort fan-out (failure doesn't block)

## Time-window logic decision

CheckIn's post-shift 30-min grace and \`shift-time.ts\`'s pre-shift \`isCheckInOpen\` are **bit-different windows for different problems**:

- \`isCheckInOpen\` (Dashboard "Check In" button): \`[start − 30min, end]\` — no late check-in past end.
- \`isWithinPostShiftGrace\` (QR check-in page): allows check-in for 30 min **past** end; no pre-shift gate.

Bit-equivalence check failed. Added \`isWithinPostShiftGrace\` as a **peer** in \`shift-time.ts\` rather than unifying. No follow-up issue needed — these are intentionally different windows.

## Type debt — `as` casts that landed in new code

| Location | Cast | Why |
|---|---|---|
| \`checkin-actions.ts:112\` | \`((data as any[]) \|\| []) as BookingRow[]\` | Embedded select boundary — same documented pattern as PRs #125 / #127 / #129 / #130 |
| \`checkin-actions.ts:220\` | \`notifications as never\` | Json type narrowness on the notifications insert — same pattern as \`booking-actions.ts\` in PR #125 |

\`useState<any>(null)\` for `user` was narrowed to `User | null` from `@supabase/supabase-js` (structural cleanup required for clean extraction; same precedent as \`validateAddUser\` reshape in PR #130).

## Verification

- [x] \`npx tsc --build\` — clean
- [x] \`npx eslint . --max-warnings=0\` — clean
- [x] \`npx vitest run\` — 103/103 passing
- [ ] Playwright E2E — runs in CI on this PR

---

## 🎯 Phase 4 complete — five-PR cumulative metrics

| PR | Page | Before | After | Reduction | New files |
|---|---|---|---|---|---|
| [#125](https://github.com/sabihusman/easterseals-volunteer-scheduler/pull/125) | VolunteerDashboard | 941 | 321 | -66% | 13 |
| [#127](https://github.com/sabihusman/easterseals-volunteer-scheduler/pull/127) | Settings | 1016 | 99 | -90% | 11 |
| [#129](https://github.com/sabihusman/easterseals-volunteer-scheduler/pull/129) | ManageShifts | 662 | 110 | -83% | 5 |
| [#130](https://github.com/sabihusman/easterseals-volunteer-scheduler/pull/130) | AdminUsers | 678 | 260 | -62% | 8 |
| [#131](https://github.com/sabihusman/easterseals-volunteer-scheduler/pull/131) | CheckIn (this) | 581 | 186 | -68% | 7 |
| **Totals** | **5 god components** | **3,878** | **976** | **-75% (-2,902 lines)** | **44** |

**Boundary cast surface across all five PRs:** **16 new casts** total — 8 (#125), 4 (#127), 1 (#129), 1 (#130), 2 (#131). Every new cast is at a supabase type-system boundary; same documented pattern as \`(supabase as any).rpc()\` in \`eslint.config.js\`.

**Five god components decomposed.** Page-level line count cut by 75%. ~2,902 lines of mixed responsibility moved into ~44 focused files (hooks, lib utilities, presentational components, and panels-own-state forms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)