### PR TITLE
fix: bump DatePicker popover z-index above dialog stacking layer

### DIFF
--- a/src/components/shared/DatePicker.tsx
+++ b/src/components/shared/DatePicker.tsx
@@ -37,7 +37,34 @@ export function DatePicker({ value, onChange, placeholder = "Pick a date", disab
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-auto p-0"
+        // z-[60] overrides the default z-50 from
+        // src/components/ui/popover.tsx via tailwind-merge.
+        //
+        // The DialogOverlay, DialogContent, and PopoverContent are all
+        // at z-50 by default. DialogContent creates a stacking context
+        // via `transform: translate(...)`, so its descendants (form
+        // labels, inputs, etc.) compete with the popover at the same
+        // z-50 layer when both are portaled to body. Real-Chromium
+        // evidence (PR #159 Playwright spec timeout): the dialog
+        // subtree was intercepting clicks on day-cell and next-month
+        // buttons inside the popover. Raising the popover above the
+        // dialog's z-50 layer ensures the calendar wins stacking
+        // regardless of DOM-append order or React re-render timing.
+        //
+        // Pairs with `modal={false}` (PR #156) and the
+        // onPointerDownOutside / onOpenAutoFocus handlers below
+        // (PR #158). Each layer addresses a different surface:
+        //   - modal={false}: Dialog stops trapping pointerdown for
+        //     popover-content events at the Radix model layer
+        //   - onPointerDownOutside conditional preventDefault: stops
+        //     the popover from closing when its own descendants are
+        //     clicked
+        //   - onOpenAutoFocus preventDefault: stops focus-stolen
+        //     events from being misread as outside-clicks
+        //   - z-[60] (this fix): puts the popover physically above
+        //     the dialog so descendants of the dialog don't
+        //     geometrically intercept the click
+        className="z-[60] w-auto p-0"
         align="start"
         // Sabih's diagnostic from PR #156 captured zero pointerdown /
         // click / Calendar.onSelect events on production despite


### PR DESCRIPTION
## What the diagnostic showed

PR #159's Playwright spec ran against production and timed out with the same trace from PR #158's earlier run:

```
Test timeout of 60000ms exceeded.
<label "End Time *"> from <div role="dialog" id="radix-:r7:">
subtree intercepts pointer events
```

**This is NOT a handler-level bug.** It's CSS-stacking-level. Confirmed by:
- The `End Time` label (a deep descendant of DialogContent) is intercepting clicks meant for the calendar
- The dialog content has `transform: translate(-50%, -50%)` which creates a stacking context
- Both DialogContent and PopoverContent are at `z-50`
- Their descendants compete at the same layer; whichever stacking context wins (dialog's, due to render order + parent stacking) intercepts the click

## Root cause

```
DialogOverlay:    z-50
DialogContent:    z-50  ← creates stacking context via transform
PopoverContent:   z-50
```

When both are portaled to `document.body` and share `z-50`, DOM order matters. But because DialogContent creates a stacking context, **all of its descendants stack within that context**, which competes with the popover's stacking layer at z-50. Result: dialog form-fields visually on top of where the calendar opens, intercepting clicks.

## Fix

One-line change in `src/components/shared/DatePicker.tsx`: add `z-[60]` to PopoverContent's className. `tailwind-merge` resolves the conflict by overriding the default `z-50` from the popover.tsx primitive. **Targeted to this single component** — doesn't change the popover.tsx primitive that other parts of the app use without dialog nesting.

## Why all the previous fixes stay (they each address a real surface)

The bug had **four** distinct surfaces; each PR fixed one. All four fixes remain in DatePicker.tsx:

| Layer | What it fixes | PR |
|---|---|---|
| `modal={false}` on Popover | Radix Dialog model layer pointer-trap | #156 |
| `onPointerDownOutside` conditional preventDefault | Close-handler firing on own descendants | #158 |
| `onOpenAutoFocus={(e) => e.preventDefault()}` | Focus-stolen events misread as outside-click | #158 |
| **`z-[60]` on PopoverContent** | **CSS stacking context interception** | **this PR** |

Each was confirmed correct for its surface by a diagnostic capture. The missing layer was CSS — confirmed by Playwright's element-stability checker showing dialog descendants on top.

## Verification

- [x] `npx eslint . --max-warnings=0` — clean
- [x] `npx tsc --build` — clean
- [x] `npx vitest run` — 203/203 unit tests unchanged
- [x] `npm run build` — Vite build succeeds
- [ ] **Real-browser CI:** PR #158's `tests/e2e/06-admin-creates-shift-via-ui.spec.ts` is currently `test.skip()` because it ran against production while production lagged. After this fix merges and deploys, unskipping it should make it pass — that's the proper E2E validation. Follow-up PR after merge.
- [ ] **Manual gate:** Sabih opens the PR-160 Vercel preview (or production after merge), Create Shift, click Date, click any day. Confirm the date sticks and the popover stays open and the form saves.

## What this PR is NOT

- Not modifying any other component
- Not removing the previous handler-level fixes (each addresses a real surface even if z-index turned out to be the dominant cause)
- Not bundling unrelated cleanup
- Not unskipping spec 06 in this PR (would still fail until production deploys; unskip in a follow-up after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)