### PR TITLE
fix: show booked slot times on dashboard + warn on cross-location adjacency

### DIFF
--- a/src/components/volunteer/SlotSelectionDialog.tsx
+++ b/src/components/volunteer/SlotSelectionDialog.tsx
@@ -166,6 +166,97 @@ export function SlotSelectionDialog({ open, onOpenChange, shift, bookedSlotIds, 
 
     setSubmitting(true);
 
+    // Adjacency warning: if the volunteer already has a same-day booking
+    // whose slot ends exactly when one of these starts (or vice versa)
+    // AND the existing booking's department lives at a different
+    // physical location, surface a soft confirm. The DB trigger
+    // prevent_overlapping_bookings only blocks true [a,b)-overlap, so
+    // back-to-back slots at different sites pass through silently —
+    // which is what produced the user-reported "double-booked 10–2"
+    // visual in PR #168 review (different shifts, adjacent slots, same
+    // calendar day, distinct locations, zero travel time). Non-blocking
+    // by design: same-LOCATION back-to-back is a legitimate volunteer
+    // pattern (split shift), so we only warn on cross-location adjacency.
+    const selectedSlotRanges = selectedSlots.map((s) => ({
+      slot_start: s.slot_start,
+      slot_end: s.slot_end,
+    }));
+    if (selectedSlotRanges.length > 0) {
+      // Find this shift's location once. department_id is on the prop;
+      // location_id requires the join.
+      const { data: thisShiftLoc } = await supabase
+        .from("shifts")
+        .select("departments(location_id, locations:location_id(name))")
+        .eq("id", shift.id)
+        .maybeSingle();
+      const thisLocationId =
+        // PostgREST embedded select shape — single boundary cast
+        (thisShiftLoc as any)?.departments?.location_id ?? null;
+      const thisLocationName =
+        (thisShiftLoc as any)?.departments?.locations?.name ?? "another location";
+
+      // Pull all same-day bookings for this volunteer with their slot
+      // times AND the location of the parent shift's department.
+      const { data: sameDay } = await supabase
+        .from("shift_bookings")
+        .select(
+          "id, shifts!inner(title, shift_date, department_id, departments(location_id, locations:location_id(name))), shift_time_slots(slot_start, slot_end)"
+        )
+        .eq("volunteer_id", user.id)
+        .in("booking_status", ["confirmed", "waitlisted"])
+        .eq("shifts.shift_date", shift.shift_date);
+
+      type SameDayRow = {
+        id: string;
+        shifts: {
+          title: string;
+          shift_date: string;
+          department_id: string;
+          departments: {
+            location_id: string | null;
+            locations: { name: string } | null;
+          } | null;
+        } | null;
+        shift_time_slots: { slot_start: string; slot_end: string } | null;
+      };
+      const sameDayRows = (sameDay as unknown as SameDayRow[]) || [];
+
+      // Detect adjacency: existing.slot_end == new.slot_start OR
+      // existing.slot_start == new.slot_end. Time strings are HH:MM:SS
+      // so direct equality is safe.
+      let adjacentExisting: SameDayRow | null = null;
+      for (const row of sameDayRows) {
+        if (!row.shift_time_slots) continue;
+        const otherLocId = row.shifts?.departments?.location_id ?? null;
+        // Same-location adjacency is allowed silently.
+        if (otherLocId && thisLocationId && otherLocId === thisLocationId) continue;
+        for (const sel of selectedSlotRanges) {
+          if (
+            row.shift_time_slots.slot_end === sel.slot_start ||
+            row.shift_time_slots.slot_start === sel.slot_end
+          ) {
+            adjacentExisting = row;
+            break;
+          }
+        }
+        if (adjacentExisting) break;
+      }
+
+      if (adjacentExisting) {
+        const otherTitle = adjacentExisting.shifts?.title ?? "another shift";
+        const otherLoc =
+          adjacentExisting.shifts?.departments?.locations?.name ??
+          "a different location";
+        const ok = window.confirm(
+          `Heads up: "${otherTitle}" at ${otherLoc} is back-to-back with this booking, with no travel time between locations (${thisLocationName} ↔ ${otherLoc}). Book anyway?`
+        );
+        if (!ok) {
+          setSubmitting(false);
+          return;
+        }
+      }
+    }
+
     // Fresh per-slot capacity check
     const { data: freshSlots } = await supabase
       .from("shift_time_slots")

--- a/src/components/volunteer/UpcomingShiftCard.tsx
+++ b/src/components/volunteer/UpcomingShiftCard.tsx
@@ -5,7 +5,7 @@ import { Calendar, Clock, MapPin, Shield } from "lucide-react";
 import { format } from "date-fns";
 import { downloadICS, googleCalendarUrl, timeLabel } from "@/lib/calendar-utils";
 import { getEffectiveTimes, isCheckInOpen } from "@/lib/shift-time";
-import { BookedSlotsDisplay } from "@/components/volunteer/BookedSlotsDisplay";
+import { formatSlotRange, slotHours } from "@/lib/slot-utils";
 import { InviteFriendModal } from "@/components/volunteer/InviteFriendModal";
 import type { VolunteerBooking } from "@/hooks/useVolunteerBookings";
 
@@ -49,6 +49,33 @@ export function UpcomingShiftCard({ bookings, today, userId, onCheckIn, onCancel
   const checkInOpen = isToday && isCheckInOpen(s, new Date(nowMs));
   const anyCheckedIn = bookings.some((b) => !!b.checked_in_at);
 
+  // When the volunteer booked specific time slots (rather than the full
+  // shift), the actual committed hours are the slot range(s), NOT the
+  // parent shift window. Pre-PR #170 the card showed only the parent
+  // shift window (e.g. "10:00 AM – 2:00 PM") even when the booking was
+  // for a 2-hour slot inside it, which made two adjacent bookings on the
+  // same day (10–12 + 12–2 in two different shifts that both span 10–2)
+  // visually read as identical duplicates. We now lift the slot times to
+  // the prominent line and demote the parent shift window to secondary.
+  const slotBookings = bookings.filter(
+    (b) => b.time_slot_id && b.shift_time_slots
+  );
+  const sortedSlots = [...slotBookings]
+    .map((b) => b.shift_time_slots!)
+    .sort((a, b) => a.slot_start.localeCompare(b.slot_start));
+  const hasSlotBookings = sortedSlots.length > 0;
+  const slotRangeText = hasSlotBookings
+    ? sortedSlots
+        .map((sl) => formatSlotRange(sl.slot_start, sl.slot_end))
+        .join(", ")
+    : "";
+  const slotTotalHours = hasSlotBookings
+    ? sortedSlots.reduce(
+        (sum, sl) => sum + slotHours(sl.slot_start, sl.slot_end),
+        0
+      )
+    : 0;
+
   return (
     <Card>
       <CardContent className="pt-4 pb-4">
@@ -57,14 +84,24 @@ export function UpcomingShiftCard({ bookings, today, userId, onCheckIn, onCancel
             <div className="font-medium">{s.title}</div>
             <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
               <span className="flex items-center gap-1"><Calendar className="h-3 w-3" />{format(new Date(s.shift_date + "T00:00:00"), "MMM d, yyyy")}</span>
-              <span className="flex items-center gap-1"><Clock className="h-3 w-3" />{timeLabel(s)}</span>
+              <span className="flex items-center gap-1">
+                <Clock className="h-3 w-3" />
+                {hasSlotBookings ? `${slotRangeText} (${slotTotalHours}h)` : timeLabel(s)}
+              </span>
               <span className="flex items-center gap-1"><MapPin className="h-3 w-3" />{s.departments?.name}</span>
             </div>
+            {hasSlotBookings && (
+              // Secondary line: the parent shift window. Kept so the
+              // volunteer still has context for what shift their slot is
+              // part of, but visually subordinate to their actual booked
+              // hours so adjacent bookings can no longer collide visually.
+              <div className="text-xs text-muted-foreground/80 pl-4">
+                Part of {timeLabel(s)} shift
+              </div>
+            )}
             <div className="flex gap-2">
               {s.requires_bg_check && <Badge variant="outline" className="text-xs"><Shield className="h-3 w-3 mr-1" />BG Check</Badge>}
             </div>
-            {/* Per-slot bookings */}
-            <BookedSlotsDisplay shiftId={s.id} volunteerId={userId} />
 
             {/* Individual slot actions */}
             {bookings.length > 1 && (

--- a/src/hooks/useVolunteerBookings.ts
+++ b/src/hooks/useVolunteerBookings.ts
@@ -20,6 +20,15 @@ export interface VolunteerBooking {
   waitlist_offer_expires_at: string | null;
   created_at: string;
   time_slot_id?: string | null;
+  /**
+   * Joined slot times when this booking is for a specific time slot. The
+   * UpcomingShiftCard reads these to show the volunteer's actual booked
+   * range (e.g. 12:00–14:00) instead of the parent shift window. PR #170
+   * added the embedded select; before that the dashboard card showed the
+   * parent shift window which made adjacent same-day bookings (e.g.
+   * 10–12 + 12–2) read as duplicate "10:00–14:00" rows.
+   */
+  shift_time_slots?: { slot_start: string; slot_end: string } | null;
   shifts: {
     id: string;
     title: string;
@@ -87,7 +96,7 @@ export function useVolunteerBookings(user: User | null, today: string): UseVolun
       const [{ data, error: bookingsErr }, { data: pendingData }] = await Promise.all([
         supabase
           .from("shift_bookings")
-          .select("id, booking_status, confirmation_status, checked_in_at, waitlist_offer_expires_at, created_at, shifts(id, title, shift_date, time_type, start_time, end_time, total_slots, booked_slots, requires_bg_check, status, allows_group, department_id, departments(name, location_id))")
+          .select("id, booking_status, confirmation_status, checked_in_at, waitlist_offer_expires_at, created_at, time_slot_id, shift_time_slots(slot_start, slot_end), shifts(id, title, shift_date, time_type, start_time, end_time, total_slots, booked_slots, requires_bg_check, status, allows_group, department_id, departments(name, location_id))")
           .eq("volunteer_id", user.id)
           .in("booking_status", ["confirmed", "waitlisted"])
           .order("created_at", { ascending: false }),


### PR DESCRIPTION
## Summary

Both issues surfaced from the dashboard screenshot during PR #168 review — two same-day bookings (Groundskeeping 12–2 PM and Friday Dance Party 10–12 PM) reading as identical "10:00 AM – 2:00 PM" cards.

### 1. Display: booked slot times are now the prominent line

The card was showing the **parent shift window** (10–2) instead of the volunteer's **actual booked slot** (12–2 / 10–12). When two different shifts share the same parent window and you book back-to-back slots in each, both cards looked like duplicate full-day commitments.

Fix: when the booking has a \`time_slot_id\`, show the slot range(s) on the primary clock line. The parent shift window is kept as a small secondary "Part of {window} shift" line so the volunteer still has context but can't visually mistake adjacent slots for overlap.

\`useVolunteerBookings\` select now embeds \`shift_time_slots(slot_start, slot_end)\` so the card has the data synchronously — no second round-trip.

### 2. Soft warning: cross-location back-to-back

The DB trigger \`prevent_overlapping_bookings\` uses strict half-open interval semantics. Two adjacent slots (one ends at 12:00, next starts at 12:00) genuinely don't overlap, so the trigger silently allows them. That's correct for split shifts at the same location.

Cross-location back-to-back, though, is physically impossible (zero travel time between sites). \`SlotSelectionDialog\` now does a single same-day query, finds any existing booking whose slot is adjacent to a selected slot, compares \`departments.location_id\`, and if they differ shows:

> Heads up: "Friday Dance Party" at Camp Sunnyside is back-to-back with this booking, with no travel time between locations. Book anyway?

Non-blocking — same-location split shifts pass through silently. The DB trigger semantics are unchanged.

## Test plan

- [ ] Dashboard: book slots 10–12 on shift A and 12–2 on shift B (same date) — cards now show the slot times distinctly, not duplicate "10–2"
- [ ] Booking flow: book 12–2 at location X, then try to book 10–12 at location Y on same date — confirm dialog appears
- [ ] Booking flow: book 10–12 at location X, then 12–2 in a different shift at the same location X — no warning (legitimate split shift)
- [ ] Existing overlap protection: try to book a slot that truly overlaps an existing booking — DB trigger still blocks with the existing toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)