### PR TITLE
fix: ManageShifts handles null role gracefully (#128)

### DIFF
--- a/src/hooks/__tests__/useShiftsList.test.tsx
+++ b/src/hooks/__tests__/useShiftsList.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { User } from "@supabase/supabase-js";
+
+/**
+ * Regression test for issue #128: ManageShifts spinner hang on null role.
+ *
+ * Before the fix, the hook's mount effect early-returned when role was
+ * null, never flipping `loading` to false → ManageShifts stuck on its
+ * spinner forever. The fix splits the guard: wait for `user`, but if
+ * `role` is still null clear `loading` so the page can render an empty
+ * fallback (the route guard is the real access check).
+ */
+
+// Chainable query builder that resolves to empty rows for any chain
+// shape (.select().eq().order(), .select().eq().in(), etc.).
+function chainable() {
+  const builder: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "in", "neq", "order", "limit"]) {
+    builder[m] = () => builder;
+  }
+  builder.then = (onFulfilled: (v: unknown) => unknown) =>
+    Promise.resolve({ data: [], error: null }).then(onFulfilled);
+  return builder;
+}
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: () => chainable(),
+  },
+}));
+
+import { useShiftsList } from "@/hooks/useShiftsList";
+
+const fakeUser = { id: "user-1" } as unknown as User;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useShiftsList", () => {
+  it("clears loading when user is loaded but role is still null (issue #128)", async () => {
+    const { result } = renderHook(() => useShiftsList(fakeUser, null));
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.shifts).toEqual([]);
+    expect(result.current.departments).toEqual([]);
+  });
+
+  it("stays in loading while user is null (auth still resolving)", () => {
+    const { result } = renderHook(() => useShiftsList(null, null));
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("loads data and clears loading when user + role are both present", async () => {
+    const { result } = renderHook(() => useShiftsList(fakeUser, "admin"));
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+  });
+});

--- a/src/hooks/useShiftsList.ts
+++ b/src/hooks/useShiftsList.ts
@@ -99,7 +99,16 @@ export function useShiftsList(user: User | null, role: string | null): UseShifts
   }, [user, role]);
 
   useEffect(() => {
-    if (!user || !role) return;
+    // Wait for the auth user to resolve. Once it has, even if `role` is
+    // still null (fresh account, race during sign-up), we must clear
+    // `loading` so the page doesn't hang on its spinner. Issue #128:
+    // ProtectedRoute already gates the route on role, so an empty
+    // shifts/departments render here is the correct fallback.
+    if (!user) return;
+    if (!role) {
+      setLoading(false);
+      return;
+    }
     refresh().then(() => setLoading(false));
   }, [user, role, refresh]);
 


### PR DESCRIPTION
## Summary

- `useShiftsList` initialized `loading=true` and early-returned its mount effect on `!user || !role`, never clearing `loading` if `role` resolved to `null` — `ManageShifts` would hang on its spinner forever.
- Split the guard: wait for `user`, but if `role` is still `null` clear `loading` and leave `shifts`/`departments` empty so the page renders normally.
- `ProtectedRoute requiredRole={["coordinator","admin"]}` remains the real access gate, so this is a defensive fix.

Closes #128.

## Test plan
- [x] New `src/hooks/__tests__/useShiftsList.test.tsx` — 3 tests covering null-role, null-user, and the happy path
- [x] `npx vitest run` — 198/198 passing
- [x] `npx tsc --build` — clean
- [x] `npx eslint . --max-warnings=0` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)