### PR TITLE
test: auth flow coverage (Phase 5b Tier 1)

### DIFF
--- a/src/pages/__tests__/Auth.test.tsx
+++ b/src/pages/__tests__/Auth.test.tsx
@@ -1,0 +1,380 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+/**
+ * Tier 1 auth tests for Auth (Sign In + Register tabs).
+ *
+ * Mocked: supabase.auth.* + rpc + from(...).insert + signInWithOAuth,
+ * Turnstile widget, react-router-dom navigate/location/Link, useToast,
+ * sendEmail (fire-and-forget welcome email on register).
+ *
+ * Sign In:
+ *   - Username identifier resolves through `get_email_by_username` RPC.
+ *   - Username-not-found returns generic "Invalid credentials" — verified
+ *     literally to guard against email-enumeration regressions.
+ *   - MFA AAL check after sign-in routes to /mfa-verify when step-up is needed.
+ *
+ * Register:
+ *   - Zod validates name/email/username/password; we drive the schema
+ *     errors through specific field-level inputs.
+ *   - Username availability RPC + TOS + Turnstile must all be true.
+ *
+ * The dead `showReset` branch (lines 205–243 of Auth.tsx) is intentionally
+ * not tested — it's unreachable. Tracked separately as a follow-up issue.
+ */
+
+const signInWithPasswordMock = vi.fn();
+const signUpMock = vi.fn();
+const getAALMock = vi.fn();
+const signInWithOAuthMock = vi.fn();
+const rpcMock = vi.fn();
+const insertMock = vi.fn();
+const sendEmailMock = vi.fn();
+const navigateMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: (...args: unknown[]) => signInWithPasswordMock(...args),
+      signUp: (...args: unknown[]) => signUpMock(...args),
+      signInWithOAuth: (...args: unknown[]) => signInWithOAuthMock(...args),
+      mfa: {
+        getAuthenticatorAssuranceLevel: (...args: unknown[]) => getAALMock(...args),
+      },
+    },
+    rpc: (...args: unknown[]) => rpcMock(...args),
+    from: () => ({
+      insert: (...args: unknown[]) => insertMock(...args),
+    }),
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/lib/email-utils", () => ({
+  sendEmail: (...args: unknown[]) => sendEmailMock(...args),
+}));
+
+vi.mock("@marsidev/react-turnstile", () => ({
+  Turnstile: (props: { onSuccess: (t: string) => void }) => (
+    <button type="button" onClick={() => props.onSuccess("mock-turnstile-token")}>
+      Mock Turnstile
+    </button>
+  ),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useLocation: () => ({ pathname: "/auth", state: null, search: "", hash: "", key: "" }),
+    Link: ({ children, to }: { children: React.ReactNode; to: string }) => <a href={to}>{children}</a>,
+  };
+});
+
+import Auth from "@/pages/Auth";
+
+beforeEach(() => {
+  signInWithPasswordMock.mockReset();
+  signUpMock.mockReset();
+  getAALMock.mockReset();
+  signInWithOAuthMock.mockReset();
+  rpcMock.mockReset();
+  insertMock.mockReset();
+  sendEmailMock.mockReset();
+  navigateMock.mockReset();
+  toastMock.mockReset();
+  // Default: no MFA step-up required.
+  getAALMock.mockResolvedValue({
+    data: { currentLevel: "aal1", nextLevel: "aal1" },
+    error: null,
+  });
+  sendEmailMock.mockResolvedValue(undefined);
+});
+
+function clickTurnstile() {
+  fireEvent.click(screen.getAllByRole("button", { name: /mock turnstile/i })[0]);
+}
+
+/**
+ * Direct id-based queries. Auth.tsx gives every input an explicit id, and
+ * Radix Tabs unmounts inactive tab content, so an id-by-id approach is
+ * deterministic across the tab switch in a way label-text queries are not.
+ */
+function getInput(id: string): HTMLInputElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`Input #${id} not in DOM`);
+  return el as HTMLInputElement;
+}
+
+function fillLogin(identifier: string, password: string) {
+  fireEvent.change(getInput("login-identifier"), { target: { value: identifier } });
+  fireEvent.change(getInput("login-password"), { target: { value: password } });
+}
+
+/**
+ * Submit a form via fireEvent.submit on its <form> ancestor. The submit
+ * button text changes based on Turnstile state ("Sign In" → "Verifying..." →
+ * "Signing in...") so a button-text query is fragile; the form-submit path
+ * dispatches the same onSubmit handler regardless.
+ */
+function submitFormContaining(input: HTMLElement) {
+  const form = input.closest("form");
+  if (!form) throw new Error("Input is not inside a form");
+  fireEvent.submit(form);
+}
+
+function fillRegister(opts: Partial<{ name: string; email: string; username: string; password: string; tos: boolean }>) {
+  if (opts.name !== undefined) {
+    fireEvent.change(getInput("reg-name"), { target: { value: opts.name } });
+  }
+  if (opts.email !== undefined) {
+    fireEvent.change(getInput("reg-email"), { target: { value: opts.email } });
+  }
+  if (opts.username !== undefined) {
+    fireEvent.change(getInput("reg-username"), { target: { value: opts.username } });
+  }
+  if (opts.password !== undefined) {
+    fireEvent.change(getInput("reg-password"), { target: { value: opts.password } });
+  }
+  if (opts.tos) {
+    fireEvent.click(screen.getByRole("checkbox", { name: /terms of service/i }));
+  }
+}
+
+describe("Auth — Sign In tab", () => {
+  it("renders sign-in form by default with identifier and password fields", () => {
+    render(<Auth />);
+    expect(getInput("login-identifier")).toBeInTheDocument();
+    expect(getInput("login-password")).toBeInTheDocument();
+  });
+
+  it("shows verification toast and skips sign-in when no Turnstile token", () => {
+    render(<Auth />);
+    fillLogin("vol@example.com", "secret123");
+    submitFormContaining(getInput("login-identifier"));
+    expect(signInWithPasswordMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringMatching(/verification required/i),
+    }));
+  });
+
+  it("signs in with email identifier and navigates to / on success", async () => {
+    signInWithPasswordMock.mockResolvedValue({ error: null });
+    render(<Auth />);
+    fillLogin("vol@example.com", "secret123");
+    clickTurnstile();
+    fireEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(signInWithPasswordMock).toHaveBeenCalledWith({
+        email: "vol@example.com",
+        password: "secret123",
+        options: { captchaToken: "mock-turnstile-token" },
+      });
+      expect(navigateMock).toHaveBeenCalledWith("/");
+    });
+    expect(rpcMock).not.toHaveBeenCalled(); // email shouldn't trigger the username-resolve RPC
+  });
+
+  it("resolves username via RPC then signs in with the resolved email", async () => {
+    rpcMock.mockResolvedValue({ data: "vol@example.com", error: null });
+    signInWithPasswordMock.mockResolvedValue({ error: null });
+    render(<Auth />);
+    fillLogin("jane_doe", "secret123");
+    clickTurnstile();
+    fireEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith("get_email_by_username", { p_username: "jane_doe" });
+      expect(signInWithPasswordMock).toHaveBeenCalledWith(expect.objectContaining({
+        email: "vol@example.com",
+      }));
+    });
+  });
+
+  it("shows generic 'Invalid credentials' when username is not found (no enumeration leak)", async () => {
+    rpcMock.mockResolvedValue({ data: null, error: null });
+    render(<Auth />);
+    fillLogin("ghost_user", "secret123");
+    clickTurnstile();
+    fireEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Login failed",
+        description: "Invalid credentials.",
+        variant: "destructive",
+      }));
+    });
+    expect(signInWithPasswordMock).not.toHaveBeenCalled();
+    // Guard against any leak of "user not found" / "no such user" / username-specific copy.
+    const allDescs = toastMock.mock.calls.map((c) => (c[0] as { description?: string }).description);
+    expect(allDescs.every((d) => !/not found|no such|user/i.test(d || ""))).toBe(true);
+  });
+
+  it("shows 'Login failed' toast when signInWithPassword returns an error", async () => {
+    signInWithPasswordMock.mockResolvedValue({ error: { message: "wrong password" } });
+    render(<Auth />);
+    fillLogin("vol@example.com", "wrongpass");
+    clickTurnstile();
+    fireEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Login failed",
+        description: "Invalid credentials.",
+        variant: "destructive",
+      }));
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("navigates to /mfa-verify when MFA step-up is required after sign-in", async () => {
+    signInWithPasswordMock.mockResolvedValue({ error: null });
+    getAALMock.mockResolvedValue({
+      data: { currentLevel: "aal1", nextLevel: "aal2" },
+      error: null,
+    });
+    render(<Auth />);
+    fillLogin("vol@example.com", "secret123");
+    clickTurnstile();
+    fireEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith("/mfa-verify");
+    });
+  });
+});
+
+describe("Auth — Register tab", () => {
+  /**
+   * Radix Tabs trigger value changes via onMouseDown (NOT onClick) — this
+   * is in the Radix source. fireEvent.click silently no-ops on tab triggers.
+   * Use mouseDown + click for full simulation.
+   */
+  async function switchToRegister() {
+    const trigger = screen.getByRole("tab", { name: /register/i });
+    fireEvent.mouseDown(trigger);
+    fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(document.getElementById("reg-name")).not.toBeNull();
+    });
+  }
+
+  it("reveals the registration form when the Register tab is clicked", async () => {
+    render(<Auth />);
+    await switchToRegister();
+    expect(getInput("reg-name")).toBeInTheDocument();
+    expect(getInput("reg-email")).toBeInTheDocument();
+    expect(getInput("reg-username")).toBeInTheDocument();
+  });
+
+  it("renders zod field errors when the form is empty on submit", async () => {
+    render(<Auth />);
+    await switchToRegister();
+    submitFormContaining(getInput("reg-name"));
+    expect(screen.getByText(/full name is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/invalid email address/i)).toBeInTheDocument();
+    // zod fires the regex check before the min-length check on empty input,
+    // so the username error here is "letters, numbers, and underscores".
+    // We assert that *some* username-side error rendered rather than pinning
+    // to one of the three possible messages.
+    // Helper text below the username field says "3-30 characters, letters,
+    // numbers, and underscores only" — so a /letters, numbers/i match also
+    // catches the helper. Assert at least 2 matches when the error renders
+    // alongside it, or 1 match for the min-length variant.
+    const minLenErr = screen.queryByText(/username must be at least 3/i);
+    const regexErr = screen.queryAllByText(/letters, numbers, and underscores/i);
+    expect(minLenErr !== null || regexErr.length >= 2).toBe(true);
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("renders email error for invalid email format", async () => {
+    render(<Auth />);
+    await switchToRegister();
+    fillRegister({ name: "Jane", email: "not-an-email", username: "jane_d", password: "abcd1234" });
+    submitFormContaining(getInput("reg-name"));
+    expect(screen.getByText(/invalid email address/i)).toBeInTheDocument();
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("renders password error when password lacks a digit", async () => {
+    render(<Auth />);
+    await switchToRegister();
+    fillRegister({ name: "Jane", email: "j@example.com", username: "jane_d", password: "noDigitsHere" });
+    submitFormContaining(getInput("reg-name"));
+    expect(screen.getByText(/must contain at least one number/i)).toBeInTheDocument();
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("registers successfully when validation, username availability, TOS, and Turnstile all pass", async () => {
+    rpcMock.mockResolvedValue({ data: true, error: null }); // username_available → true
+    signUpMock.mockResolvedValue({ data: { user: { id: "new-user-id" } }, error: null });
+    insertMock.mockResolvedValue({ error: null });
+
+    render(<Auth />);
+    await switchToRegister();
+    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234", tos: true });
+    clickTurnstile();
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith("username_available", { p_username: "jane_doe" });
+      expect(signUpMock).toHaveBeenCalledWith(expect.objectContaining({
+        email: "jane@example.com",
+        password: "abcd1234",
+      }));
+      expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({
+        id: "new-user-id",
+        email: "jane@example.com",
+        username: "jane_doe",
+        full_name: "Jane Doe",
+        role: "volunteer",
+      }));
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Account created",
+      }));
+    });
+    // Welcome email is fire-and-forget — we don't await it but it should be invoked.
+    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+      to: "jane@example.com",
+      type: "registration_welcome",
+    }));
+  });
+
+  it("shows username-taken error and skips signUp when RPC returns not-available", async () => {
+    rpcMock.mockResolvedValue({ data: false, error: null });
+    render(<Auth />);
+    await switchToRegister();
+    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234", tos: true });
+    clickTurnstile();
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/username is already taken/i)).toBeInTheDocument();
+    });
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("shows toast and skips signUp when TOS is not accepted", async () => {
+    rpcMock.mockResolvedValue({ data: true, error: null });
+    render(<Auth />);
+    await switchToRegister();
+    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234" });
+    // Skip TOS click intentionally.
+    clickTurnstile();
+    submitFormContaining(getInput("reg-name"));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: expect.stringMatching(/terms required/i),
+      }));
+    });
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/__tests__/ForgotPassword.test.tsx
+++ b/src/pages/__tests__/ForgotPassword.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+/**
+ * Tier 1 auth flow tests for ForgotPassword.
+ *
+ * Mocked: supabase client, Turnstile widget, react-router-dom, useToast.
+ * Each test asserts a single observable behavior — what supabase was called
+ * with, what toast was fired, or what UI state is visible.
+ */
+
+const resetPasswordForEmailMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      resetPasswordForEmail: (...args: unknown[]) => resetPasswordForEmailMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+// Turnstile renders as a button; clicking it simulates a successful captcha.
+vi.mock("@marsidev/react-turnstile", () => ({
+  Turnstile: (props: { onSuccess: (t: string) => void }) => (
+    <button type="button" onClick={() => props.onSuccess("mock-turnstile-token")}>
+      Mock Turnstile
+    </button>
+  ),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    Link: ({ children, to }: { children: React.ReactNode; to: string }) => <a href={to}>{children}</a>,
+  };
+});
+
+import ForgotPassword from "@/pages/ForgotPassword";
+
+beforeEach(() => {
+  resetPasswordForEmailMock.mockReset();
+  toastMock.mockReset();
+});
+
+describe("ForgotPassword", () => {
+  it("renders the email field and Turnstile widget", () => {
+    render(<ForgotPassword />);
+    expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /mock turnstile/i })).toBeInTheDocument();
+    // Submit is disabled until the captcha succeeds.
+    expect(screen.getByRole("button", { name: /verifying/i })).toBeDisabled();
+  });
+
+  it("shows verification toast and skips supabase when no Turnstile token", () => {
+    render(<ForgotPassword />);
+    const form = screen.getByLabelText(/email address/i).closest("form")!;
+    fireEvent.submit(form);
+    expect(resetPasswordForEmailMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringMatching(/verification required/i),
+      variant: "destructive",
+    }));
+  });
+
+  it("calls resetPasswordForEmail and shows the sent state on success", async () => {
+    resetPasswordForEmailMock.mockResolvedValue({ error: null });
+    render(<ForgotPassword />);
+
+    fireEvent.change(screen.getByLabelText(/email address/i), {
+      target: { value: "vol@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /mock turnstile/i }));
+    fireEvent.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(resetPasswordForEmailMock).toHaveBeenCalledWith(
+        "vol@example.com",
+        expect.objectContaining({ captchaToken: "mock-turnstile-token" }),
+      );
+    });
+    // Sent state — generic copy not promising "we sent it" but "if account exists you'll get one".
+    expect(await screen.findByText(/if an account exists/i)).toBeInTheDocument();
+  });
+
+  it("shows error toast and does NOT show the sent state on supabase error", async () => {
+    resetPasswordForEmailMock.mockResolvedValue({ error: { message: "rate limited" } });
+    render(<ForgotPassword />);
+
+    fireEvent.change(screen.getByLabelText(/email address/i), {
+      target: { value: "vol@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /mock turnstile/i }));
+    fireEvent.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Error",
+        description: "rate limited",
+        variant: "destructive",
+      }));
+    });
+    expect(screen.queryByText(/if an account exists/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/MfaVerify.test.tsx
+++ b/src/pages/__tests__/MfaVerify.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+/**
+ * Tier 1 auth tests for MfaVerify.
+ *
+ * The page mounts → fetches AAL → fetches factors → either redirects
+ * (already aal2 / no aal2 needed) or renders the 6-digit form. Recovery
+ * mode submits a backup code via the `mfa-recovery` edge function.
+ *
+ * Mocked: supabase.auth.mfa.* + functions.invoke + auth.signOut, navigate, toast.
+ */
+
+const getAALMock = vi.fn();
+const listFactorsMock = vi.fn();
+const challengeMock = vi.fn();
+const verifyMock = vi.fn();
+const signOutMock = vi.fn();
+const invokeMock = vi.fn();
+const navigateMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      mfa: {
+        getAuthenticatorAssuranceLevel: (...args: unknown[]) => getAALMock(...args),
+        listFactors: (...args: unknown[]) => listFactorsMock(...args),
+        challenge: (...args: unknown[]) => challengeMock(...args),
+        verify: (...args: unknown[]) => verifyMock(...args),
+      },
+      signOut: (...args: unknown[]) => signOutMock(...args),
+    },
+    functions: {
+      invoke: (...args: unknown[]) => invokeMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+import MfaVerify from "@/pages/MfaVerify";
+
+const verifiedFactor = { id: "totp-factor-1", status: "verified", factor_type: "totp" };
+
+beforeEach(() => {
+  getAALMock.mockReset();
+  listFactorsMock.mockReset();
+  challengeMock.mockReset();
+  verifyMock.mockReset();
+  signOutMock.mockReset();
+  invokeMock.mockReset();
+  navigateMock.mockReset();
+  toastMock.mockReset();
+
+  // Sensible defaults — tests override per-case.
+  getAALMock.mockResolvedValue({
+    data: { currentLevel: "aal1", nextLevel: "aal2" },
+    error: null,
+  });
+  listFactorsMock.mockResolvedValue({
+    data: { totp: [verifiedFactor] },
+    error: null,
+  });
+  signOutMock.mockResolvedValue({ error: null });
+});
+
+describe("MfaVerify", () => {
+  it("renders the 6-digit code form when MFA challenge is required", async () => {
+    render(<MfaVerify />);
+    expect(await screen.findByPlaceholderText("000000")).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /dashboard when AAL is already aal2", async () => {
+    getAALMock.mockResolvedValue({
+      data: { currentLevel: "aal2", nextLevel: "aal2" },
+      error: null,
+    });
+    render(<MfaVerify />);
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("redirects to /dashboard when nextLevel is not aal2", async () => {
+    getAALMock.mockResolvedValue({
+      data: { currentLevel: "aal1", nextLevel: "aal1" },
+      error: null,
+    });
+    render(<MfaVerify />);
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("calls challenge + verify and navigates to /dashboard on valid 6-digit code", async () => {
+    challengeMock.mockResolvedValue({ data: { id: "challenge-1" }, error: null });
+    verifyMock.mockResolvedValue({ data: {}, error: null });
+    render(<MfaVerify />);
+
+    const input = await screen.findByPlaceholderText("000000");
+    fireEvent.change(input, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /^verify$/i }));
+
+    await waitFor(() => {
+      expect(challengeMock).toHaveBeenCalledWith({ factorId: "totp-factor-1" });
+      expect(verifyMock).toHaveBeenCalledWith({
+        factorId: "totp-factor-1",
+        challengeId: "challenge-1",
+        code: "123456",
+      });
+      expect(navigateMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("shows error toast and clears the code field on verify error", async () => {
+    challengeMock.mockResolvedValue({ data: { id: "challenge-1" }, error: null });
+    verifyMock.mockResolvedValue({ data: null, error: { message: "wrong code" } });
+    render(<MfaVerify />);
+
+    const input = await screen.findByPlaceholderText("000000");
+    fireEvent.change(input, { target: { value: "999999" } });
+    fireEvent.click(screen.getByRole("button", { name: /^verify$/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Verification failed",
+        variant: "destructive",
+      }));
+    });
+    // UX guard: the field is cleared so the user can retry without manually deleting.
+    expect((input as HTMLInputElement).value).toBe("");
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the backup-code form when recovery mode is toggled", async () => {
+    render(<MfaVerify />);
+    await screen.findByPlaceholderText("000000");
+    fireEvent.click(screen.getByRole("button", { name: /backup recovery code/i }));
+    expect(screen.getByPlaceholderText("XXXX-XXXX")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("000000")).not.toBeInTheDocument();
+  });
+
+  it("calls mfa-recovery edge function when backup code is submitted", async () => {
+    invokeMock.mockResolvedValue({ data: { success: true }, error: null });
+    render(<MfaVerify />);
+    await screen.findByPlaceholderText("000000");
+    fireEvent.click(screen.getByRole("button", { name: /backup recovery code/i }));
+
+    fireEvent.change(screen.getByPlaceholderText("XXXX-XXXX"), {
+      target: { value: "ABCD1234" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /use recovery code/i }));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("mfa-recovery", {
+        body: { code: "ABCD1234" },
+      });
+    });
+  });
+
+  it("signs out and navigates to /auth on successful recovery", async () => {
+    invokeMock.mockResolvedValue({ data: { success: true }, error: null });
+    render(<MfaVerify />);
+    await screen.findByPlaceholderText("000000");
+    fireEvent.click(screen.getByRole("button", { name: /backup recovery code/i }));
+
+    fireEvent.change(screen.getByPlaceholderText("XXXX-XXXX"), {
+      target: { value: "ABCD1234" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /use recovery code/i }));
+
+    await waitFor(() => {
+      expect(signOutMock).toHaveBeenCalled();
+      expect(navigateMock).toHaveBeenCalledWith("/auth");
+    });
+  });
+
+  it("shows error toast and clears recovery code on invalid backup code", async () => {
+    invokeMock.mockResolvedValue({ data: { success: false }, error: null });
+    render(<MfaVerify />);
+    await screen.findByPlaceholderText("000000");
+    fireEvent.click(screen.getByRole("button", { name: /backup recovery code/i }));
+
+    const input = screen.getByPlaceholderText("XXXX-XXXX");
+    fireEvent.change(input, { target: { value: "BADCODE1" } });
+    fireEvent.click(screen.getByRole("button", { name: /use recovery code/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Invalid recovery code",
+        variant: "destructive",
+      }));
+    });
+    expect((input as HTMLInputElement).value).toBe("");
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/__tests__/ResetPassword.test.tsx
+++ b/src/pages/__tests__/ResetPassword.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+/**
+ * Tier 1 auth tests for ResetPassword.
+ *
+ * Mocked: supabase auth.updateUser, react-router-dom navigate + Link, toast.
+ * The page is hash-gated (`#type=recovery`) — tests set the hash before
+ * mount via a helper.
+ *
+ * The success path schedules a 2s setTimeout to navigate. We spy on
+ * window.setTimeout and invoke the captured callback manually rather
+ * than mixing fake timers with async work — cleaner and deterministic.
+ */
+
+const updateUserMock = vi.fn();
+const navigateMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      updateUser: (...args: unknown[]) => updateUserMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    Link: ({ children, to }: { children: React.ReactNode; to: string }) => <a href={to}>{children}</a>,
+  };
+});
+
+import ResetPassword from "@/pages/ResetPassword";
+
+function setHash(hash: string) {
+  // jsdom's location.hash is writable
+  window.location.hash = hash;
+}
+
+beforeEach(() => {
+  updateUserMock.mockReset();
+  navigateMock.mockReset();
+  toastMock.mockReset();
+  setHash("");
+});
+
+function fillForm(password: string, confirm: string) {
+  fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: password } });
+  fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: confirm } });
+}
+
+describe("ResetPassword", () => {
+  it("shows invalid-link card when hash does not contain type=recovery", () => {
+    setHash(""); // no recovery flag
+    render(<ResetPassword />);
+    expect(screen.getByText(/this reset link has expired or is invalid/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /request a new reset link/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^new password$/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the password form when hash contains type=recovery", () => {
+    setHash("#access_token=abc&type=recovery");
+    render(<ResetPassword />);
+    expect(screen.getByLabelText(/^new password$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm new password/i)).toBeInTheDocument();
+  });
+
+  it("disables submit when password is shorter than 8 characters", () => {
+    setHash("#type=recovery");
+    render(<ResetPassword />);
+    fillForm("abc1", "abc1");
+    expect(screen.getByRole("button", { name: /update password/i })).toBeDisabled();
+  });
+
+  it("disables submit when password lacks a letter", () => {
+    setHash("#type=recovery");
+    render(<ResetPassword />);
+    fillForm("12345678", "12345678");
+    expect(screen.getByRole("button", { name: /update password/i })).toBeDisabled();
+  });
+
+  it("disables submit when password lacks a digit", () => {
+    setHash("#type=recovery");
+    render(<ResetPassword />);
+    fillForm("abcdefgh", "abcdefgh");
+    expect(screen.getByRole("button", { name: /update password/i })).toBeDisabled();
+  });
+
+  it("shows mismatch error and disables submit when passwords do not match", () => {
+    setHash("#type=recovery");
+    render(<ResetPassword />);
+    fillForm("abcd1234", "different1");
+    expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /update password/i })).toBeDisabled();
+  });
+
+  it("calls updateUser, shows success state, and schedules a 2s redirect on submit success", async () => {
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+    updateUserMock.mockResolvedValue({ error: null });
+    setHash("#type=recovery");
+    render(<ResetPassword />);
+
+    fillForm("validpw1", "validpw1");
+    fireEvent.click(screen.getByRole("button", { name: /update password/i }));
+
+    await waitFor(() => {
+      expect(updateUserMock).toHaveBeenCalledWith({ password: "validpw1" });
+    });
+    expect(await screen.findByText(/password updated successfully/i)).toBeInTheDocument();
+
+    // The redirect is scheduled with setTimeout(..., 2000) but hasn't fired yet.
+    expect(navigateMock).not.toHaveBeenCalled();
+    const redirectCall = setTimeoutSpy.mock.calls.find((c) => c[1] === 2000);
+    expect(redirectCall).toBeDefined();
+
+    // Manually invoke the scheduled callback — confirms it would navigate.
+    const callback = redirectCall![0] as () => void;
+    callback();
+    expect(navigateMock).toHaveBeenCalledWith("/dashboard");
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("shows error toast and stays on form on supabase error", async () => {
+    updateUserMock.mockResolvedValue({ error: { message: "session expired" } });
+    setHash("#type=recovery");
+    render(<ResetPassword />);
+
+    fillForm("validpw1", "validpw1");
+    fireEvent.click(screen.getByRole("button", { name: /update password/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Error",
+        description: "session expired",
+        variant: "destructive",
+      }));
+    });
+    expect(screen.queryByText(/password updated successfully/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -13,3 +13,15 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: () => false,
   }),
 });
+
+// jsdom 20 doesn't provide ResizeObserver, but Radix UI primitives
+// (Checkbox, Tabs, Select, …) read it during their layout effects. Without
+// this stub, mounting any of those crashes the test render. Same role as
+// the matchMedia stub above — purely a test-environment polyfill.
+class ResizeObserverStub implements ResizeObserver {
+  constructor(_callback: ResizeObserverCallback) { void _callback; }
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver = ResizeObserverStub;


### PR DESCRIPTION
## Summary

React Testing Library coverage for the four auth pages. Test count rises from 103 to 138 (+35 tests, +4 test files). No production code changed; one test-infrastructure addition (ResizeObserver polyfill in \`setup.ts\`).

## Pages covered

| Page | Tests | Notes |
|---|---|---|
| \`Auth.tsx\` | 14 | Sign In + Register tabs (dead \`showReset\` branch intentionally not tested — see #134) |
| \`MfaVerify.tsx\` | 9 | TOTP code entry + recovery-code fallback |
| \`ForgotPassword.tsx\` | 4 | Email + Turnstile → \`resetPasswordForEmail\` |
| \`ResetPassword.tsx\` | 8 | Hash-gated form + strength meter |

## Test count delta

**103 → 138** (+35 tests). 8 → 12 test files.

## Mocked surfaces

| Module | Mock |
|---|---|
| \`@/integrations/supabase/client\` | \`auth.signInWithPassword/signUp/signOut/signInWithOAuth/resetPasswordForEmail/updateUser\`, \`auth.mfa.getAuthenticatorAssuranceLevel/listFactors/challenge/verify\`, \`from(...).insert\`, \`rpc(...)\`, \`functions.invoke(...)\` |
| \`@marsidev/react-turnstile\` | Rendered as a \`<button>\` that fires \`onSuccess("mock-turnstile-token")\` on click |
| \`react-router-dom\` | \`useNavigate\` / \`useLocation\` / \`Link\` |
| \`@/hooks/use-toast\` | \`toast\` spy |
| \`@/lib/email-utils\` | \`sendEmail\` (fire-and-forget welcome email on register) |

Module-level \`vi.mock\` matching the precedent in \`useUnreadCount.test.tsx\`. No \`@testing-library/user-event\` (not installed; uses \`fireEvent\` per project rules).

## Test infrastructure change

\`src/test/setup.ts\` gains a \`ResizeObserver\` polyfill stub. Radix UI Checkbox / Tabs / Select primitives read \`ResizeObserver\` during their layout effects; jsdom 20 doesn't provide it. Same pattern as the \`matchMedia\` stub already in the file. **Test-environment-only — no runtime behavior change.**

## Notable test patterns documented inline

- **Radix Tabs trigger value changes via \`onMouseDown\`, not \`onClick\`.** The \`switchToRegister\` helper fires both events, then \`waitFor\`s the register form to mount.
- **Submit-button text is Turnstile-state dependent** (\`"Sign In"\` → \`"Verifying..."\` → \`"Signing in..."\`). Tests use \`fireEvent.submit\` on the form ancestor rather than button-text queries — same handler regardless of label.
- **ResetPassword's 2-second setTimeout redirect** is verified by spying on \`window.setTimeout\` and asserting the 2000ms call was scheduled, then invoking the captured callback manually. Cleaner than mixing fake timers with async work.

## Security guard verifications

- **Auth.tsx test #5** confirms the username-not-found path returns the generic "Invalid credentials" toast (no email-enumeration leak). Asserts no toast description matches \`/not found|no such|user/i\`.
- **MfaVerify.tsx test #5** confirms the verify-error path clears the code field for retry — the UX guard exists in production code.

## Surfaced and filed (not fixed)

- [#134](https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/134): \`Auth.tsx\` contains a dead \`showReset\` reset-password branch. \`showReset\` is never set to \`true\`; the "Forgot your password?" link routes to \`/forgot-password\` (a separate page) instead. ~40 lines of unreachable JSX. Cleanup, not a bug.

## Verification

- [x] \`npx tsc --build\` — clean
- [x] \`npx eslint . --max-warnings=0\` — clean
- [x] \`npx vitest run\` — **138/138 passing**

## Phase 5b status

**Tier 1 complete. Tier 2 (highest-stakes panels) is next.**

Tier 2 will cover: \`MfaPanel\`, \`DeleteAccountPanel\`, \`ProfilePanel\` (settings/), \`AddUserDialog\`, \`RoleChangeDialog\` (admin/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)