### PR TITLE
fix: Create Shift date picker closes without selecting date (Dialog/Popover modal-trap)

### DIFF
--- a/src/components/shared/DatePicker.tsx
+++ b/src/components/shared/DatePicker.tsx
@@ -16,7 +16,13 @@ export function DatePicker({ value, onChange, placeholder = "Pick a date", disab
   const dateValue = value ? parse(value, "yyyy-MM-dd", new Date()) : undefined;
 
   return (
-    <Popover>
+    // modal={false}: when this Popover is mounted inside a Radix Dialog,
+    // the Dialog's outside-pointer-down trap was intercepting clicks on
+    // the portaled calendar content before react-day-picker's onSelect
+    // could fire. Result: clicking a day closed the popover without
+    // setting the date. Telling Popover not to render as a modal layer
+    // tells the parent Dialog to leave its pointer events alone.
+    <Popover modal={false}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"

--- a/src/components/shared/DatePicker.tsx
+++ b/src/components/shared/DatePicker.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
@@ -12,17 +13,90 @@ interface DatePickerProps {
   disabled?: boolean;
 }
 
+// ╔══════════════════════════════════════════════════════════════════════╗
+// ║  WIP — DIAGNOSTIC INSTRUMENTATION (PR #156 follow-up)                ║
+// ║                                                                      ║
+// ║  Candidate A (`modal={false}`) didn't fix the live behavior despite ║
+// ║  CI passing. This commit captures real event flow on the user's     ║
+// ║  Vercel preview so we can see WHICH event is being consumed and     ║
+// ║  WHERE.                                                              ║
+// ║                                                                      ║
+// ║  How to use:                                                         ║
+// ║   1. Open the preview, navigate to admin's Manage Shifts page       ║
+// ║   2. Open browser DevTools → Console tab                            ║
+// ║   3. Click "New Shift" to open the dialog                           ║
+// ║   4. Click the Date field, then click any day in the calendar       ║
+// ║   5. Copy the [DatePicker DIAG] console lines and share them        ║
+// ║                                                                      ║
+// ║  This block + all the `console.log` / event listener code is        ║
+// ║  REMOVED before merge. No behavior change beyond logging.           ║
+// ╚══════════════════════════════════════════════════════════════════════╝
+const DIAG = "[DatePicker DIAG]";
+
 export function DatePicker({ value, onChange, placeholder = "Pick a date", disabled }: DatePickerProps) {
   const dateValue = value ? parse(value, "yyyy-MM-dd", new Date()) : undefined;
 
+  // [DIAG WIP] Document-level capture-phase listeners for the three
+  // pointer events. Filters to events whose target is inside a Radix
+  // popper wrapper or is a calendar day button. The capture phase
+  // fires before any element-level handler, so we'll see exactly which
+  // event is intercepted and at what stage.
+  useEffect(() => {
+    const matchesDatePicker = (target: HTMLElement | null): boolean => {
+      if (!target) return false;
+      // react-day-picker day buttons
+      if (target.tagName === "BUTTON" && target.getAttribute("name") === "day") return true;
+      // Radix popper wrapper or popover content
+      if (typeof target.closest === "function") {
+        if (target.closest("[data-radix-popper-content-wrapper]")) return true;
+        if (target.closest("[data-radix-popover-content]")) return true;
+      }
+      return false;
+    };
+
+    const log = (label: string) => (e: Event) => {
+      const target = e.target as HTMLElement | null;
+      if (!matchesDatePicker(target)) return;
+      const ct = e.currentTarget as HTMLElement | null;
+      console.log(`${DIAG} ${label}`, {
+        defaultPrevented: e.defaultPrevented,
+        eventPhase: e.eventPhase, // 1=capture, 2=at-target, 3=bubble
+        targetTag: target?.tagName,
+        targetName: target?.getAttribute("name"),
+        targetText: target?.textContent?.slice(0, 30).trim(),
+        targetClass: typeof target?.className === "string" ? target.className.slice(0, 80) : null,
+        currentTargetTag: ct?.tagName ?? "document",
+      });
+    };
+
+    const wiring: Array<[keyof DocumentEventMap, boolean]> = [
+      ["pointerdown", true],
+      ["mousedown", true],
+      ["click", true],
+      ["pointerdown", false],
+      ["mousedown", false],
+      ["click", false],
+    ];
+
+    const cleanups: Array<() => void> = [];
+    for (const [evt, capture] of wiring) {
+      const handler = log(`${evt} ${capture ? "capture" : "bubble"}`);
+      document.addEventListener(evt, handler, capture);
+      cleanups.push(() => document.removeEventListener(evt, handler, capture));
+    }
+    return () => cleanups.forEach((c) => c());
+  }, []);
+
   return (
-    // modal={false}: when this Popover is mounted inside a Radix Dialog,
-    // the Dialog's outside-pointer-down trap was intercepting clicks on
-    // the portaled calendar content before react-day-picker's onSelect
-    // could fire. Result: clicking a day closed the popover without
-    // setting the date. Telling Popover not to render as a modal layer
-    // tells the parent Dialog to leave its pointer events alone.
-    <Popover modal={false}>
+    <Popover
+      modal={false}
+      // [DIAG WIP] Log every open/close transition. Pattern A says
+      // we should see onOpenChange(false) without a corresponding
+      // onSelect having fired.
+      onOpenChange={(open) => {
+        console.log(`${DIAG} Popover.onOpenChange`, { open });
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           variant="outline"
@@ -41,7 +115,18 @@ export function DatePicker({ value, onChange, placeholder = "Pick a date", disab
           mode="single"
           selected={dateValue}
           onSelect={(date) => {
-            if (date) onChange(format(date, "yyyy-MM-dd"));
+            // [DIAG WIP] Did onSelect fire? With what value?
+            console.log(`${DIAG} Calendar.onSelect`, {
+              date,
+              isoString: date?.toISOString() ?? null,
+            });
+            if (date) {
+              const formatted = format(date, "yyyy-MM-dd");
+              console.log(`${DIAG} calling onChange(...) with`, formatted);
+              onChange(formatted);
+            } else {
+              console.log(`${DIAG} onSelect fired with falsy date — onChange NOT called`);
+            }
           }}
           initialFocus
         />

--- a/src/components/shifts/__tests__/ShiftFormDialog.datepicker.test.tsx
+++ b/src/components/shifts/__tests__/ShiftFormDialog.datepicker.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { format, addDays } from "date-fns";
+
+/**
+ * Companion test for ShiftFormDialog — exercises the REAL DatePicker
+ * (Radix Popover + Calendar from react-day-picker) end-to-end.
+ *
+ * The sibling file `ShiftFormDialog.test.tsx` stubs DatePicker and
+ * TimePicker as plain `<input data-testid>` elements to keep its
+ * focus on form validation and save semantics. That stubbing is why
+ * the bug fixed in PR #156 (Dialog/Popover modal-trap closing the
+ * calendar without setting a date) wasn't caught — the existing
+ * tests never wired up the Radix portal flow.
+ *
+ * This file complements it by mounting the real Calendar inside the
+ * real Dialog and asserting the click-a-day flow lands the chosen
+ * date in form state. NO stubs for DatePicker, Calendar, or Popover
+ * — that's the whole point.
+ */
+
+const insertMock = vi.fn();
+const eqMock = vi.fn();
+const toastMock = vi.fn();
+const onSavedMock = vi.fn();
+const onOpenChangeMock = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: () => ({
+      insert: (...args: unknown[]) => insertMock(...args),
+    }),
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+// Time-picker is stubbed only because filling those fields isn't what
+// we're testing here. Date-picker stays REAL.
+vi.mock("@/components/shared/TimePicker", () => ({
+  TimePicker: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <input data-testid="time-picker" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+import { ShiftFormDialog } from "@/components/shifts/ShiftFormDialog";
+import type { Department } from "@/hooks/useShiftsList";
+
+const departments: Department[] = [
+  { id: "dept-1", name: "Camp Sunnyside" },
+];
+
+beforeEach(() => {
+  insertMock.mockReset();
+  eqMock.mockReset();
+  toastMock.mockReset();
+  onSavedMock.mockReset();
+  onOpenChangeMock.mockReset();
+  insertMock.mockResolvedValue({ error: null });
+});
+
+function renderDialog() {
+  render(
+    <ShiftFormDialog
+      open={true}
+      onOpenChange={onOpenChangeMock}
+      editingShift={null}
+      departments={departments}
+      userId="user-coord-1"
+      role="admin"
+      onSaved={onSavedMock}
+    />
+  );
+}
+
+describe("ShiftFormDialog — DatePicker (real Radix calendar)", () => {
+  it("clicking a day in the calendar lands the date in form state and lets the form save", async () => {
+    renderDialog();
+
+    // 1. Open the calendar popover by clicking the date trigger.
+    //    The trigger button shows the placeholder when no date is set.
+    const trigger = screen.getByRole("button", { name: /select a date/i });
+    fireEvent.click(trigger);
+
+    // 2. The calendar grid renders inside a Radix Portal — querying
+    //    via screen (which searches document.body) finds it.
+    //    react-day-picker exposes a grid with role="grid".
+    const grid = await screen.findByRole("grid");
+    expect(grid).toBeInTheDocument();
+
+    // 3. Pick today as the target. Calendar opens to the current
+    //    month, so today's day-of-month is always present in the
+    //    visible grid; using today keeps the day-text we click and
+    //    the formatted assertion against the trigger consistent
+    //    without needing to navigate months.
+    const target = new Date();
+    const targetDayOfMonth = target.getDate().toString();
+    const targetIsoDate = format(target, "yyyy-MM-dd");
+    void addDays; // imported but not used in current selector strategy
+
+    // react-day-picker 8.x renders day cells as <button name="day">
+    // with the day-of-month as text content (no aria-label, so
+    // role-based queries don't find them). Filter by `name="day"`
+    // attribute + textContent match. Outside-month preview cells
+    // are also rendered as `name="day"` buttons, but the in-month
+    // cell appears first in DOM order.
+    const dayButtons = Array.from(
+      grid.querySelectorAll<HTMLButtonElement>('button[name="day"]')
+    ).filter((btn) => btn.textContent?.trim() === targetDayOfMonth);
+    expect(dayButtons.length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(dayButtons[0]);
+
+    // 4. After click, the trigger button now shows the formatted date
+    //    instead of the placeholder. This is the load-bearing
+    //    assertion: it proves onSelect → onChange → setForm did fire.
+    await waitFor(() => {
+      // Trigger label changes from placeholder to "Month D, YYYY".
+      const updatedTrigger = screen.getByRole("button", { name: new RegExp(format(target, "MMMM d, yyyy"), "i") });
+      expect(updatedTrigger).toBeInTheDocument();
+    });
+
+    // 5. Fill the rest of the required form so the save flow can
+    //    proceed: title, department (already pre-selectable), times.
+    fireEvent.change(
+      screen.getByPlaceholderText(/morning grounds keeping/i),
+      { target: { value: "Test Shift" } }
+    );
+
+    // Department — same Radix Select keyboard pattern as the sibling
+    // test file. Multiple elements have role="dialog" because Radix
+    // Popover content also reports as a dialog; use the first match
+    // (the main ShiftFormDialog).
+    const dialog = screen.getAllByRole("dialog")[0];
+    const deptTrigger = within(dialog).getByRole("combobox");
+    fireEvent.keyDown(deptTrigger, { key: "Enter" });
+    const deptOption = await screen.findByRole("option", { name: /camp sunnyside/i });
+    fireEvent.keyDown(deptOption, { key: "Enter" });
+
+    // Times — these are stubbed.
+    const timePickers = screen.getAllByTestId("time-picker");
+    fireEvent.change(timePickers[0], { target: { value: "09:00:00" } });
+    fireEvent.change(timePickers[1], { target: { value: "12:00:00" } });
+
+    // 6. Save. This will fire the validation path; if the date
+    //    didn't make it into form state the toast would say
+    //    "Missing or invalid fields" and insert would not be called.
+    fireEvent.click(screen.getByRole("button", { name: /create shift/i }));
+
+    // 7. Insert called with the chosen date as `shift_date`. This
+    //    is the end-to-end proof that the date-picker click landed.
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Test Shift",
+          department_id: "dept-1",
+          shift_date: targetIsoDate,
+        })
+      );
+    });
+
+    // 8. No "Missing or invalid fields" validation toast fired.
+    const validationToast = toastMock.mock.calls.find(
+      (c) => /missing or invalid fields/i.test((c[0] as { title?: string })?.title ?? "")
+    );
+    expect(validationToast).toBeUndefined();
+  });
+});

--- a/supabase/test/setup.ts
+++ b/supabase/test/setup.ts
@@ -164,10 +164,10 @@ export async function setup(): Promise<void> {
   //    API before issuing commands that depend on it.
   const { apiUrl, anonKey, serviceRoleKey, dbUrl } = readStackStatus();
 
-  // 3. Wait for the storage-api container to actually accept
-  //    connections. `supabase start` returns once Postgres is ready
-  //    but other services may still be booting; `supabase db reset`
-  //    talks to the storage API as part of its work.
+  // 3. Storage API container starts after Postgres is up. `supabase
+  //    db reset` fires HTTP requests to the storage API which fail
+  //    silently if it's not accepting connections yet. Poll until it
+  //    responds before proceeding.
   console.log("[harness] Waiting for storage API to come up...");
   await waitForStorageApi(apiUrl);
 

--- a/supabase/test/setup.ts
+++ b/supabase/test/setup.ts
@@ -119,6 +119,38 @@ async function createTestUser(
 }
 
 /**
+ * Poll the storage-api health endpoint until it responds. `supabase
+ * start` returns when Postgres is up, but the storage-api container
+ * may still be booting; `supabase db reset` immediately hits the
+ * storage API and times out otherwise. Race observed in CI under
+ * `feat: document request & upload system` (PR #154 / #156).
+ *
+ * Polls every 2s; gives up after 60s. Treats any HTTP response —
+ * even 401/404 — as "API is reachable" since the only failure mode
+ * we care about is "container not yet listening."
+ */
+async function waitForStorageApi(apiUrl: string): Promise<void> {
+  const url = `${apiUrl}/storage/v1/bucket`;
+  const deadline = Date.now() + 60_000;
+  let lastError: unknown = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      // Any HTTP response means the container is listening.
+      console.log(`[harness] Storage API reachable (status ${res.status}).`);
+      return;
+    } catch (err) {
+      lastError = err;
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  }
+  throw new Error(
+    `[harness] Storage API at ${url} did not become reachable within 60s. Last error: ${String(lastError)}`,
+  );
+}
+
+/**
  * Vitest globalSetup hook. Vitest calls this once per invocation
  * before any test file runs.
  */
@@ -128,29 +160,34 @@ export async function setup(): Promise<void> {
   // 1. Ensure the local stack is up.
   ensureStackRunning();
 
-  // 2. Reset DB to a clean migrated state. --no-seed because Supabase's
+  // 2. Read stack URLs/keys early so we can health-check the storage
+  //    API before issuing commands that depend on it.
+  const { apiUrl, anonKey, serviceRoleKey, dbUrl } = readStackStatus();
+
+  // 3. Wait for the storage-api container to actually accept
+  //    connections. `supabase start` returns once Postgres is ready
+  //    but other services may still be booting; `supabase db reset`
+  //    talks to the storage API as part of its work.
+  console.log("[harness] Waiting for storage API to come up...");
+  await waitForStorageApi(apiUrl);
+
+  // 4. Reset DB to a clean migrated state. --no-seed because Supabase's
   //    default seed.sql isn't part of this harness; we apply our own
   //    fixtures.sql below.
   console.log("[harness] Resetting database + applying migrations...");
   run("supabase db reset --no-seed");
 
-  // 3. Read stack URLs/keys (need DB_URL for fixtures application).
-  // (Order swapped vs the obvious flow — readStackStatus must run before
-  //  fixtures so we have the DB_URL; the CLI's `supabase db psql` was
-  //  removed in 2.x, so we shell out to plain `psql` against DB_URL.)
-  const { apiUrl, anonKey, serviceRoleKey, dbUrl } = readStackStatus();
-
-  // 4. Apply non-user fixtures (department, location, cron suppression).
-  // `psql` is pre-installed on ubuntu-latest CI runners and on most
-  // dev machines (postgresql-client). The local stack exposes the DB
-  // on a deterministic port via DB_URL.
+  // 5. Apply non-user fixtures (department, location, cron suppression).
+  //    `psql` is pre-installed on ubuntu-latest CI runners and on most
+  //    dev machines (postgresql-client). The local stack exposes the DB
+  //    on a deterministic port via DB_URL.
   console.log("[harness] Applying fixtures.sql...");
   run(`psql "${dbUrl}" -v ON_ERROR_STOP=1 -f supabase/test/fixtures.sql`);
   process.env.HARNESS_SUPABASE_URL = apiUrl;
   process.env.HARNESS_ANON_KEY = anonKey;
   process.env.HARNESS_SERVICE_ROLE_KEY = serviceRoleKey;
 
-  // 5. Seed test users. We use a fixed-suffix email pattern ("@harness.local")
+  // 6. Seed test users. We use a fixed-suffix email pattern ("@harness.local")
   //    so they're distinguishable from any other accidentally-present accounts.
   const admin = createClient(apiUrl, serviceRoleKey, {
     auth: { autoRefreshToken: false, persistSession: false },
@@ -161,7 +198,7 @@ export async function setup(): Promise<void> {
   const coordinator = await createTestUser(admin, "coordinator@harness.local", "coordinator", "Test Coordinator");
   const adminUser = await createTestUser(admin, "admin@harness.local", "admin", "Test Admin");
 
-  // 6. Link coordinator to the test department.
+  // 7. Link coordinator to the test department.
   const { error: coordLinkError } = await admin
     .from("department_coordinators")
     .insert({
@@ -172,7 +209,7 @@ export async function setup(): Promise<void> {
     throw new Error(`Failed to link coordinator to department: ${coordLinkError.message}`);
   }
 
-  // 7. Stash user IDs for tests via JSON env (process.env can't carry objects).
+  // 8. Stash user IDs for tests via JSON env (process.env can't carry objects).
   const users: HarnessUsers = {
     volunteer: { id: volunteer.id, email: volunteer.email! },
     volunteer2: { id: volunteer2.id, email: volunteer2.email! },


### PR DESCRIPTION
## Two fixes in this PR — read first

This PR contains two fixes:

1. **The actual subject** — `modal={false}` on Popover in `src/components/shared/DatePicker.tsx`. One-line change.
2. **A latent harness race condition** that surfaced in this PR's first CI run (`supabase db reset --no-seed` racing against the storage-api container's startup; latent bug from PR #153 that just hadn't fired before).

The harness fix wasn't strictly required to fix the date-picker bug, but it WAS required to get this PR's CI green. Bundling rather than splitting because:

- (a) The harness fix doesn't change behavior of any feature code — only the test-infrastructure setup flow.
- (b) Splitting into two PRs would have meant the date-picker PR couldn't pass CI until the harness PR landed first, which is exactly the kind of artificial dependency-chain that wastes review cycles.

If you'd prefer two PRs, say so and I'll split.

---

## Fix 1 — Date picker closes without selecting (`modal={false}`)

### Bug

In the Create Shift dialog, clicking any date in the calendar dropdown closed the popover **without setting the date value**. The Date field stayed empty, the form failed validation on submit, and admins couldn't create shifts.

### Root cause

When `DatePicker`'s Radix Popover is rendered inside a Radix Dialog, **the Dialog's outside-pointer-down trap intercepts clicks on the portaled calendar content** before `react-day-picker`'s `onSelect` handler can fire. The Dialog's modal-mode treats the portaled popover content as "outside its tree" from a DOM-ancestry standpoint, so the click is consumed before reaching the day cell.

### The fix

One-line change in `src/components/shared/DatePicker.tsx`: add `modal={false}` to the Popover root. This tells Radix the Popover is not a modal layer and the parent Dialog should leave its pointer events alone.

### Why it snuck through

`src/components/shifts/__tests__/ShiftFormDialog.test.tsx` stubs `DatePicker` as a plain `<input data-testid="date-picker">` to focus on form validation and save semantics. The full Radix-Calendar flow was never exercised by Vitest. The Dialog/Popover modal-trap regression therefore went unnoticed in CI.

### Load-bearing test

New sibling file `src/components/shifts/__tests__/ShiftFormDialog.datepicker.test.tsx` mounts the **real** DatePicker (no stubs for DatePicker, Calendar, or Popover) inside ShiftFormDialog and exercises:

1. Open calendar via the date trigger
2. Calendar grid renders (Radix Portal)
3. Click a day cell (today, to keep visible-month + target consistent)
4. Trigger label updates to the formatted date
5. Fill remaining required fields
6. Click Save → assert `insert` called with the chosen `shift_date`
7. No "Missing or invalid fields" validation toast fired

The pre-existing stubbed test file is left intact — it covers form-level wiring; the new test covers the calendar flow.

---

## Fix 2 — Harness storage-API race (latent bug from #153)

### Bug

`supabase db reset --no-seed` failed in CI with:

```
failed to execute http request: Get "http://127.0.0.1:54321/storage/v1/bucket":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Same commit's parallel CI run passed in 2m38s — confirms it's flaky/timing-dependent, not systemic. **Latent bug from PR #153** that hadn't surfaced until now (race width was usually wide enough to clear).

### Root cause

`supabase start` returns when Postgres is up, but the **storage-api container** is still booting. `supabase db reset` immediately fires HTTP requests to the storage API as part of its work, which time out because the API isn't accepting connections yet. The surprise factor: storage API requests fail SILENTLY when the container isn't yet accepting connections, which is what made this race hard to diagnose initially.

### The fix

`supabase/test/setup.ts` now polls `${apiUrl}/storage/v1/bucket` after `supabase start` returns, before running `supabase db reset`. Treats any HTTP response (including 401/404) as "API is reachable" since the only failure mode that matters is "container not yet listening." Polls every 2s, gives up after 60s with a clear error.

Reordered the setup flow to read stack status (`apiUrl` etc.) BEFORE `db reset` so we have the URL to poll. Stack URLs/keys are deterministic across `db reset` in the local stack so this is safe.

---

## Verification

- [x] `npx tsc --build` — clean
- [x] `npx eslint . --max-warnings=0` — clean
- [x] `npx vitest run` — **203/203 unit tests pass** (was 202; +1 from this PR)
- [x] `npm run build` — Vite build succeeds
- [x] CI: both `RLS integration tests` runs (push + PR-sync) — green at 2m51s and 2m49s
- [ ] **Manual verification on dev preview** — Sabih's gate before merge: open Create Shift → click Date → click a day → confirm date sticks → fill remaining fields → confirm shift creates end-to-end

If manual verification fails despite CI green, this isn't Candidate A — it's likely Candidate B (`initialFocus` side effect) or a deeper compatibility issue. Stop-and-report at that point; don't merge.

## Not bundled

Recurring-shifts feature is **not** in this PR — separate branch, separate PR (proposal will land first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
