### PR TITLE
test: highest-stakes panel coverage (Phase 5b Tier 2)

### DIFF
--- a/src/components/admin/__tests__/AddUserDialog.test.tsx
+++ b/src/components/admin/__tests__/AddUserDialog.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+/**
+ * Tier 2 test for AddUserDialog.
+ *
+ * Validates: form validation, admin cap enforcement, signUp + profiles.insert
+ * flow, 23505 unique-violation handling (admin sees clear message — text
+ * content asserted, not just toast call), and the form ↔ credentials view
+ * lifecycle.
+ *
+ * generatePassword is mocked to a known string so credential assertions
+ * are deterministic.
+ */
+
+const signUpMock = vi.fn();
+const insertMock = vi.fn();
+const toastMock = vi.fn();
+const onUserCreatedMock = vi.fn();
+const onOpenChangeMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      signUp: (...args: unknown[]) => signUpMock(...args),
+    },
+    from: () => ({
+      insert: (...args: unknown[]) => insertMock(...args),
+    }),
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/lib/admin-user-utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/admin-user-utils")>(
+    "@/lib/admin-user-utils"
+  );
+  return {
+    ...actual,
+    generatePassword: () => "GENERATED-PW-FIXED",
+  };
+});
+
+import { AddUserDialog } from "@/components/admin/AddUserDialog";
+
+beforeEach(() => {
+  signUpMock.mockReset();
+  insertMock.mockReset();
+  toastMock.mockReset();
+  onUserCreatedMock.mockReset();
+  onOpenChangeMock.mockReset();
+});
+
+function renderOpen(adminCount = 0) {
+  return render(
+    <AddUserDialog
+      open={true}
+      onOpenChange={onOpenChangeMock}
+      adminCount={adminCount}
+      onUserCreated={onUserCreatedMock}
+    />
+  );
+}
+
+function fillForm({ name, email }: { name: string; email: string }) {
+  const dialog = screen.getByRole("dialog");
+  fireEvent.change(within(dialog).getByPlaceholderText("Jane Smith"), { target: { value: name } });
+  fireEvent.change(within(dialog).getByPlaceholderText("jane@example.com"), { target: { value: email } });
+}
+
+function clickCreate() {
+  fireEvent.click(screen.getByRole("button", { name: /create user/i }));
+}
+
+describe("AddUserDialog", () => {
+  it("rejects empty name with a visible error and does not call signUp", () => {
+    renderOpen();
+    fillForm({ name: "", email: "valid@example.com" });
+    clickCreate();
+    expect(screen.getByText(/name must be 2.*100 characters/i)).toBeInTheDocument();
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid email format with a visible error and does not call signUp", () => {
+    renderOpen();
+    fillForm({ name: "Jane Doe", email: "not-an-email" });
+    clickCreate();
+    expect(screen.getByText(/enter a valid email/i)).toBeInTheDocument();
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks creating a 3rd admin when adminCount=2 (cap enforcement)", async () => {
+    renderOpen(2);
+    fillForm({ name: "Third Admin", email: "third@example.com" });
+    // Radix Select doesn't respond to fireEvent.click in jsdom (uses pointer
+    // events with capture phases that jsdom doesn't fully simulate). Easier
+    // path: drive the trigger via keyboard, which Radix supports identically.
+    const dialog = screen.getByRole("dialog");
+    const roleTrigger = within(dialog).getByRole("combobox");
+    fireEvent.keyDown(roleTrigger, { key: "Enter" });
+    const adminOption = await screen.findByRole("option", { name: /^admin$/i });
+    fireEvent.keyDown(adminOption, { key: "Enter" });
+    clickCreate();
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringMatching(/admin limit reached/i),
+    }));
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("on successful create, calls signUp + profiles.insert and shows the credentials view", async () => {
+    signUpMock.mockResolvedValue({ data: { user: { id: "new-user-id" } }, error: null });
+    insertMock.mockResolvedValue({ error: null });
+    renderOpen();
+    fillForm({ name: "Jane Doe", email: "jane@example.com" });
+    clickCreate();
+
+    await waitFor(() => {
+      expect(signUpMock).toHaveBeenCalledWith(expect.objectContaining({
+        email: "jane@example.com",
+        password: "GENERATED-PW-FIXED",
+      }));
+      expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({
+        id: "new-user-id",
+        email: "jane@example.com",
+        full_name: "Jane Doe",
+        role: "coordinator",
+        is_active: true,
+      }));
+    });
+    // Credentials view appears with the generated password visible.
+    expect(await screen.findByText(/user created successfully/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue("GENERATED-PW-FIXED")).toBeInTheDocument();
+  });
+
+  it("shows 'Error creating user' toast and skips profiles.insert when signUp fails", async () => {
+    signUpMock.mockResolvedValue({ data: { user: null }, error: { message: "auth-broken" } });
+    renderOpen();
+    fillForm({ name: "Jane Doe", email: "jane@example.com" });
+    clickCreate();
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Error creating user",
+        description: "auth-broken",
+        variant: "destructive",
+      }));
+    });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the supabase 23505 unique-violation message verbatim so the admin sees a clear cause", async () => {
+    signUpMock.mockResolvedValue({ data: { user: { id: "new-user-id" } }, error: null });
+    // Real PostgREST shape for a unique-key violation.
+    insertMock.mockResolvedValue({
+      error: {
+        code: "23505",
+        message: 'duplicate key value violates unique constraint "profiles_email_key"',
+      },
+    });
+    renderOpen();
+    fillForm({ name: "Jane Doe", email: "jane@example.com" });
+    clickCreate();
+
+    // Admin must see both: a clear top-line title AND the supabase message itself
+    // — not a stack trace, not silence, not a generic "something went wrong".
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "User created but profile insert failed",
+        description: 'duplicate key value violates unique constraint "profiles_email_key"',
+        variant: "destructive",
+      }));
+    });
+    // Credentials view must NOT appear (insert failed).
+    expect(screen.queryByText(/user created successfully/i)).not.toBeInTheDocument();
+  });
+
+  it("Done button on credentials view calls onUserCreated and closes the dialog", async () => {
+    signUpMock.mockResolvedValue({ data: { user: { id: "new-user-id" } }, error: null });
+    insertMock.mockResolvedValue({ error: null });
+    renderOpen();
+    fillForm({ name: "Jane Doe", email: "jane@example.com" });
+    clickCreate();
+    await screen.findByText(/user created successfully/i);
+    fireEvent.click(screen.getByRole("button", { name: /done/i }));
+    expect(onUserCreatedMock).toHaveBeenCalledTimes(1);
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false);
+  });
+
+  it("Cancel on form view closes the dialog without creating anything", () => {
+    renderOpen();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false);
+    expect(onUserCreatedMock).not.toHaveBeenCalled();
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/admin/__tests__/RoleChangeDialog.test.tsx
+++ b/src/components/admin/__tests__/RoleChangeDialog.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+/**
+ * Tier 2 test for RoleChangeDialog.
+ *
+ * Pure presentational AlertDialog. Tests verify the UI behavior only:
+ *   - target=null → not rendered
+ *   - role-aware warning copy
+ *   - onConfirm wiring + loading-state disabling
+ *
+ * The RLS-aware "0 rows updated" guard lives in AdminUsers.tsx's
+ * confirmRoleChange handler, NOT in this dialog. That guard is
+ * page-layer; testing it would require mounting AdminUsers.
+ */
+
+import { RoleChangeDialog } from "@/components/admin/RoleChangeDialog";
+
+const onConfirm = vi.fn();
+const onClose = vi.fn();
+
+beforeEach(() => {
+  onConfirm.mockReset();
+  onClose.mockReset();
+});
+
+describe("RoleChangeDialog", () => {
+  it("does not render when target is null", () => {
+    render(<RoleChangeDialog target={null} loading={false} onConfirm={onConfirm} onClose={onClose} />);
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("shows the admin-promotion warning copy when promoting to admin", () => {
+    render(
+      <RoleChangeDialog
+        target={{ id: "u1", name: "Alex", from: "coordinator", to: "admin" }}
+        loading={false}
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByText(/admins have full access to all data/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 admins/i)).toBeInTheDocument();
+  });
+
+  it("shows the coordinator-promotion warning copy when promoting to coordinator", () => {
+    render(
+      <RoleChangeDialog
+        target={{ id: "u1", name: "Alex", from: "volunteer", to: "coordinator" }}
+        loading={false}
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByText(/coordinator dashboard for their assigned department/i)).toBeInTheDocument();
+  });
+
+  it("shows NO warning panel when demoting to volunteer", () => {
+    render(
+      <RoleChangeDialog
+        target={{ id: "u1", name: "Alex", from: "coordinator", to: "volunteer" }}
+        loading={false}
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />
+    );
+    // Neither warning copy should be present.
+    expect(screen.queryByText(/admins have full access/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/coordinator dashboard/i)).not.toBeInTheDocument();
+    // The base description still mentions the target role/name.
+    expect(screen.getByText(/change Alex's role to volunteer/i)).toBeInTheDocument();
+  });
+
+  it("calls onConfirm on click; loading=true disables both Cancel and Confirm", () => {
+    const { rerender } = render(
+      <RoleChangeDialog
+        target={{ id: "u1", name: "Alex", from: "volunteer", to: "coordinator" }}
+        loading={false}
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    // Now flip to loading=true.
+    rerender(
+      <RoleChangeDialog
+        target={{ id: "u1", name: "Alex", from: "volunteer", to: "coordinator" }}
+        loading={true}
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByRole("button", { name: /updating/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+  });
+});

--- a/src/components/settings/__tests__/DeleteAccountPanel.test.tsx
+++ b/src/components/settings/__tests__/DeleteAccountPanel.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+/**
+ * Tier 2 test for DeleteAccountPanel.
+ *
+ * The email-typing gate is the security primitive: nothing destructive
+ * fires until the user types their email exactly. Tests verify both the
+ * UI gate and the success/error branches.
+ */
+
+const invokeMock = vi.fn();
+const navigateMock = vi.fn();
+const toastMock = vi.fn();
+const onSignOutMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: (...args: unknown[]) => invokeMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+import { DeleteAccountPanel } from "@/components/settings/DeleteAccountPanel";
+
+const baseProps = {
+  userId: "user-123",
+  email: "vol@example.com",
+  role: "volunteer" as const,
+  onSignOut: onSignOutMock,
+};
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  navigateMock.mockReset();
+  toastMock.mockReset();
+  onSignOutMock.mockReset();
+  onSignOutMock.mockResolvedValue(undefined);
+});
+
+async function openConfirm() {
+  // Radix AlertDialog Trigger (with asChild) forwards click handlers to the
+  // Button, but the open transition mounts the content asynchronously via
+  // Radix Presence — we wait for the dialog to fully appear before any
+  // assertions. Both the trigger button and the confirm button inside the
+  // dialog use the text "Delete My Account", so subsequent queries scope
+  // via `within(dialog)` to disambiguate.
+  const trigger = screen.getByRole("button", { name: /delete my account/i });
+  fireEvent.click(trigger);
+  return await screen.findByRole("alertdialog");
+}
+
+function confirmButton(dialog: HTMLElement) {
+  return within(dialog).getByRole("button", { name: /delete my account/i });
+}
+
+describe("DeleteAccountPanel", () => {
+  it("keeps the confirm button disabled when typed email does not match", async () => {
+    render(<DeleteAccountPanel {...baseProps} />);
+    const dialog = await openConfirm();
+    fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+      target: { value: "wrong@example.com" },
+    });
+    expect(confirmButton(dialog)).toBeDisabled();
+  });
+
+  it("enables the confirm button when typed email matches exactly", async () => {
+    render(<DeleteAccountPanel {...baseProps} />);
+    const dialog = await openConfirm();
+    fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+      target: { value: baseProps.email },
+    });
+    expect(confirmButton(dialog)).toBeEnabled();
+  });
+
+  it("invokes delete-user, signs out, and navigates with accountDeleted state on success", async () => {
+    invokeMock.mockResolvedValue({ data: {}, error: null });
+    render(<DeleteAccountPanel {...baseProps} />);
+    const dialog = await openConfirm();
+    fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+      target: { value: baseProps.email },
+    });
+    fireEvent.click(confirmButton(dialog));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("delete-user", { body: { userId: "user-123" } });
+      expect(onSignOutMock).toHaveBeenCalled();
+      expect(navigateMock).toHaveBeenCalledWith("/auth", { state: { accountDeleted: true } });
+    });
+  });
+
+  it("shows error toast and does NOT sign out or navigate when supabase returns an error", async () => {
+    invokeMock.mockResolvedValue({ data: null, error: { message: "edge fn down" } });
+    render(<DeleteAccountPanel {...baseProps} />);
+    const dialog = await openConfirm();
+    fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+      target: { value: baseProps.email },
+    });
+    fireEvent.click(confirmButton(dialog));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Error",
+        description: expect.stringMatching(/could not delete account/i),
+        variant: "destructive",
+      }));
+    });
+    expect(onSignOutMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+});

--- a/src/components/settings/__tests__/MfaPanel.test.tsx
+++ b/src/components/settings/__tests__/MfaPanel.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+/**
+ * Tier 2 test for MfaPanel.
+ *
+ * Two render branches: enrolled vs not. Enrollment is a 3-step async flow
+ * (enroll → challenge → verify) that — on success — generates backup codes
+ * via RPC and renders the BackupCodesDialog. Tests cover both branches
+ * plus the error paths and the regenerate + remove operations.
+ *
+ * Verified during test authoring: the production code DOES render the
+ * BackupCodesDialog on first verify success (line 109: setBackupCodes(codes)
+ * after verify). No bug to flag here.
+ */
+
+const listFactorsMock = vi.fn();
+const enrollMock = vi.fn();
+const challengeMock = vi.fn();
+const verifyMock = vi.fn();
+const unenrollMock = vi.fn();
+const rpcMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      mfa: {
+        listFactors: (...a: unknown[]) => listFactorsMock(...a),
+        enroll: (...a: unknown[]) => enrollMock(...a),
+        challenge: (...a: unknown[]) => challengeMock(...a),
+        verify: (...a: unknown[]) => verifyMock(...a),
+        unenroll: (...a: unknown[]) => unenrollMock(...a),
+      },
+    },
+    rpc: (...a: unknown[]) => rpcMock(...a),
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+import { MfaPanel } from "@/components/settings/MfaPanel";
+
+beforeEach(() => {
+  listFactorsMock.mockReset();
+  enrollMock.mockReset();
+  challengeMock.mockReset();
+  verifyMock.mockReset();
+  unenrollMock.mockReset();
+  rpcMock.mockReset();
+  toastMock.mockReset();
+  // Default: not enrolled.
+  listFactorsMock.mockResolvedValue({ data: { totp: [] }, error: null });
+});
+
+describe("MfaPanel", () => {
+  it("renders Enable 2FA button when no verified factor exists", async () => {
+    render(<MfaPanel />);
+    await screen.findByRole("button", { name: /enable 2fa/i });
+    expect(screen.queryByText(/^active$/i)).not.toBeInTheDocument();
+  });
+
+  it("renders Active badge + Remove + backup-codes section when listFactors returns a verified factor", async () => {
+    listFactorsMock.mockResolvedValue({
+      data: { totp: [{ id: "factor-1", status: "verified" }] },
+      error: null,
+    });
+    rpcMock.mockResolvedValue({ data: 7, error: null });
+    render(<MfaPanel />);
+    await screen.findByText(/^active$/i);
+    expect(screen.getByRole("button", { name: /remove 2fa/i })).toBeInTheDocument();
+    await screen.findByText(/7 of 10 codes remaining/i);
+  });
+
+  it("clicking Enable calls auth.mfa.enroll and opens the enrollment dialog with the QR code", async () => {
+    enrollMock.mockResolvedValue({
+      data: { id: "enroll-factor-1", totp: { qr_code: "data:image/png;base64,FAKEQR" } },
+      error: null,
+    });
+    render(<MfaPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /enable 2fa/i }));
+    await waitFor(() => expect(enrollMock).toHaveBeenCalledWith({ factorType: "totp" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByAltText(/mfa qr code/i)).toBeInTheDocument();
+  });
+
+  it("submitting a 6-digit verify code calls challenge + verify, generates backup codes, and renders BackupCodesDialog", async () => {
+    enrollMock.mockResolvedValue({
+      data: { id: "enroll-factor-1", totp: { qr_code: "data:image/png;base64,FAKEQR" } },
+      error: null,
+    });
+    challengeMock.mockResolvedValue({ data: { id: "challenge-1" }, error: null });
+    verifyMock.mockResolvedValue({ error: null });
+    rpcMock.mockResolvedValue({ data: ["AAA-111", "BBB-222", "CCC-333"], error: null });
+
+    render(<MfaPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /enable 2fa/i }));
+    const dialog = await screen.findByRole("dialog");
+    const codeInput = within(dialog).getByPlaceholderText("000000");
+    fireEvent.change(codeInput, { target: { value: "123456" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: /verify & enable/i }));
+
+    await waitFor(() => {
+      expect(challengeMock).toHaveBeenCalledWith({ factorId: "enroll-factor-1" });
+      expect(verifyMock).toHaveBeenCalledWith({
+        factorId: "enroll-factor-1",
+        challengeId: "challenge-1",
+        code: "123456",
+      });
+      expect(rpcMock).toHaveBeenCalledWith("mfa_generate_backup_codes");
+    });
+    // BackupCodesDialog renders one cell per code.
+    await screen.findByText("AAA-111");
+    expect(screen.getByText("BBB-222")).toBeInTheDocument();
+    expect(screen.getByText("CCC-333")).toBeInTheDocument();
+  });
+
+  it("verify error shows 'Verification failed' toast and clears the code field", async () => {
+    enrollMock.mockResolvedValue({
+      data: { id: "enroll-factor-1", totp: { qr_code: "data:image/png;base64,FAKEQR" } },
+      error: null,
+    });
+    challengeMock.mockResolvedValue({ data: { id: "challenge-1" }, error: null });
+    verifyMock.mockResolvedValue({ error: { message: "wrong code" } });
+
+    render(<MfaPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /enable 2fa/i }));
+    const dialog = await screen.findByRole("dialog");
+    const codeInput = within(dialog).getByPlaceholderText("000000") as HTMLInputElement;
+    fireEvent.change(codeInput, { target: { value: "000000" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: /verify & enable/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Verification failed",
+        description: "wrong code",
+        variant: "destructive",
+      }));
+    });
+    // Code cleared. Confirm via the controlled input value.
+    expect(codeInput.value).toBe("");
+  });
+
+  it("clicking Remove calls auth.mfa.unenroll and flips back to the not-enrolled view", async () => {
+    listFactorsMock.mockResolvedValue({
+      data: { totp: [{ id: "factor-1", status: "verified" }] },
+      error: null,
+    });
+    rpcMock.mockResolvedValue({ data: 5, error: null });
+    unenrollMock.mockResolvedValue({ error: null });
+
+    render(<MfaPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /remove 2fa/i }));
+    await waitFor(() => expect(unenrollMock).toHaveBeenCalledWith({ factorId: "factor-1" }));
+    await screen.findByRole("button", { name: /enable 2fa/i });
+    expect(screen.queryByText(/^active$/i)).not.toBeInTheDocument();
+  });
+
+  it("clicking Generate new codes calls the backup-codes RPC and renders the new codes", async () => {
+    listFactorsMock.mockResolvedValue({
+      data: { totp: [{ id: "factor-1", status: "verified" }] },
+      error: null,
+    });
+    // First call: count fetch on mount. Subsequent: regenerate.
+    rpcMock
+      .mockResolvedValueOnce({ data: 5, error: null })
+      .mockResolvedValueOnce({ data: ["NEW-1", "NEW-2"], error: null });
+
+    render(<MfaPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /generate new codes/i }));
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith("mfa_generate_backup_codes");
+    });
+    await screen.findByText("NEW-1");
+    expect(screen.getByText("NEW-2")).toBeInTheDocument();
+  });
+
+  it("shows '0 of 10 codes remaining' messaging when the count RPC returns 0", async () => {
+    listFactorsMock.mockResolvedValue({
+      data: { totp: [{ id: "factor-1", status: "verified" }] },
+      error: null,
+    });
+    rpcMock.mockResolvedValue({ data: 0, error: null });
+    render(<MfaPanel />);
+    await screen.findByText(/no codes remaining/i);
+  });
+});

--- a/src/components/settings/__tests__/ProfilePanel.test.tsx
+++ b/src/components/settings/__tests__/ProfilePanel.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+/**
+ * Tier 2 test for ProfilePanel.
+ *
+ * Focus: profile save semantics. Email change must trigger
+ * supabase.auth.updateUser({ email }) AND show a verification toast;
+ * unchanged email must NOT call auth.updateUser. DOB onChange must
+ * call setIsMinor with the right boolean.
+ *
+ * AvatarUploadField is stubbed — it has its own storage surface that
+ * we don't want to drag into profile-save tests.
+ */
+
+const updateUserMock = vi.fn();
+const profileUpdateMock = vi.fn();
+const profileEqMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      updateUser: (...args: unknown[]) => updateUserMock(...args),
+    },
+    from: () => ({
+      update: (...args: unknown[]) => {
+        profileUpdateMock(...args);
+        return { eq: (...eqArgs: unknown[]) => profileEqMock(...eqArgs) };
+      },
+    }),
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/components/settings/AvatarUploadField", () => ({
+  AvatarUploadField: () => <div data-testid="avatar-upload-stub" />,
+}));
+
+import { ProfilePanel } from "@/components/settings/ProfilePanel";
+import type { SettingsProfile } from "@/components/settings/types";
+
+const baseProfile: SettingsProfile = {
+  id: "user-123",
+  full_name: "Vol Tester",
+  email: "vol@example.com",
+  phone: "555-0100",
+  emergency_contact_name: "EC Name",
+  emergency_contact_phone: "555-0200",
+  avatar_url: null,
+  notif_email: true,
+  notif_in_app: true,
+  notif_sms: false,
+  date_of_birth: "1990-05-15",
+  is_minor: false,
+  username: "voltester",
+  notif_shift_reminders: true,
+  notif_new_messages: true,
+  notif_milestone: true,
+  notif_document_expiry: true,
+  notif_booking_changes: true,
+};
+
+beforeEach(() => {
+  updateUserMock.mockReset();
+  profileUpdateMock.mockReset();
+  profileEqMock.mockReset();
+  toastMock.mockReset();
+  // Default success.
+  profileEqMock.mockResolvedValue({ error: null });
+  updateUserMock.mockResolvedValue({ error: null });
+});
+
+interface RenderOptions {
+  phone?: string;
+  emergencyPhone?: string;
+  isMinor?: boolean;
+  setPhone?: (v: string) => void;
+  setEmergencyPhone?: (v: string) => void;
+  setIsMinor?: (v: boolean) => void;
+  onSaved?: () => Promise<void> | void;
+}
+
+function renderPanel(opts: RenderOptions = {}) {
+  const setPhone = opts.setPhone ?? vi.fn();
+  const setEmergencyPhone = opts.setEmergencyPhone ?? vi.fn();
+  const setIsMinor = opts.setIsMinor ?? vi.fn();
+  const onSaved = opts.onSaved ?? vi.fn();
+  render(
+    <ProfilePanel
+      userId="user-123"
+      profile={baseProfile}
+      phone={opts.phone ?? baseProfile.phone ?? ""}
+      setPhone={setPhone}
+      emergencyPhone={opts.emergencyPhone ?? baseProfile.emergency_contact_phone ?? ""}
+      setEmergencyPhone={setEmergencyPhone}
+      isMinor={opts.isMinor ?? false}
+      setIsMinor={setIsMinor}
+      onSaved={onSaved}
+    />
+  );
+  return { setPhone, setEmergencyPhone, setIsMinor, onSaved };
+}
+
+function clickSave() {
+  fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+}
+
+describe("ProfilePanel", () => {
+  it("calls profiles.update only and shows 'Profile updated' toast when email is unchanged", async () => {
+    renderPanel();
+    clickSave();
+
+    await waitFor(() => {
+      expect(profileUpdateMock).toHaveBeenCalledTimes(1);
+      expect(profileEqMock).toHaveBeenCalledWith("id", "user-123");
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Profile updated",
+      }));
+    });
+    expect(updateUserMock).not.toHaveBeenCalled();
+  });
+
+  it("calls auth.updateUser AND shows verification toast when email changes", async () => {
+    renderPanel();
+    fireEvent.change(screen.getByDisplayValue(baseProfile.email!), {
+      target: { value: "newemail@example.com" },
+    });
+    clickSave();
+
+    await waitFor(() => {
+      expect(updateUserMock).toHaveBeenCalledWith({ email: "newemail@example.com" });
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Verification sent",
+      }));
+    });
+  });
+
+  it("shows error toast and does NOT call auth.updateUser when profiles.update fails", async () => {
+    profileEqMock.mockResolvedValue({ error: { message: "RLS denied" } });
+    renderPanel();
+    fireEvent.change(screen.getByDisplayValue(baseProfile.email!), {
+      target: { value: "newemail@example.com" },
+    });
+    clickSave();
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Error",
+        description: "RLS denied",
+        variant: "destructive",
+      }));
+    });
+    expect(updateUserMock).not.toHaveBeenCalled();
+  });
+
+  it("shows error toast when auth.updateUser fails after profiles.update succeeds (partial save)", async () => {
+    updateUserMock.mockResolvedValue({ error: { message: "auth backend down" } });
+    renderPanel();
+    fireEvent.change(screen.getByDisplayValue(baseProfile.email!), {
+      target: { value: "newemail@example.com" },
+    });
+    clickSave();
+
+    await waitFor(() => {
+      expect(profileUpdateMock).toHaveBeenCalled();
+      expect(updateUserMock).toHaveBeenCalled();
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Error updating email",
+        description: "auth backend down",
+        variant: "destructive",
+      }));
+    });
+  });
+
+  it("calls setIsMinor(true) when DOB changes to a minor age", () => {
+    const setIsMinor = vi.fn();
+    renderPanel({ setIsMinor });
+    // 2015 → ~10 years old → minor.
+    fireEvent.change(screen.getByDisplayValue(baseProfile.date_of_birth!), {
+      target: { value: "2015-06-15" },
+    });
+    expect(setIsMinor).toHaveBeenCalledWith(true);
+  });
+
+  it("calls setIsMinor(false) when DOB changes to an adult age", () => {
+    const setIsMinor = vi.fn();
+    renderPanel({ setIsMinor });
+    // 1990 → adult.
+    fireEvent.change(screen.getByDisplayValue(baseProfile.date_of_birth!), {
+      target: { value: "1980-06-15" },
+    });
+    expect(setIsMinor).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -13,3 +13,25 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: () => false,
   }),
 });
+
+// jsdom 20 doesn't provide ResizeObserver, but Radix UI primitives
+// (Checkbox, Tabs, Select, …) read it during their layout effects. Without
+// this stub, mounting any of those crashes the test render. Same role as
+// the matchMedia stub above — purely a test-environment polyfill.
+class ResizeObserverStub implements ResizeObserver {
+  constructor(_callback: ResizeObserverCallback) { void _callback; }
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver = ResizeObserverStub;
+
+// Radix Select uses pointer-capture APIs and scrollIntoView during its
+// open animation. jsdom doesn't implement these on Element; without stubs
+// the option list never renders in tests. Stubs only — no behavior beyond
+// not crashing.
+const elProto = Element.prototype as unknown as Record<string, unknown>;
+if (!elProto.hasPointerCapture) elProto.hasPointerCapture = () => false;
+if (!elProto.setPointerCapture) elProto.setPointerCapture = () => {};
+if (!elProto.releasePointerCapture) elProto.releasePointerCapture = () => {};
+if (!elProto.scrollIntoView) elProto.scrollIntoView = () => {};

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -26,3 +26,16 @@ class ResizeObserverStub implements ResizeObserver {
 }
 globalThis.ResizeObserver = ResizeObserverStub;
 
+// Radix Select uses pointer-capture APIs and scrollIntoView during its
+// open animation. jsdom 20 doesn't implement any of these — neither
+// `Element.prototype.scrollIntoView` nor `HTMLElement.prototype.scrollIntoView`
+// is defined (verified via prototype probe). Polyfill on HTMLElement.prototype
+// per the standard inheritance chain (Radix calls these on instance methods,
+// which resolve through HTMLElement → Element). Stubs only — no behavior
+// beyond not crashing.
+const htmlElProto = HTMLElement.prototype as unknown as Record<string, unknown>;
+htmlElProto.hasPointerCapture = () => false;
+htmlElProto.setPointerCapture = () => {};
+htmlElProto.releasePointerCapture = () => {};
+htmlElProto.scrollIntoView = () => {};
+


### PR DESCRIPTION
## Summary

React Testing Library coverage for the five panels where silent failure causes real user harm: MFA, account deletion, role changes, profile email change, admin user creation. **31 new tests** across 5 files. No production code changed; two test-infrastructure additions.

## Components covered

| Component | Tests | Notes |
|---|---|---|
| `DeleteAccountPanel` (settings/) | 4 | Email-typing security gate + happy/error paths |
| `RoleChangeDialog` (admin/) | 5 | Pure presentational dialog UI |
| `ProfilePanel` (settings/) | 6 | Email-change → `auth.updateUser` + DOB → minor detection |
| `AddUserDialog` (admin/) | 8 | Validation + admin cap + 23505 unique-violation handling |
| `MfaPanel` (settings/) | 8 | Both render branches (enrolled vs not) + enrollment flow |

## Test count delta

**103 → 134** (+31 tests). 8 → 13 test files. *(After PR #135 merges, this becomes 138 → 169.)*

## Mocked surfaces (per component)

| Component | Mocks |
|---|---|
| DeleteAccountPanel | `supabase.functions.invoke`, `useNavigate`, `useToast` |
| RoleChangeDialog | None — pure presentational; props are `vi.fn()` spies |
| ProfilePanel | `supabase.from("profiles").update().eq()`, `supabase.auth.updateUser`, `useToast`, `AvatarUploadField` stubbed |
| AddUserDialog | `supabase.auth.signUp`, `supabase.from("profiles").insert`, `useToast`, `generatePassword` (mocked to fixed string for deterministic assertion) |
| MfaPanel | `supabase.auth.mfa.{listFactors,enroll,challenge,verify,unenroll}`, `supabase.rpc`, `useToast` |

## Test infrastructure changes (src/test/setup.ts)

1. **`ResizeObserverStub`** — same polyfill as PR #135. Duplicated here so this PR is independently mergeable; identical bytes will git-merge trivially with #135.
2. **`Element.prototype` pointer-capture + scrollIntoView stubs** — new in this PR. Required for Radix Select to render its option list in jsdom; without them the dropdown never opens, and the admin-cap test for AddUserDialog can't reach the "admin" option.

## Notable test patterns documented inline

- **DeleteAccountPanel**: both the trigger button and the confirm button inside the dialog use the text "Delete My Account". Tests scope the confirm via `within(dialog).getByRole(...)` to disambiguate.
- **AddUserDialog admin-cap test**: Radix Select doesn't respond to `fireEvent.click` in jsdom (uses pointer-capture APIs not fully simulated). Drive the trigger via `fireEvent.keyDown({ key: "Enter" })` — Radix supports keyboard nav identically.
- **DeleteAccountPanel & AddUserDialog**: Radix AlertDialog/Dialog open asynchronously via Presence — wait via `await screen.findByRole("alertdialog" | "dialog")` before any in-dialog query.

## Findings during test authoring

- **`DeleteAccountPanel` handler does NOT check `data?.error`** (only `error`). Originally planned a 5th test for this; removed because the test would have asserted behavior that doesn't exist in this component. The `data.error` guard *does* exist in `AdminUsers.confirmDeleteUser` (a different handler — admin deleting another user), where it's tested at the page layer.
- **`MfaPanel` test #4** confirms the `BackupCodesDialog` renders on **first verify success** (production line 109: `setBackupCodes(codes)` runs after `verify` completes). No UX bug to flag — the dialog appears on first verify, not only on regenerate.

## Out of Tier 2 scope (covered at the right layer, just not in this PR)

- **RoleChangeDialog** tests cover the dialog UI only. The "RLS-aware 0-row update" security guard mentioned in the original Tier 2 prompt is in `AdminUsers.confirmRoleChange` — page-level orchestration. Testing it requires mounting AdminUsers, which is a separate scope. The security primitive *is* covered in production code; testing happens at the right layer (page), just not in this PR.

## Verification

- [x] `npx tsc --build` — clean
- [x] `npx eslint . --max-warnings=0` — clean
- [x] `npx vitest run` — **134/134 passing**

## Phase 5b status

**Tier 2 complete. Tier 3 (coordinator + volunteer flows) is next.**

Tier 3 will cover: `ShiftFormDialog` (shifts/), `LoginForm` (checkin/), `ConfirmCheckinScreen` (checkin/), `InviteVolunteerModal` (shifts/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)