### PR TITLE
fix: pointer-events-auto on DatePicker popover (z-index alone wasn't enough)

### DIFF
--- a/src/components/shared/DatePicker.tsx
+++ b/src/components/shared/DatePicker.tsx
@@ -37,34 +37,27 @@ export function DatePicker({ value, onChange, placeholder = "Pick a date", disab
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        // z-[60] overrides the default z-50 from
-        // src/components/ui/popover.tsx via tailwind-merge.
+        // pointer-events-auto + z-[60]: PR #160's z-index bump alone
+        // didn't resolve the bug. Diagnosis: Radix Dialog with
+        // modal={true} (its default in DialogContent) sets
+        // `pointer-events: none` on document.body while open.
+        // PopoverContent is portaled to body via Radix Portal, so it
+        // INHERITS pointer-events: none from body — even though it has
+        // higher z-index, browsers' elementFromPoint() skips over
+        // pointer-events:none elements, so the click goes through to
+        // the dialog content beneath. That's the "subtree intercepts
+        // pointer events" Playwright trace from PR #159.
         //
-        // The DialogOverlay, DialogContent, and PopoverContent are all
-        // at z-50 by default. DialogContent creates a stacking context
-        // via `transform: translate(...)`, so its descendants (form
-        // labels, inputs, etc.) compete with the popover at the same
-        // z-50 layer when both are portaled to body. Real-Chromium
-        // evidence (PR #159 Playwright spec timeout): the dialog
-        // subtree was intercepting clicks on day-cell and next-month
-        // buttons inside the popover. Raising the popover above the
-        // dialog's z-50 layer ensures the calendar wins stacking
-        // regardless of DOM-append order or React re-render timing.
+        // `pointer-events-auto` on PopoverContent breaks the
+        // inheritance — the popover and its descendants reactivate
+        // click handling. z-[60] keeps the popover stacked above the
+        // dialog so it actually catches the clicks once they're
+        // routable to it.
         //
-        // Pairs with `modal={false}` (PR #156) and the
-        // onPointerDownOutside / onOpenAutoFocus handlers below
-        // (PR #158). Each layer addresses a different surface:
-        //   - modal={false}: Dialog stops trapping pointerdown for
-        //     popover-content events at the Radix model layer
-        //   - onPointerDownOutside conditional preventDefault: stops
-        //     the popover from closing when its own descendants are
-        //     clicked
-        //   - onOpenAutoFocus preventDefault: stops focus-stolen
-        //     events from being misread as outside-clicks
-        //   - z-[60] (this fix): puts the popover physically above
-        //     the dialog so descendants of the dialog don't
-        //     geometrically intercept the click
-        className="z-[60] w-auto p-0"
+        // Pairs with `modal={false}` (PR #156), onPointerDownOutside
+        // and onOpenAutoFocus (PR #158), and z-[60] (PR #160). Each
+        // layer addresses a different surface; all four remain.
+        className="z-[60] w-auto p-0 pointer-events-auto"
         align="start"
         // Sabih's diagnostic from PR #156 captured zero pointerdown /
         // click / Calendar.onSelect events on production despite


### PR DESCRIPTION
## Why this PR exists

PR #160 deployed `z-[60]` on DatePicker's PopoverContent. **Verified** the class lands in both bundles in production:

```
$ curl prod /assets/index.css | grep z-
.z-50{z-index:50}
.z-\[60\]{z-index:60}    ← present, deployed correctly
```

But PR #159's diagnostic Playwright spec on run #879 (which ran ~5 min after #160 merged, with the fix on production) **still timed out with the same trace**:

```
<div role="dialog" id="radix-:r7:"> subtree intercepts pointer events
retrying click action 100+ times until timeout
```

So z-index alone was NOT the cause. Re-diagnosing.

## Actual root cause

Playwright's "intercepts pointer events" check uses `document.elementFromPoint(x, y)`. That returns the **topmost element at the coordinates that's NOT `pointer-events: none`**. If the popover has higher z-index BUT also has `pointer-events: none`, `elementFromPoint` skips past it and returns the dialog content beneath.

That's exactly what's happening:

- Radix Dialog with `modal={true}` (the default in shadcn `DialogContent`) sets **`pointer-events: none` on `document.body`** while the dialog is open.
- PopoverContent is portaled to `document.body` via Radix Portal.
- **CSS `pointer-events` is inherited.** PopoverContent inherits `pointer-events: none` from body.
- The popover renders visually on top (z-[60] working) but is **transparent to pointer events** because `pointer-events: none` cascaded in from body.
- Clicks pass through to the dialog's form fields underneath. Trace consistently shows `<label "End Time *"> from <div role="dialog">` — exactly that.

## Fix

Add `pointer-events-auto` to PopoverContent's className. Breaks the inheritance from body. Combined with `z-[60]` from PR #160, the popover both **stacks above the dialog** AND **receives the clicks aimed at it**.

```diff
- className="z-[60] w-auto p-0"
+ className="z-[60] w-auto p-0 pointer-events-auto"
```

## Layered defense now at five levels

Each addresses a distinct surface that was confirmed by a diagnostic capture. All five remain in `DatePicker.tsx`:

| Layer | What it fixes | PR |
|---|---|---|
| `modal={false}` on Popover | Radix model layer pointer-trap | #156 |
| `onPointerDownOutside` conditional preventDefault | Close-handler firing on own descendants | #158 |
| `onOpenAutoFocus` preventDefault | Focus-stolen events misread as outside-click | #158 |
| `z-[60]` on PopoverContent | CSS stacking interception | #160 |
| **`pointer-events-auto` on PopoverContent** | **Inherited `pointer-events: none` from body** | **this PR** |

The previous four fixes were each correct for their respective surface. The bug had multiple causes layered on top of each other; #160 unblocked z-index and exposed the pointer-events cascade as the next-deepest cause.

## Verification

- [x] `npx eslint . --max-warnings=0` — clean
- [x] `npx tsc --build` — clean
- [x] `npx vitest run` — **203/203 unit tests pass**
- [x] `npm run build` — Vite build succeeds
- [ ] **Manual gate (yours):** PR-161 Vercel preview, hard-refresh / incognito. Open Create Shift → click Date → click any day. Confirm date sticks.
- [ ] **Real-browser validation post-merge:** unskip `tests/e2e/06-admin-creates-shift-via-ui.spec.ts` AND merge PR #159's spec 07 (which currently lives on a separate branch). Both should pass against production with this fix deployed. Follow-up PR after manual verification confirms the fix.

If your manual test STILL shows the bug after this PR's fix deploys, we have a sixth-layer surface that none of the diagnostic data has surfaced. I'd be very surprised — `pointer-events-auto` directly addresses what `elementFromPoint`-based interception checks read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)