### PR TITLE
fix: refresh MFA backup count on every panel render (#126)

### DIFF
--- a/src/components/settings/MfaPanel.tsx
+++ b/src/components/settings/MfaPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -46,14 +46,24 @@ export function MfaPanel() {
     checkMfa();
   }, []);
 
-  // When MFA is enrolled, fetch how many backup codes the user has left.
+  // Fetch how many backup codes the user has left. Extracted as a callback
+  // so we can invoke it from multiple triggers (mount, focus, post-regen).
+  const refreshBackupCount = useCallback(async () => {
+    const { data, error } = await (supabase as any).rpc("mfa_unused_backup_code_count");
+    if (!error && typeof data === "number") setUnusedBackupCount(data);
+  }, []);
+
+  // When MFA is enrolled, fetch the count. Also refetch when the window
+  // regains focus — issue #126: a backup code consumed during a recovery
+  // login (often in another tab) wouldn't otherwise update the displayed
+  // count, since `enrolled` never flips and the panel stays mounted.
   useEffect(() => {
     if (!enrolled) { setUnusedBackupCount(null); return; }
-    (async () => {
-      const { data, error } = await (supabase as any).rpc("mfa_unused_backup_code_count");
-      if (!error && typeof data === "number") setUnusedBackupCount(data);
-    })();
-  }, [enrolled]);
+    refreshBackupCount();
+    const onFocus = () => { refreshBackupCount(); };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [enrolled, refreshBackupCount]);
 
   const handleEnable = async () => {
     setLoading(true);

--- a/src/components/settings/__tests__/MfaPanel.test.tsx
+++ b/src/components/settings/__tests__/MfaPanel.test.tsx
@@ -177,6 +177,29 @@ describe("MfaPanel", () => {
     expect(screen.getByText("NEW-2")).toBeInTheDocument();
   });
 
+  it("refetches the backup count on window focus (issue #126: count stale after recovery code consumption)", async () => {
+    listFactorsMock.mockResolvedValue({
+      data: { totp: [{ id: "factor-1", status: "verified" }] },
+      error: null,
+    });
+    // First mount-time call returns 10; after a code is consumed elsewhere
+    // and the window regains focus, the next call returns 9.
+    rpcMock
+      .mockResolvedValueOnce({ data: 10, error: null })
+      .mockResolvedValueOnce({ data: 9, error: null });
+
+    render(<MfaPanel />);
+    await screen.findByText(/10 of 10 codes remaining/i);
+
+    // Simulate a backup code being consumed in another tab during recovery
+    // login, then this tab regaining focus.
+    window.dispatchEvent(new Event("focus"));
+
+    await screen.findByText(/9 of 10 codes remaining/i);
+    expect(rpcMock).toHaveBeenCalledWith("mfa_unused_backup_code_count");
+    expect(rpcMock.mock.calls.filter((c) => c[0] === "mfa_unused_backup_code_count").length).toBeGreaterThanOrEqual(2);
+  });
+
   it("shows '0 of 10 codes remaining' messaging when the count RPC returns 0", async () => {
     listFactorsMock.mockResolvedValue({
       data: { totp: [{ id: "factor-1", status: "verified" }] },


### PR DESCRIPTION
## Summary

The `mfa_unused_backup_code_count` RPC only fired when `enrolled` flipped false→true — i.e., once per MfaPanel mount. A backup code consumed during a recovery login (often in another tab, or after re-auth without remount) left the displayed "X of 10 codes remaining" stale until the user clicked "Generate new codes".

Extracted the count fetch into a `useCallback` and added a `window` `focus` listener so the count refreshes when the tab regains focus. The existing mount-time fetch behavior is preserved.

Closes #126.

## Test plan
- [x] New test in `MfaPanel.test.tsx`: mount-time count = 10 → simulate consumption + window focus event → count = 9
- [x] `npx vitest run` — 196/196 passing (was 195, +1 new test)
- [x] `npx tsc --build` — clean
- [x] `npx eslint . --max-warnings=0` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)