### PR TITLE
fix: a11y labels on icon-only buttons + duplicate DOB label

### DIFF
--- a/src/components/settings/ProfilePanel.tsx
+++ b/src/components/settings/ProfilePanel.tsx
@@ -131,7 +131,6 @@ export function ProfilePanel({
           <Input type="tel" placeholder="(XXX) XXX-XXXX" value={emergencyPhone} onChange={(e) => setEmergencyPhone(e.target.value)} />
         </div>
         <Separator />
-        <p className="text-sm font-medium text-muted-foreground">Date of Birth</p>
         <div className="space-y-2">
           <Label>Date of Birth</Label>
           <Input

--- a/src/components/shifts/ShiftsTable.tsx
+++ b/src/components/shifts/ShiftsTable.tsx
@@ -64,7 +64,7 @@ export function ShiftsTable({ shifts, onEdit, onDelete, onInvite }: Props) {
               </TableCell>
               <TableCell className="text-right">
                 <div className="flex items-center justify-end gap-1">
-                  <Button variant="ghost" size="icon" onClick={() => onInvite(s)} title="Invite volunteer">
+                  <Button variant="ghost" size="icon" onClick={() => onInvite(s)} title="Invite volunteer" aria-label="Invite volunteer">
                     <UserPlus className="h-4 w-4" />
                   </Button>
                   <Button
@@ -73,6 +73,7 @@ export function ShiftsTable({ shifts, onEdit, onDelete, onInvite }: Props) {
                     onClick={() => onEdit(s)}
                     disabled={s.status === "completed"}
                     title={s.status === "completed" ? "Completed shifts cannot be edited" : undefined}
+                    aria-label="Edit shift"
                   >
                     <Pencil className="h-4 w-4" />
                   </Button>
@@ -83,6 +84,7 @@ export function ShiftsTable({ shifts, onEdit, onDelete, onInvite }: Props) {
                     onClick={() => onDelete(s.id)}
                     disabled={s.status === "completed"}
                     title={s.status === "completed" ? "Completed shifts cannot be deleted" : undefined}
+                    aria-label="Delete shift"
                   >
                     <Trash2 className="h-4 w-4" />
                   </Button>

--- a/src/pages/CoordinatorDashboard.tsx
+++ b/src/pages/CoordinatorDashboard.tsx
@@ -304,8 +304,8 @@ export default function CoordinatorDashboard() {
           <div className="flex justify-end">
             <Tabs value={view} onValueChange={(v) => setView(v as "list" | "calendar")}>
               <TabsList>
-                <TabsTrigger value="list"><List className="h-4 w-4" /></TabsTrigger>
-                <TabsTrigger value="calendar"><CalendarDays className="h-4 w-4" /></TabsTrigger>
+                <TabsTrigger value="list" aria-label="List view"><List className="h-4 w-4" /></TabsTrigger>
+                <TabsTrigger value="calendar" aria-label="Calendar view"><CalendarDays className="h-4 w-4" /></TabsTrigger>
               </TabsList>
             </Tabs>
           </div>


### PR DESCRIPTION
## Summary

Three small cleanups from the coordinator-side production sweep:

- **ShiftsTable row actions** — added `aria-label` to the invite / edit / delete icon buttons. They already had `title` for sighted hover but the a11y tree showed unnamed buttons.
- **Department Shifts view toggle** — same fix on the list / calendar `TabsTrigger` icon-only buttons in `CoordinatorDashboard`.
- **Settings → Profile** — removed the redundant "Date of Birth" section header; the `<Label>` below already announces the field, so the heading was rendering the same string twice in a row.

No behavior changes. No styling changes other than the deleted `<p>`.

## Test plan

- [ ] `npm run lint` clean
- [ ] `npx tsc --noEmit` clean
- [ ] Manual: Settings page no longer shows "Date of Birth" twice
- [ ] Manual: Manage Shifts row icon buttons announce "Invite volunteer" / "Edit shift" / "Delete shift" via screen reader
- [ ] Manual: Department Shifts list/calendar toggle announces "List view" / "Calendar view"

🤖 Generated with [Claude Code](https://claude.com/claude-code)