### PR TITLE
test: coordinator + volunteer flow coverage (Phase 5b Tier 3)

### DIFF
--- a/src/components/checkin/__tests__/ConfirmCheckinScreen.test.tsx
+++ b/src/components/checkin/__tests__/ConfirmCheckinScreen.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+/**
+ * Tier 3 test for ConfirmCheckinScreen.
+ *
+ * Pure presentational. Tests cover:
+ *   - Single-shift mode (no "Check In to All" button)
+ *   - Multi-shift mode (per-shift cards + "Check In to All")
+ *   - Both callback wirings
+ */
+
+import { ConfirmCheckinScreen } from "@/components/checkin/ConfirmCheckinScreen";
+import type { MatchedShift } from "@/lib/checkin-actions";
+
+const onCheckIn = vi.fn();
+const onCheckInAll = vi.fn();
+
+const baseShift: MatchedShift = {
+  bookingId: "booking-1",
+  shiftId: "shift-1",
+  title: "Morning Grounds Crew",
+  shiftDate: "2026-05-01",
+  startTime: "09:00",
+  endTime: "12:00",
+  departmentName: "Grounds",
+  timeSlotId: null,
+  slotStart: null,
+  slotEnd: null,
+};
+
+const secondShift: MatchedShift = {
+  ...baseShift,
+  bookingId: "booking-2",
+  shiftId: "shift-2",
+  title: "Afternoon Adult Day",
+  startTime: "13:00",
+  endTime: "16:00",
+  departmentName: "Adult Day Services",
+};
+
+beforeEach(() => {
+  onCheckIn.mockReset();
+  onCheckInAll.mockReset();
+});
+
+describe("ConfirmCheckinScreen", () => {
+  it("renders one card per shift and the 'Check In to All' button when there are 2+ shifts", () => {
+    render(
+      <ConfirmCheckinScreen
+        volunteerName="Alex"
+        shifts={[baseShift, secondShift]}
+        onCheckIn={onCheckIn}
+        onCheckInAll={onCheckInAll}
+      />
+    );
+    expect(screen.getByText(baseShift.title)).toBeInTheDocument();
+    expect(screen.getByText(secondShift.title)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /check in to all 2 slots/i })).toBeInTheDocument();
+  });
+
+  it("does NOT render the 'Check In to All' button with a single shift", () => {
+    render(
+      <ConfirmCheckinScreen
+        volunteerName="Alex"
+        shifts={[baseShift]}
+        onCheckIn={onCheckIn}
+        onCheckInAll={onCheckInAll}
+      />
+    );
+    expect(screen.getByText(baseShift.title)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /check in to all/i })).not.toBeInTheDocument();
+  });
+
+  it("invokes onCheckIn with the clicked shift", () => {
+    render(
+      <ConfirmCheckinScreen
+        volunteerName="Alex"
+        shifts={[baseShift, secondShift]}
+        onCheckIn={onCheckIn}
+        onCheckInAll={onCheckInAll}
+      />
+    );
+    // The shift cards are <button> elements wrapping the shift content; click
+    // by visible title.
+    fireEvent.click(screen.getByText(secondShift.title).closest("button")!);
+    expect(onCheckIn).toHaveBeenCalledTimes(1);
+    expect(onCheckIn).toHaveBeenCalledWith(secondShift);
+  });
+
+  it("invokes onCheckInAll when the multi-slot button is clicked", () => {
+    render(
+      <ConfirmCheckinScreen
+        volunteerName="Alex"
+        shifts={[baseShift, secondShift]}
+        onCheckIn={onCheckIn}
+        onCheckInAll={onCheckInAll}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /check in to all 2 slots/i }));
+    expect(onCheckInAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/checkin/__tests__/LoginForm.test.tsx
+++ b/src/components/checkin/__tests__/LoginForm.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+/**
+ * Tier 3 test for LoginForm (QR check-in login).
+ *
+ * Same security guard as Auth.tsx test #5 from Tier 1: username-not-found
+ * must surface a generic "Invalid credentials" — no email-enumeration leak.
+ *
+ * The MFA AAL gate is the second half of the auth transaction and stays
+ * inside this component; tests cover both the no-step-up path (call
+ * onLoginSuccess) and the step-up-required path (toast + refuse).
+ */
+
+const signInWithPasswordMock = vi.fn();
+const getAALMock = vi.fn();
+const resolveLoginIdentifierToEmailMock = vi.fn();
+const toastMock = vi.fn();
+const onLoginSuccessMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: (...a: unknown[]) => signInWithPasswordMock(...a),
+      mfa: {
+        getAuthenticatorAssuranceLevel: (...a: unknown[]) => getAALMock(...a),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/checkin-actions", () => ({
+  resolveLoginIdentifierToEmail: (...a: unknown[]) => resolveLoginIdentifierToEmailMock(...a),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@marsidev/react-turnstile", () => ({
+  Turnstile: (props: { onSuccess: (t: string) => void }) => (
+    <button type="button" onClick={() => props.onSuccess("mock-turnstile-token")}>
+      Mock Turnstile
+    </button>
+  ),
+}));
+
+import { LoginForm } from "@/components/checkin/LoginForm";
+
+beforeEach(() => {
+  signInWithPasswordMock.mockReset();
+  getAALMock.mockReset();
+  resolveLoginIdentifierToEmailMock.mockReset();
+  toastMock.mockReset();
+  onLoginSuccessMock.mockReset();
+  // Default: no MFA step-up required.
+  getAALMock.mockResolvedValue({
+    data: { currentLevel: "aal1", nextLevel: "aal1" },
+    error: null,
+  });
+});
+
+function fillCredentials(identifier: string, password: string) {
+  const idInput = document.getElementById("checkin-identifier") as HTMLInputElement;
+  const pwInput = document.getElementById("checkin-password") as HTMLInputElement;
+  fireEvent.change(idInput, { target: { value: identifier } });
+  fireEvent.change(pwInput, { target: { value: password } });
+}
+
+function clickTurnstile() {
+  fireEvent.click(screen.getByRole("button", { name: /mock turnstile/i }));
+}
+
+function submit() {
+  // Button text varies with state; submit via the form to avoid label drift.
+  const form = (document.getElementById("checkin-identifier") as HTMLInputElement).closest("form")!;
+  fireEvent.submit(form);
+}
+
+describe("LoginForm", () => {
+  it("shows verification toast and skips signin when no Turnstile token", () => {
+    render(<LoginForm onLoginSuccess={onLoginSuccessMock} />);
+    fillCredentials("vol@example.com", "secret123");
+    submit();
+    expect(signInWithPasswordMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringMatching(/verification required/i),
+    }));
+  });
+
+  it("calls onLoginSuccess with the user when email login succeeds and no MFA step-up is needed", async () => {
+    const fakeUser = { id: "user-1", email: "vol@example.com" };
+    signInWithPasswordMock.mockResolvedValue({ data: { session: { user: fakeUser } }, error: null });
+    render(<LoginForm onLoginSuccess={onLoginSuccessMock} />);
+    fillCredentials("vol@example.com", "secret123");
+    clickTurnstile();
+    submit();
+
+    await waitFor(() => {
+      expect(signInWithPasswordMock).toHaveBeenCalledWith({
+        email: "vol@example.com",
+        password: "secret123",
+        options: { captchaToken: "mock-turnstile-token" },
+      });
+      expect(onLoginSuccessMock).toHaveBeenCalledWith(fakeUser);
+    });
+    // Email path skips the username-resolve RPC.
+    expect(resolveLoginIdentifierToEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves a username via RPC then signs in with the resolved email", async () => {
+    resolveLoginIdentifierToEmailMock.mockResolvedValue("vol@example.com");
+    const fakeUser = { id: "user-1", email: "vol@example.com" };
+    signInWithPasswordMock.mockResolvedValue({ data: { session: { user: fakeUser } }, error: null });
+    render(<LoginForm onLoginSuccess={onLoginSuccessMock} />);
+    fillCredentials("jane_doe", "secret123");
+    clickTurnstile();
+    submit();
+
+    await waitFor(() => {
+      expect(resolveLoginIdentifierToEmailMock).toHaveBeenCalledWith("jane_doe");
+      expect(signInWithPasswordMock).toHaveBeenCalledWith(expect.objectContaining({
+        email: "vol@example.com",
+      }));
+    });
+  });
+
+  it("shows generic 'Invalid credentials' when username is not found (no enumeration leak)", async () => {
+    resolveLoginIdentifierToEmailMock.mockResolvedValue(null);
+    render(<LoginForm onLoginSuccess={onLoginSuccessMock} />);
+    fillCredentials("ghost_user", "secret123");
+    clickTurnstile();
+    submit();
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Login failed",
+        description: "Invalid credentials.",
+        variant: "destructive",
+      }));
+    });
+    expect(signInWithPasswordMock).not.toHaveBeenCalled();
+    expect(onLoginSuccessMock).not.toHaveBeenCalled();
+    // Guard against any leak of "user not found" / "no such user" / username-specific copy.
+    const calls = toastMock.mock.calls.flat();
+    for (const c of calls) {
+      const desc = (c as { description?: string }).description ?? "";
+      expect(desc).not.toMatch(/not found|no such|user.*exist/i);
+    }
+  });
+
+  it("shows 'Login failed' toast when signInWithPassword returns an error", async () => {
+    signInWithPasswordMock.mockResolvedValue({ data: { session: null }, error: { message: "wrong pw" } });
+    render(<LoginForm onLoginSuccess={onLoginSuccessMock} />);
+    fillCredentials("vol@example.com", "wrongpass");
+    clickTurnstile();
+    submit();
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Login failed",
+        variant: "destructive",
+      }));
+    });
+    expect(onLoginSuccessMock).not.toHaveBeenCalled();
+  });
+
+  it("shows MFA-required toast and does NOT call onLoginSuccess when AAL step-up is required", async () => {
+    const fakeUser = { id: "user-1", email: "vol@example.com" };
+    signInWithPasswordMock.mockResolvedValue({ data: { session: { user: fakeUser } }, error: null });
+    getAALMock.mockResolvedValue({
+      data: { currentLevel: "aal1", nextLevel: "aal2" },
+      error: null,
+    });
+    render(<LoginForm onLoginSuccess={onLoginSuccessMock} />);
+    fillCredentials("vol@example.com", "secret123");
+    clickTurnstile();
+    submit();
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "MFA Required",
+        variant: "destructive",
+      }));
+    });
+    // The login transaction stops at the gate — no onLoginSuccess call.
+    expect(onLoginSuccessMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/shifts/__tests__/InviteVolunteerModal.test.tsx
+++ b/src/components/shifts/__tests__/InviteVolunteerModal.test.tsx
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+/**
+ * Tier 3 test for InviteVolunteerModal.
+ *
+ * The supabase from(table) call returns table-specific query builders;
+ * we route based on the table argument so each table has its own
+ * mockable surface.
+ *
+ * Search input is debounced (250ms) — tests use fake timers + advanceTimersByTime.
+ */
+
+const shiftInvitationsSelectMock = vi.fn();
+const shiftInvitationsInsertMock = vi.fn();
+const restrictionsSelectMock = vi.fn();
+const profilesSelectMock = vi.fn();
+const notificationsInsertMock = vi.fn();
+const shiftBookingsSelectMock = vi.fn();
+const toastMock = vi.fn();
+const onSentMock = vi.fn();
+const onOpenChangeMock = vi.fn();
+
+const mockUser = { id: "coord-user-1" };
+
+/**
+ * Build a query-builder shape that resolves to the desired result. The
+ * production code uses .select(...).eq(...).eq(...).not(...) chains for
+ * shift_invitations and similar, so each method returns `this` until a
+ * terminal `.then` (the await) resolves the promise.
+ */
+function chainable(result: unknown) {
+  const builder: Record<string, unknown> = {};
+  // Most methods return the builder; eq/ilike/limit/order/not all chain.
+  for (const m of ["eq", "ilike", "order", "limit", "not"]) {
+    builder[m] = () => builder;
+  }
+  // Final await on the chain returns the result via the thenable interface.
+  builder.then = (onFulfilled: (v: unknown) => unknown) => Promise.resolve(result).then(onFulfilled);
+  return builder;
+}
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: (table: string) => {
+      if (table === "shift_invitations") {
+        return {
+          select: () => chainable(shiftInvitationsSelectMock()),
+          insert: (...a: unknown[]) => shiftInvitationsInsertMock(...a),
+        };
+      }
+      if (table === "department_restrictions") {
+        return { select: () => chainable(restrictionsSelectMock()) };
+      }
+      if (table === "profiles") {
+        return { select: () => chainable(profilesSelectMock()) };
+      }
+      if (table === "notifications") {
+        return { insert: (...a: unknown[]) => notificationsInsertMock(...a) };
+      }
+      if (table === "shift_bookings") {
+        return { select: () => chainable(shiftBookingsSelectMock()) };
+      }
+      return { select: () => chainable({ data: [], error: null }) };
+    },
+  },
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+import { InviteVolunteerModal } from "@/components/shifts/InviteVolunteerModal";
+
+const baseShift = {
+  id: "shift-1",
+  title: "Morning Crew",
+  shift_date: "2026-06-15",
+  start_time: "09:00:00",
+  end_time: "12:00:00",
+  department_id: "dept-1",
+  total_slots: 4,
+  departments: { name: "Grounds", requires_bg_check: false },
+};
+
+beforeEach(() => {
+  shiftInvitationsSelectMock.mockReset();
+  shiftInvitationsInsertMock.mockReset();
+  restrictionsSelectMock.mockReset();
+  profilesSelectMock.mockReset();
+  notificationsInsertMock.mockReset();
+  shiftBookingsSelectMock.mockReset();
+  toastMock.mockReset();
+  onSentMock.mockReset();
+  onOpenChangeMock.mockReset();
+  // Default: no one already invited, no restrictions, no conflicts.
+  shiftInvitationsSelectMock.mockReturnValue({ data: [], error: null });
+  restrictionsSelectMock.mockReturnValue({ data: [], error: null });
+  shiftBookingsSelectMock.mockReturnValue({ data: [], error: null });
+  shiftInvitationsInsertMock.mockResolvedValue({ error: null });
+  notificationsInsertMock.mockResolvedValue({ error: null });
+});
+
+function renderOpen(shiftOverride: Partial<typeof baseShift> = {}) {
+  render(
+    <InviteVolunteerModal
+      shift={{ ...baseShift, ...shiftOverride }}
+      open={true}
+      onOpenChange={onOpenChangeMock}
+      onSent={onSentMock}
+    />
+  );
+}
+
+async function typeSearch(text: string) {
+  const input = screen.getByPlaceholderText(/search by name/i);
+  fireEvent.change(input, { target: { value: text } });
+  // Real wait past the 250ms debounce. Using real timers because most tests
+  // pair this with `waitFor`, which polls in real time and doesn't compose
+  // with fake timers. Fake timers are isolated to the debounce-verification
+  // test below.
+  await new Promise((r) => setTimeout(r, 300));
+}
+
+describe("InviteVolunteerModal", () => {
+
+  it("on mount, fetches existing pending invitations and department restrictions", async () => {
+    renderOpen();
+    // The mount-time Promise.all should fire both queries synchronously.
+    await waitFor(() => {
+      expect(shiftInvitationsSelectMock).toHaveBeenCalled();
+      expect(restrictionsSelectMock).toHaveBeenCalled();
+    });
+  });
+
+  it("typing in the search field debounces 250ms before firing the profiles query", async () => {
+    profilesSelectMock.mockReturnValue({
+      data: [{ id: "v1", full_name: "Jane Volunteer", email: "jane@example.com", bg_check_status: "cleared", is_active: true }],
+      error: null,
+    });
+    renderOpen();
+    // Wait for mount-time queries to settle on real timers.
+    await waitFor(() => expect(restrictionsSelectMock).toHaveBeenCalled());
+
+    // Verify debounce: at 100ms the query has NOT fired; at 300ms it HAS.
+    fireEvent.change(screen.getByPlaceholderText(/search by name/i), { target: { value: "Ja" } });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(profilesSelectMock).not.toHaveBeenCalled();
+    await new Promise((r) => setTimeout(r, 250));
+    await waitFor(() => {
+      expect(profilesSelectMock).toHaveBeenCalled();
+      expect(screen.getByText("Jane Volunteer")).toBeInTheDocument();
+    });
+  });
+
+  it("eligibility filter: already-invited / restricted / BG-required-not-cleared all show their reason and disable the row", async () => {
+    // Pre-populate state via the mount queries.
+    shiftInvitationsSelectMock.mockReturnValue({
+      data: [{ volunteer_id: "v-invited" }],
+      error: null,
+    });
+    restrictionsSelectMock.mockReturnValue({
+      data: [{ volunteer_id: "v-restricted" }],
+      error: null,
+    });
+    profilesSelectMock.mockReturnValue({
+      data: [
+        { id: "v-invited", full_name: "Pat Pending", email: "a@x", bg_check_status: "cleared", is_active: true },
+        { id: "v-restricted", full_name: "Robin Blocked", email: "r@x", bg_check_status: "cleared", is_active: true },
+        { id: "v-needs-bg", full_name: "Sam Newcomer", email: "b@x", bg_check_status: "pending", is_active: true },
+      ],
+      error: null,
+    });
+    // Department requires BG check, so v-needs-bg becomes ineligible.
+    renderOpen({ departments: { name: "Grounds", requires_bg_check: true } });
+    await typeSearch("Vo");
+
+    // Already invited
+    const inviteRow = screen.getByText("Pat Pending").closest("button")!;
+    expect(within(inviteRow).getByText(/already invited/i)).toBeInTheDocument();
+    expect(inviteRow).toBeDisabled();
+    // Restricted
+    const restrRow = screen.getByText("Robin Blocked").closest("button")!;
+    expect(within(restrRow).getByText(/restricted/i)).toBeInTheDocument();
+    expect(restrRow).toBeDisabled();
+    // BG-required + status=pending
+    const bgRow = screen.getByText("Sam Newcomer").closest("button")!;
+    expect(within(bgRow).getByText(/bg check.*pending/i)).toBeInTheDocument();
+    expect(bgRow).toBeDisabled();
+  });
+
+  it("clicking an eligible volunteer opens the standard confirmation dialog when there's no time conflict", async () => {
+    profilesSelectMock.mockReturnValue({
+      data: [{ id: "v1", full_name: "Eligible Vol", email: "e@x", bg_check_status: "cleared", is_active: true }],
+      error: null,
+    });
+    shiftBookingsSelectMock.mockReturnValue({ data: [], error: null });
+    renderOpen();
+    await typeSearch("Eli");
+    fireEvent.click(screen.getByText("Eligible Vol").closest("button")!);
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(within(dialog).getByRole("heading", { name: /send invitation/i })).toBeInTheDocument();
+    expect(within(dialog).queryByText(/scheduling conflict/i)).not.toBeInTheDocument();
+  });
+
+  it("clicking an eligible volunteer with a same-day overlap opens the conflict-warning dialog with the conflicting shift's details", async () => {
+    profilesSelectMock.mockReturnValue({
+      data: [{ id: "v1", full_name: "Conflicted Vol", email: "c@x", bg_check_status: "cleared", is_active: true }],
+      error: null,
+    });
+    shiftBookingsSelectMock.mockReturnValue({
+      data: [{
+        shifts: {
+          title: "Existing Shift",
+          shift_date: "2026-06-15",
+          start_time: "10:00:00",
+          end_time: "13:00:00",
+        },
+      }],
+      error: null,
+    });
+    renderOpen();
+    await typeSearch("Con");
+    fireEvent.click(screen.getByText("Conflicted Vol").closest("button")!);
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(within(dialog).getByText(/scheduling conflict/i)).toBeInTheDocument();
+    expect(within(dialog).getByText(/existing shift/i)).toBeInTheDocument();
+    expect(within(dialog).getByText(/10:00/)).toBeInTheDocument();
+  });
+
+  it("on Send (no conflict), inserts shift_invitations + notification, toasts success, calls onSent + onOpenChange(false)", async () => {
+    profilesSelectMock.mockReturnValue({
+      data: [{ id: "v1", full_name: "Eligible Vol", email: "e@x", bg_check_status: "cleared", is_active: true }],
+      error: null,
+    });
+    renderOpen();
+    await typeSearch("Eli");
+    fireEvent.click(screen.getByText("Eligible Vol").closest("button")!);
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /send invitation/i }));
+
+    await waitFor(() => {
+      expect(shiftInvitationsInsertMock).toHaveBeenCalledWith(expect.objectContaining({
+        shift_id: "shift-1",
+        volunteer_id: "v1",
+        invited_by: mockUser.id,
+        invite_email: "e@x",
+        status: "pending",
+      }));
+      expect(notificationsInsertMock).toHaveBeenCalledWith(expect.objectContaining({
+        user_id: "v1",
+        type: "shift_invitation",
+      }));
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Invitation sent",
+      }));
+      expect(onSentMock).toHaveBeenCalled();
+      expect(onOpenChangeMock).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("on unique-violation insert error, shows the friendly message (not the raw constraint name)", async () => {
+    profilesSelectMock.mockReturnValue({
+      data: [{ id: "v1", full_name: "Eligible Vol", email: "e@x", bg_check_status: "cleared", is_active: true }],
+      error: null,
+    });
+    shiftInvitationsInsertMock.mockResolvedValue({
+      error: { message: 'duplicate key value violates unique constraint "uq_shift_invitation_volunteer"' },
+    });
+    renderOpen();
+    await typeSearch("Eli");
+    fireEvent.click(screen.getByText("Eligible Vol").closest("button")!);
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /send invitation/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Failed to send invitation",
+        description: "This volunteer already has a pending invitation for this shift.",
+        variant: "destructive",
+      }));
+    });
+    // Asserted exact user-visible text — the raw constraint name must not leak.
+    const calls = toastMock.mock.calls.flat();
+    const descriptions = calls.map((c) => (c as { description?: string }).description ?? "");
+    for (const d of descriptions) {
+      expect(d).not.toMatch(/uq_shift_invitation_volunteer|duplicate key/);
+    }
+  });
+
+  it("on generic insert error, shows the supabase message verbatim in the toast", async () => {
+    profilesSelectMock.mockReturnValue({
+      data: [{ id: "v1", full_name: "Eligible Vol", email: "e@x", bg_check_status: "cleared", is_active: true }],
+      error: null,
+    });
+    shiftInvitationsInsertMock.mockResolvedValue({
+      error: { message: "RLS denied" },
+    });
+    renderOpen();
+    await typeSearch("Eli");
+    fireEvent.click(screen.getByText("Eligible Vol").closest("button")!);
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /send invitation/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Failed to send invitation",
+        description: "RLS denied",
+        variant: "destructive",
+      }));
+    });
+  });
+});

--- a/src/components/shifts/__tests__/ShiftFormDialog.test.tsx
+++ b/src/components/shifts/__tests__/ShiftFormDialog.test.tsx
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+/**
+ * Tier 3 test for ShiftFormDialog.
+ *
+ * Validates: validation-kind branch coverage (missing / invalid_range /
+ * not_assigned / long_shift_needs_confirm), create vs edit semantics,
+ * and edit-mode form pre-population.
+ *
+ * DatePicker + TimePicker are stubbed as plain inputs — same precedent
+ * as AvatarUploadField in Tier 2. The test's purpose is form-validation
+ * + save semantics, not Radix Popover behavior in those shared widgets.
+ */
+
+const insertMock = vi.fn();
+const updateMock = vi.fn();
+const eqMock = vi.fn();
+const toastMock = vi.fn();
+const onSavedMock = vi.fn();
+const onOpenChangeMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: () => ({
+      insert: (...args: unknown[]) => insertMock(...args),
+      update: (...args: unknown[]) => {
+        updateMock(...args);
+        return { eq: (...eqArgs: unknown[]) => eqMock(...eqArgs) };
+      },
+    }),
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+// Stubs for the shared/ children — see file header comment.
+vi.mock("@/components/shared/DatePicker", () => ({
+  DatePicker: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <input data-testid="date-picker" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+vi.mock("@/components/shared/TimePicker", () => ({
+  TimePicker: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <input data-testid="time-picker" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+import { ShiftFormDialog } from "@/components/shifts/ShiftFormDialog";
+import type { Department, Shift } from "@/hooks/useShiftsList";
+
+const departments: Department[] = [
+  { id: "dept-1", name: "Camp Sunnyside" },
+  { id: "dept-2", name: "Adult Day" },
+];
+
+beforeEach(() => {
+  insertMock.mockReset();
+  updateMock.mockReset();
+  eqMock.mockReset();
+  toastMock.mockReset();
+  onSavedMock.mockReset();
+  onOpenChangeMock.mockReset();
+  // Default success.
+  insertMock.mockResolvedValue({ error: null });
+  eqMock.mockResolvedValue({ error: null });
+});
+
+interface RenderOptions {
+  editingShift?: Shift | null;
+  role?: string | null;
+  open?: boolean;
+}
+
+function renderDialog(opts: RenderOptions = {}) {
+  render(
+    <ShiftFormDialog
+      open={opts.open ?? true}
+      onOpenChange={onOpenChangeMock}
+      editingShift={opts.editingShift ?? null}
+      departments={departments}
+      userId="user-coord-1"
+      role={opts.role ?? "admin"}
+      onSaved={onSavedMock}
+    />
+  );
+}
+
+function getDialogScope() {
+  return within(screen.getByRole("dialog"));
+}
+
+function fillTitle(title: string) {
+  fireEvent.change(getDialogScope().getByPlaceholderText(/morning grounds keeping/i), {
+    target: { value: title },
+  });
+}
+
+function fillDate(date: string) {
+  fireEvent.change(screen.getByTestId("date-picker"), { target: { value: date } });
+}
+
+function fillTimes(start: string, end: string) {
+  const pickers = screen.getAllByTestId("time-picker");
+  fireEvent.change(pickers[0], { target: { value: start } });
+  fireEvent.change(pickers[1], { target: { value: end } });
+}
+
+async function selectDepartment(deptId: string) {
+  // Radix Select needs keyboard nav in jsdom (same pattern as AddUserDialog).
+  const dialog = screen.getByRole("dialog");
+  const trigger = within(dialog).getByRole("combobox");
+  fireEvent.keyDown(trigger, { key: "Enter" });
+  const option = await screen.findByRole("option", { name: new RegExp(departments.find((d) => d.id === deptId)!.name, "i") });
+  fireEvent.keyDown(option, { key: "Enter" });
+}
+
+function clickSave() {
+  fireEvent.click(screen.getByRole("button", { name: /create shift|update shift/i }));
+}
+
+describe("ShiftFormDialog", () => {
+  it("toasts 'Missing or invalid fields' and skips supabase when required fields are empty", () => {
+    renderDialog();
+    clickSave();
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringMatching(/missing or invalid fields/i),
+      variant: "destructive",
+    }));
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("toasts 'Invalid time range' when end time is before start time", async () => {
+    renderDialog();
+    fillTitle("Test Shift");
+    await selectDepartment("dept-1");
+    fillDate("2026-06-15");
+    fillTimes("17:00:00", "09:00:00");
+    clickSave();
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringMatching(/invalid time range/i),
+      variant: "destructive",
+    }));
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("toasts 'Not assigned' when a coordinator edits a shift whose department isn't in their assigned list", () => {
+    // Real-world path: a shift exists in dept-2; the coordinator was
+    // unassigned from dept-2 but still has the edit dialog open. The form
+    // pre-populates from editingShift, so form.department_id = "dept-2"
+    // even though departments=[dept-1]. validateShiftForm catches this.
+    const stale: Shift = {
+      id: "shift-stale",
+      title: "Stale Edit",
+      department_id: "dept-2", // not in coordinator's assigned list below
+      shift_date: "2026-06-15",
+      start_time: "09:00:00",
+      end_time: "12:00:00",
+      total_slots: 1,
+      status: "open",
+      coordinator_note: null,
+    };
+    render(
+      <ShiftFormDialog
+        open={true}
+        onOpenChange={onOpenChangeMock}
+        editingShift={stale}
+        departments={[{ id: "dept-1", name: "Camp Sunnyside" }]}
+        userId="user-coord-1"
+        role="coordinator"
+        onSaved={onSavedMock}
+      />
+    );
+    clickSave();
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringMatching(/not assigned/i),
+      variant: "destructive",
+    }));
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("on long shift (>12h), confirms via window.confirm; cancel skips insert; accept proceeds", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm");
+    renderDialog();
+    fillTitle("Long Shift");
+    await selectDepartment("dept-1");
+    fillDate("2026-06-15");
+    fillTimes("06:00:00", "23:00:00"); // 17h
+    // Branch 1: user cancels
+    confirmSpy.mockReturnValueOnce(false);
+    clickSave();
+    expect(insertMock).not.toHaveBeenCalled();
+
+    // Branch 2: user accepts
+    confirmSpy.mockReturnValueOnce(true);
+    clickSave();
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalledTimes(1);
+    });
+    confirmSpy.mockRestore();
+  });
+
+  it("on valid create, calls insert with payload + created_by + success toast + onSaved + onOpenChange(false)", async () => {
+    renderDialog();
+    fillTitle("Morning Grounds");
+    await selectDepartment("dept-1");
+    fillDate("2026-06-15");
+    fillTimes("09:00:00", "12:00:00");
+    clickSave();
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Morning Grounds",
+        department_id: "dept-1",
+        shift_date: "2026-06-15",
+        start_time: "09:00:00",
+        end_time: "12:00:00",
+        created_by: "user-coord-1",
+      }));
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: expect.stringMatching(/shift created/i),
+      }));
+      expect(onOpenChangeMock).toHaveBeenCalledWith(false);
+      expect(onSavedMock).toHaveBeenCalled();
+    });
+  });
+
+  it("on valid edit, calls update().eq() (no created_by) and shows 'Shift updated' toast", async () => {
+    const editing: Shift = {
+      id: "shift-existing",
+      title: "Edit Me",
+      department_id: "dept-1",
+      shift_date: "2026-06-15",
+      start_time: "09:00:00",
+      end_time: "12:00:00",
+      total_slots: 4,
+      status: "open",
+      coordinator_note: null,
+    };
+    renderDialog({ editingShift: editing });
+    // Form is pre-populated; just click save.
+    clickSave();
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Edit Me",
+        department_id: "dept-1",
+      }));
+      // The update payload should NOT include created_by — that's a create-only field.
+      expect(updateMock.mock.calls[0][0]).not.toHaveProperty("created_by");
+      expect(eqMock).toHaveBeenCalledWith("id", "shift-existing");
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: expect.stringMatching(/shift updated/i),
+      }));
+    });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("on supabase error, shows 'Error' toast and keeps the dialog open (no onSaved)", async () => {
+    insertMock.mockResolvedValue({ error: { message: "RLS denied" } });
+    renderDialog();
+    fillTitle("New Shift");
+    await selectDepartment("dept-1");
+    fillDate("2026-06-15");
+    fillTimes("09:00:00", "12:00:00");
+    clickSave();
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Error",
+        description: "RLS denied",
+        variant: "destructive",
+      }));
+    });
+    expect(onOpenChangeMock).not.toHaveBeenCalledWith(false);
+    expect(onSavedMock).not.toHaveBeenCalled();
+  });
+
+  it("opening in edit mode pre-populates the form fields from editingShift", () => {
+    const editing: Shift = {
+      id: "shift-existing",
+      title: "Pre-Populated Title",
+      department_id: "dept-2",
+      shift_date: "2026-07-04",
+      start_time: "13:00:00",
+      end_time: "16:00:00",
+      total_slots: 7,
+      status: "open",
+      coordinator_note: "Bring sunscreen",
+    };
+    renderDialog({ editingShift: editing });
+    // Title input.
+    expect((screen.getByPlaceholderText(/morning grounds keeping/i) as HTMLInputElement).value).toBe("Pre-Populated Title");
+    // Date and times via the stubs.
+    expect((screen.getByTestId("date-picker") as HTMLInputElement).value).toBe("2026-07-04");
+    const pickers = screen.getAllByTestId("time-picker") as HTMLInputElement[];
+    expect(pickers[0].value).toBe("13:00:00");
+    expect(pickers[1].value).toBe("16:00:00");
+    // Total slots.
+    expect((screen.getByDisplayValue(7) as HTMLInputElement).value).toBe("7");
+    // Coordinator note.
+    expect((screen.getByPlaceholderText(/optional note visible/i) as HTMLTextAreaElement).value).toBe("Bring sunscreen");
+  });
+});


### PR DESCRIPTION
## Summary

Tier 3 of Sprint 2 Phase 5b — RTL coverage for the coordinator + volunteer flow components. Adds **26 tests** across 4 files; total suite **169 → 195** passing.

### Components covered
- `ShiftFormDialog` — 8 tests: validation branches (missing / invalid_range / not_assigned / long_shift_needs_confirm — both branches of `window.confirm`), valid create with `created_by`, valid edit without `created_by`, supabase error keeps dialog open, edit-mode pre-population.
- `LoginForm` (QR check-in) — 6 tests: Turnstile gate, email login + `onLoginSuccess`, username RPC resolution, **generic "Invalid credentials" guard against email-enumeration leak** (mirrors Auth.tsx Tier 1 test #5), signin error, MFA AAL step-up gate refuses `onLoginSuccess`.
- `ConfirmCheckinScreen` — 4 tests: single-shift mode, multi-shift mode + "Check In to All", both callback wirings.
- `InviteVolunteerModal` — 8 tests: mount-load eligibility data, 250ms debounce verified at 100ms (no fire) and 350ms (fires), eligibility filter (already-invited / restricted / BG-required), eligible click → standard dialog, eligible click w/ overlap → conflict dialog, send happy path, **unique-violation friendly message with explicit assertion that raw constraint name does not leak**, generic insert error verbatim.

### Test infrastructure
No new dependencies. Existing `src/test/setup.ts` polyfills (ResizeObserver, scrollIntoView, pointer-capture) cover all Tier 3 friction points. DatePicker / TimePicker stubbed as plain inputs for ShiftFormDialog (same precedent as AvatarUploadField stub in Tier 2).

## Phase 5b cumulative metrics (PRs #135 + #136 + this)

| Tier | PR | Tests added | Components |
|---|---|---|---|
| 1 — Auth flow | #135 | 35 | Auth, ResetPassword, AcceptInvite, MFAEnrollment |
| 2 — High-stakes panels | #136 | 31 | DeleteAccountPanel, AddUserDialog, AdminUsers, ProfileEditDialog |
| 3 — Coord + volunteer flows | this | 26 | ShiftFormDialog, LoginForm, ConfirmCheckinScreen, InviteVolunteerModal |
| **Total** | | **92** | **12 components/pages** |

Suite size: **103 → 195** tests. **Phase 5b complete; Sprint 2 substantively complete.**

## Test plan
- [x] `npx vitest run` — 195/195 passing
- [x] `npx tsc --build` — clean
- [x] `npx eslint . --max-warnings=0` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)