### PR TITLE
fix: AdminDepartments dialog creates departments with location_id (#119)

### DIFF
--- a/src/pages/AdminDepartments.tsx
+++ b/src/pages/AdminDepartments.tsx
@@ -32,6 +32,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
 import {
   Loader2,
@@ -55,6 +62,12 @@ interface Department {
   min_age: number | null;
   allows_groups: boolean;
   is_active: boolean;
+  location_id: string;
+}
+
+interface LocationOption {
+  id: string;
+  name: string;
 }
 
 interface DeptForm {
@@ -63,6 +76,7 @@ interface DeptForm {
   requires_bg_check: boolean;
   min_age: string; // string for input, cast on save
   allows_groups: boolean;
+  location_id: string;
 }
 
 const EMPTY_FORM: DeptForm = {
@@ -71,6 +85,7 @@ const EMPTY_FORM: DeptForm = {
   requires_bg_check: false,
   min_age: "",
   allows_groups: false,
+  location_id: "",
 };
 
 /* ------------------------------------------------------------------ */
@@ -81,6 +96,7 @@ export default function AdminDepartments() {
   const { toast } = useToast();
 
   const [departments, setDepartments] = useState<Department[]>([]);
+  const [locations, setLocations] = useState<LocationOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -107,9 +123,18 @@ export default function AdminDepartments() {
     if (data) setDepartments(data as Department[]);
   }, []);
 
+  const fetchLocations = useCallback(async () => {
+    const { data } = await supabase
+      .from("locations")
+      .select("id, name")
+      .eq("is_active", true)
+      .order("name");
+    if (data) setLocations(data as LocationOption[]);
+  }, []);
+
   useEffect(() => {
-    fetchDepartments().then(() => setLoading(false));
-  }, [fetchDepartments]);
+    Promise.all([fetchDepartments(), fetchLocations()]).then(() => setLoading(false));
+  }, [fetchDepartments, fetchLocations]);
 
   /* ---------- Create / Edit Dialog ---------- */
 
@@ -127,6 +152,7 @@ export default function AdminDepartments() {
       requires_bg_check: dept.requires_bg_check,
       min_age: dept.min_age?.toString() ?? "",
       allows_groups: dept.allows_groups,
+      location_id: dept.location_id,
     });
     setDialogOpen(true);
   }
@@ -136,25 +162,31 @@ export default function AdminDepartments() {
       toast({ variant: "destructive", title: "Name is required." });
       return;
     }
+    if (!form.location_id) {
+      toast({ variant: "destructive", title: "Location is required." });
+      return;
+    }
 
     setSaving(true);
-    const payload = {
+    // Schema: `min_age` is NOT NULL with a default of 18 — omit when blank
+    // so the DB default applies. `location_id` is NOT NULL — always include
+    // it. Both pieces fix the broken create/edit paths from issue #119.
+    const basePayload: Record<string, unknown> = {
       name: form.name.trim(),
       description: form.description.trim() || null,
       requires_bg_check: form.requires_bg_check,
-      min_age: form.min_age ? Number(form.min_age) : null,
       allows_groups: form.allows_groups,
+      location_id: form.location_id,
     };
+    if (form.min_age) basePayload.min_age = Number(form.min_age);
+
+    // Boundary cast — Supabase's typed insert/update interface doesn't
+    // expose the dynamic shape we build here. Pattern documented in
+    // eslint.config.js.
+    const payload = basePayload as never;
 
     const { error } = editingId
-      // @ts-expect-error TODO(#119): payload has min_age: null but the schema is
-      // NOT NULL with a default; clearing the field via the dialog 500s. Fix
-      // tracked alongside the INSERT bug below — see issue.
       ? await supabase.from("departments").update(payload).eq("id", editingId)
-      // @ts-expect-error TODO(#119): insert payload missing required location_id.
-      // Department creation via this form has never worked — needs a location
-      // dropdown before it can succeed. See
-      // https://github.com/sabihusman/easterseals-volunteer-scheduler/issues/119
       : await supabase.from("departments").insert(payload);
 
     setSaving(false);
@@ -385,6 +417,25 @@ export default function AdminDepartments() {
                 onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
                 placeholder="e.g. Therapeutic Recreation"
               />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Location *</Label>
+              <Select
+                value={form.location_id}
+                onValueChange={(v) => setForm((f) => ({ ...f, location_id: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a location" />
+                </SelectTrigger>
+                <SelectContent>
+                  {locations.map((loc) => (
+                    <SelectItem key={loc.id} value={loc.id}>
+                      {loc.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-1.5">

--- a/src/pages/__tests__/AdminDepartments.test.tsx
+++ b/src/pages/__tests__/AdminDepartments.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+/**
+ * Issue #119: AdminDepartments create/edit dialog never worked because
+ * `location_id` (NOT NULL in schema) had no field, and `min_age` (NOT NULL
+ * with default 18) was sent as null when blank — both INSERTs and UPDATEs
+ * with empty min_age were 500ing.
+ *
+ * Tests cover the three branches the fix touches:
+ *   - validation: bail when no location selected
+ *   - create: insert payload includes location_id; min_age omitted when blank
+ *   - edit: update payload omits min_age when blank (not null)
+ */
+
+const fromMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: (...a: unknown[]) => fromMock(...a),
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+import AdminDepartments from "@/pages/AdminDepartments";
+
+const sampleDepts = [
+  {
+    id: "dept-1",
+    name: "Camp Sunnyside",
+    description: "Camp",
+    requires_bg_check: false,
+    min_age: 18,
+    allows_groups: true,
+    is_active: true,
+    location_id: "loc-1",
+  },
+];
+const sampleLocations = [
+  { id: "loc-1", name: "Des Moines HQ" },
+  { id: "loc-2", name: "Cedar Rapids" },
+];
+
+const insertMock = vi.fn();
+const updateMock = vi.fn();
+const eqUpdateMock = vi.fn();
+
+function setupSupabase() {
+  // Each .from(table) call returns a chainable builder that resolves to the
+  // appropriate seeded data; insert/update/eq are spies we assert against.
+  fromMock.mockImplementation((table: string) => {
+    if (table === "departments") {
+      return {
+        select: () => ({
+          order: () => Promise.resolve({ data: sampleDepts, error: null }),
+        }),
+        insert: (...a: unknown[]) => {
+          insertMock(...a);
+          return Promise.resolve({ error: null });
+        },
+        update: (...a: unknown[]) => {
+          updateMock(...a);
+          return { eq: (...e: unknown[]) => {
+            eqUpdateMock(...e);
+            return Promise.resolve({ error: null });
+          } };
+        },
+      };
+    }
+    if (table === "locations") {
+      return {
+        select: () => ({
+          eq: () => ({
+            order: () => Promise.resolve({ data: sampleLocations, error: null }),
+          }),
+        }),
+      };
+    }
+    return { select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }) };
+  });
+}
+
+beforeEach(() => {
+  fromMock.mockReset();
+  insertMock.mockReset();
+  updateMock.mockReset();
+  eqUpdateMock.mockReset();
+  toastMock.mockReset();
+  setupSupabase();
+});
+
+async function selectLocation(name: RegExp) {
+  // Radix Select needs keyboard nav in jsdom (same pattern as ShiftFormDialog).
+  const trigger = screen.getByRole("combobox");
+  fireEvent.keyDown(trigger, { key: "Enter" });
+  const option = await screen.findByRole("option", { name });
+  fireEvent.keyDown(option, { key: "Enter" });
+}
+
+async function openCreateDialog() {
+  const button = await screen.findByRole("button", { name: /add department/i });
+  fireEvent.click(button);
+  await screen.findByRole("dialog");
+}
+
+describe("AdminDepartments dialog (#119)", () => {
+  it("validates location: shows toast and skips insert when no location is selected", async () => {
+    render(<AdminDepartments />);
+    await openCreateDialog();
+    fireEvent.change(screen.getByPlaceholderText(/therapeutic recreation/i), {
+      target: { value: "New Dept" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create department/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Location is required.",
+        variant: "destructive",
+      }));
+    });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("on valid create, includes location_id in the insert payload and omits min_age when blank", async () => {
+    render(<AdminDepartments />);
+    await openCreateDialog();
+    fireEvent.change(screen.getByPlaceholderText(/therapeutic recreation/i), {
+      target: { value: "New Dept" },
+    });
+    await selectLocation(/cedar rapids/i);
+    fireEvent.click(screen.getByRole("button", { name: /create department/i }));
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalledTimes(1);
+    });
+    const payload = insertMock.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      name: "New Dept",
+      location_id: "loc-2",
+    });
+    // Schema default (18) should apply on the DB side — payload must not
+    // carry min_age at all when the input was blank.
+    expect(payload).not.toHaveProperty("min_age");
+  });
+
+  it("on edit with blank min_age, the update payload omits min_age (must not be null)", async () => {
+    render(<AdminDepartments />);
+    // Open edit on the seeded department.
+    const editButtons = await screen.findAllByRole("button");
+    // The pencil button is the first action button in the row.
+    const pencil = editButtons.find((b) => b.querySelector(".lucide-pencil"));
+    expect(pencil).toBeTruthy();
+    fireEvent.click(pencil!);
+    await screen.findByRole("dialog");
+
+    // Clear min_age (was 18 from the fixture).
+    const dialog = screen.getByRole("dialog");
+    const minAgeInput = within(dialog).getByPlaceholderText(/leave blank for no minimum/i);
+    fireEvent.change(minAgeInput, { target: { value: "" } });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledTimes(1);
+    });
+    const payload = updateMock.mock.calls[0][0];
+    // The fix: omit, not null. Schema default of 18 will apply.
+    expect(payload).not.toHaveProperty("min_age");
+    expect(payload.location_id).toBe("loc-1");
+    expect(eqUpdateMock).toHaveBeenCalledWith("id", "dept-1");
+  });
+});


### PR DESCRIPTION
## Summary

The create-department dialog in `AdminDepartments.tsx` has been broken since launch. Two NOT NULL constraints in the schema were being violated by the form:

| Column | Constraint | Bug |
|---|---|---|
| `departments.location_id` | `uuid NOT NULL` (FK → locations) | Form had no field for it. Every INSERT failed. |
| `departments.min_age` | `integer NOT NULL DEFAULT 18` | Form passed `null` when blank. Clearing the field on edit 500ed. |

Both bugs were guarded by `@ts-expect-error TODO(#119)` directives added during the strict-mode triage in PR #120.

## Fix

- Added `LocationOption` type, `locations` state, and a mount-time fetch of active locations alongside the existing departments fetch.
- Added a **Location** `<Select>` to the create/edit dialog.
- Extended `Department` and `DeptForm` interfaces with `location_id: string`.
- Validate `location_id` is non-empty in `handleSaveDialog` (toast + bail).
- Build the save payload conditionally: always include `location_id`, only include `min_age` when the input is non-blank (so the DB default of 18 applies).
- **Removed both `@ts-expect-error TODO(#119)` directives.** The new payload type-checks cleanly via the documented `as never` boundary cast.

No other behavior changed — rename, BG-toggle, active-toggle, and delete flows are untouched.

## Test plan
- [x] New `src/pages/__tests__/AdminDepartments.test.tsx` — 3 tests:
  - validation: missing location → toast, no insert
  - create: insert payload contains `location_id`, omits `min_age` when blank
  - edit: clearing `min_age` produces an update payload that omits the field (not `null`)
- [x] `npx vitest run` — **198/198 passing** (was 195, +3 new)
- [x] `npx tsc --build` — clean (and the removed `@ts-expect-error`s don't surface new errors)
- [x] `npx eslint . --max-warnings=0` — clean

Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)