### PR TITLE
chore(deps): ignore date-fns major bumps until react-day-picker 9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,14 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-day-picker"
         update-types: ["version-update:semver-major"]
+      # date-fns is pinned by react-day-picker@8's peer dep
+      # (^2.28.0 || ^3.0.0). PR #163: date-fns 3→4 alone fails
+      # `npm install` with ERESOLVE on the day-picker peer (Vercel
+      # build log: "peer date-fns ^2.28.0 || ^3.0.0 from
+      # react-day-picker@8.10.1"). v4 has to wait for the
+      # coordinated react-day-picker 8→9 migration above.
+      - dependency-name: "date-fns"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react-resizable-panels"
         update-types: ["version-update:semver-major"]
       # Vite + its React plugin must move together; @vitejs/plugin-react-swc


### PR DESCRIPTION
## Summary

Add `date-fns` to the Dependabot major-version ignore list.

Dependabot opened #163 to bump `date-fns` 3.6.0 → 4.1.0. Vercel rejected the install:

\`\`\`
npm error While resolving: react-day-picker@8.10.1
npm error Found: date-fns@4.1.0
npm error Could not resolve dependency:
npm error peer date-fns@\"^2.28.0 || ^3.0.0\" from react-day-picker@8.10.1
\`\`\`

`react-day-picker@8` peer-deps to date-fns ^2 || ^3, so v4 has to wait for the coordinated `react-day-picker` 8→9 migration that's already on the ignore list. Same shape as recharts / react-resizable-panels / vite — locked together until a hand-driven migration PR.

## Test plan

- [ ] Close #163 once this lands
- [ ] Confirm next Dependabot run (Mon) doesn't re-open the date-fns 4 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)