### PR TITLE
fix: volunteer can read coordinator/admin name in messaging UI

### DIFF
--- a/docs/RLS_REFERENCE.md
+++ b/docs/RLS_REFERENCE.md
@@ -219,7 +219,7 @@ These helpers stand in for the inline `EXISTS (SELECT … FROM department_coordi
 
 | Policy | Op | Allows | Why |
 |---|---|---|---|
-| `Users read own participations` | SELECT | Self or admin | A user only sees rows where they are a participant — which is why `ConversationList.tsx` resolves "other participant" via message senders, not via `conversation_participants`. |
+| `Users read own participations` | SELECT | Self or admin | A user only sees rows where they are a participant. To resolve the OTHER participant in conversations, the frontend uses three paths: (1) `messages.sender_id`, (2) `conversations.created_by`, (3) the SECURITY DEFINER RPC `get_other_participants(uuid[])` for self-created conversations pending the first reply. The RPC re-checks caller-membership inside the body so the SECURITY DEFINER context can't be used to enumerate arbitrary conversations' participants. Audit 2026-04-28 — without path 3 a freshly-created conversation displayed "Unknown" until the recipient replied. |
 | `Users update own participation` | UPDATE | Self | Update `last_read_at`, `cleared_at`, `is_archived`. |
 | `Creator or staff adds participants` | INSERT | Creator or staff | Adding participants to a conversation. |
 

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -10,6 +10,7 @@ import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { resolveOtherParticipants, type MessageRow, type ConversationCreator, type ParticipantRow } from "@/lib/conversation-participants";
 
 interface ConversationItem {
   id: string;
@@ -64,29 +65,65 @@ export function ConversationList({ selectedId, onSelect, refreshTrigger }: Conve
 
     if (!convos) { setConversations([]); setLoading(false); return; }
 
-    // Get other participants by looking up message sender IDs
-    // (conversation_participants RLS only returns own rows)
+    // Get other participants. Three resolution paths, in order:
+    //
+    //   1. messages.sender_id where it isn't the caller — covers any
+    //      conversation that has at least one inbound message.
+    //   2. conversations.created_by — covers conversations someone
+    //      else started, where they haven't yet sent a message body
+    //      (rare but possible).
+    //   3. get_other_participants RPC — covers conversations the
+    //      caller themselves created, where the recipient hasn't
+    //      replied yet. The per-row RLS on conversation_participants
+    //      ("Users read own participations") would otherwise hide the
+    //      recipient's row from the caller; the SECURITY DEFINER RPC
+    //      returns it after re-checking caller-membership inside the
+    //      function body. Audit 2026-04-28 — without path 3 the UI
+    //      shows "Unknown" for self-created conversations until the
+    //      recipient's first reply.
     const { data: allMsgs } = await (supabase as any)
       .from("messages")
       .select("conversation_id, sender_id")
       .in("conversation_id", convoIds);
 
-    // Build a map of conversation_id -> other user IDs
-    const convoToOthers: Record<string, string> = {};
-    const otherUserIds: string[] = [];
-    (allMsgs || []).forEach((m: any) => {
-      if (m.sender_id !== user.id && !convoToOthers[m.conversation_id]) {
-        convoToOthers[m.conversation_id] = m.sender_id;
-        if (!otherUserIds.includes(m.sender_id)) otherUserIds.push(m.sender_id);
-      }
+    // Run paths 1 + 2 first (no extra round trip), find the still-
+    // unresolved set, then backfill via the RPC (path 3).
+    const messages: MessageRow[] = (allMsgs as MessageRow[] | null) || [];
+    const conversationsForResolve: ConversationCreator[] =
+      ((convos as Array<{ id: string; created_by: string }> | null) || []).map(
+        (c) => ({ id: c.id, created_by: c.created_by }),
+      );
+
+    const partial = resolveOtherParticipants({
+      callerId: user.id,
+      conversations: conversationsForResolve,
+      messages,
+      rpcParticipants: [],
     });
 
-    // Also check conversations created_by (for convos where the other person sent no messages yet)
-    (convos || []).forEach((c: any) => {
-      if (c.created_by !== user.id && !otherUserIds.includes(c.created_by)) {
-        otherUserIds.push(c.created_by);
-        if (!convoToOthers[c.id]) convoToOthers[c.id] = c.created_by;
-      }
+    // Path 3 — backfill any conversation we still haven't resolved.
+    // The RPC is a SECURITY DEFINER round-trip; only call it for the
+    // conversations paths 1+2 missed.
+    const unresolvedConvoIds = convoIds.filter(
+      (id: string) => !partial.convoToOthers[id],
+    );
+    let rpcParticipants: ParticipantRow[] = [];
+    if (unresolvedConvoIds.length > 0) {
+      // Boundary cast — RPC return shape (an array of rows) doesn't
+      // round-trip cleanly through the generated types. Single cast at
+      // the call site, same pattern documented in eslint.config.js.
+      const { data: extras } = await (supabase as any).rpc(
+        "get_other_participants",
+        { p_conversation_ids: unresolvedConvoIds },
+      );
+      rpcParticipants = (extras as ParticipantRow[] | null) || [];
+    }
+
+    const { convoToOthers, otherUserIds } = resolveOtherParticipants({
+      callerId: user.id,
+      conversations: conversationsForResolve,
+      messages,
+      rpcParticipants,
     });
 
     type ProfileLite = { id: string; full_name: string | null; email: string | null };

--- a/src/lib/__tests__/conversation-participants.test.ts
+++ b/src/lib/__tests__/conversation-participants.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { resolveOtherParticipants } from "@/lib/conversation-participants";
+
+/**
+ * Resolver unit tests. The audit-driven case is the FIRST one below:
+ * a self-created conversation with no replies, where paths 1 + 2
+ * leave it unresolved and only path 3 (RPC) can identify the
+ * recipient. Pre-PR this case rendered as "Unknown" in the
+ * conversation list.
+ */
+
+const ME = "user-self";
+const COORD = "user-coord";
+const VOL2 = "user-vol2";
+
+describe("resolveOtherParticipants", () => {
+  it("audit case: self-created conversation with no replies → resolves via RPC (path 3)", () => {
+    // Volunteer just created this conversation. No messages yet AND
+    // they are the creator. Without path 3 the recipient is invisible.
+    const result = resolveOtherParticipants({
+      callerId: ME,
+      conversations: [{ id: "c1", created_by: ME }],
+      messages: [],
+      rpcParticipants: [{ conversation_id: "c1", user_id: COORD }],
+    });
+
+    expect(result.convoToOthers).toEqual({ c1: COORD });
+    expect(result.otherUserIds).toEqual([COORD]);
+  });
+
+  it("baseline: inbound message resolves the recipient via path 1", () => {
+    const result = resolveOtherParticipants({
+      callerId: ME,
+      conversations: [{ id: "c1", created_by: COORD }],
+      messages: [
+        { conversation_id: "c1", sender_id: COORD },
+        { conversation_id: "c1", sender_id: ME },
+      ],
+      rpcParticipants: [],
+    });
+
+    expect(result.convoToOthers).toEqual({ c1: COORD });
+    expect(result.otherUserIds).toEqual([COORD]);
+  });
+
+  it("path 2: someone else created the conversation but has not sent a message yet", () => {
+    const result = resolveOtherParticipants({
+      callerId: ME,
+      conversations: [{ id: "c1", created_by: COORD }],
+      messages: [],
+      rpcParticipants: [],
+    });
+
+    expect(result.convoToOthers).toEqual({ c1: COORD });
+    expect(result.otherUserIds).toEqual([COORD]);
+  });
+
+  it("path 1 wins over path 2 when both have an answer (cheaper to render)", () => {
+    // Both paths agree on the same user. The path-1 entry is processed
+    // first; the path-2 entry must NOT overwrite or duplicate.
+    const result = resolveOtherParticipants({
+      callerId: ME,
+      conversations: [{ id: "c1", created_by: COORD }],
+      messages: [{ conversation_id: "c1", sender_id: COORD }],
+      rpcParticipants: [{ conversation_id: "c1", user_id: COORD }],
+    });
+
+    expect(result.convoToOthers).toEqual({ c1: COORD });
+    // Crucially, COORD appears only once in otherUserIds.
+    expect(result.otherUserIds).toEqual([COORD]);
+  });
+
+  it("never includes the caller's own id as the 'other' participant", () => {
+    // Even with the caller appearing in messages.sender_id and the
+    // RPC echoing them back, the resolver must skip them.
+    const result = resolveOtherParticipants({
+      callerId: ME,
+      conversations: [{ id: "c1", created_by: ME }],
+      messages: [{ conversation_id: "c1", sender_id: ME }],
+      rpcParticipants: [
+        { conversation_id: "c1", user_id: COORD },
+        // RPC won't actually return this row in production, but the
+        // resolver shouldn't trust the input.
+      ],
+    });
+
+    expect(result.convoToOthers).toEqual({ c1: COORD });
+    expect(result.otherUserIds).not.toContain(ME);
+  });
+
+  it("multiple conversations, mixed paths, all resolved", () => {
+    const result = resolveOtherParticipants({
+      callerId: ME,
+      conversations: [
+        { id: "c1", created_by: ME },     // self-created → needs RPC
+        { id: "c2", created_by: COORD },  // someone else created
+        { id: "c3", created_by: ME },     // self-created with replies
+      ],
+      messages: [
+        { conversation_id: "c3", sender_id: VOL2 },
+      ],
+      rpcParticipants: [
+        { conversation_id: "c1", user_id: COORD },
+        // c2 doesn't need backfill; c3 already has a path-1 answer.
+      ],
+    });
+
+    expect(result.convoToOthers).toEqual({
+      c1: COORD,
+      c2: COORD,
+      c3: VOL2,
+    });
+    expect(result.otherUserIds).toEqual(
+      expect.arrayContaining([COORD, VOL2]),
+    );
+    expect(result.otherUserIds).toHaveLength(2);
+  });
+
+  it("returns empty maps when no inputs resolve to a non-self id", () => {
+    const result = resolveOtherParticipants({
+      callerId: ME,
+      conversations: [{ id: "c1", created_by: ME }],
+      messages: [{ conversation_id: "c1", sender_id: ME }],
+      rpcParticipants: [],
+    });
+
+    expect(result.convoToOthers).toEqual({});
+    expect(result.otherUserIds).toEqual([]);
+  });
+});

--- a/src/lib/conversation-participants.ts
+++ b/src/lib/conversation-participants.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolve the "other participant" of each conversation in a list, for
+ * the conversation-list left-rail rendering. Pure: takes the data the
+ * three resolution paths produce and returns the join map; the React
+ * component owns the actual fetches.
+ *
+ * Three resolution paths run in order; each only resolves
+ * conversations not already resolved by an earlier path:
+ *
+ *   1. messages.sender_id where it isn't the caller (covers any
+ *      conversation that has at least one inbound message).
+ *   2. conversations.created_by where it isn't the caller (covers
+ *      conversations someone else started but hasn't sent a message
+ *      body in yet).
+ *   3. get_other_participants RPC results (covers conversations the
+ *      caller themselves created, where the recipient hasn't replied
+ *      yet — the audit 2026-04-28 case that surfaced as "Unknown").
+ *
+ * The function returns BOTH the per-conversation map and a
+ * de-duplicated list of user IDs to fetch profiles for. Callers use
+ * the list to issue a single `profiles?in=` query.
+ */
+
+export interface MessageRow {
+  conversation_id: string;
+  sender_id: string;
+}
+
+export interface ConversationCreator {
+  id: string;
+  created_by: string;
+}
+
+export interface ParticipantRow {
+  conversation_id: string;
+  user_id: string;
+}
+
+export interface ResolvedParticipants {
+  /** conversation_id → user_id of the other participant */
+  convoToOthers: Record<string, string>;
+  /** De-duplicated list, in first-seen order, for the profiles fetch. */
+  otherUserIds: string[];
+}
+
+export function resolveOtherParticipants(args: {
+  callerId: string;
+  conversations: ConversationCreator[];
+  messages: MessageRow[];
+  /** RPC backfill rows. Only conversations still unresolved after
+   *  paths 1+2 are queried; the helper assumes the caller already
+   *  filtered the input set, but it's idempotent regardless. */
+  rpcParticipants: ParticipantRow[];
+}): ResolvedParticipants {
+  const { callerId, conversations, messages, rpcParticipants } = args;
+  const convoToOthers: Record<string, string> = {};
+  const otherUserIds: string[] = [];
+
+  const note = (convoId: string, userId: string) => {
+    if (!convoToOthers[convoId]) convoToOthers[convoId] = userId;
+    if (!otherUserIds.includes(userId)) otherUserIds.push(userId);
+  };
+
+  // Path 1 — messages
+  for (const m of messages) {
+    if (m.sender_id !== callerId && !convoToOthers[m.conversation_id]) {
+      note(m.conversation_id, m.sender_id);
+    }
+  }
+
+  // Path 2 — created_by
+  for (const c of conversations) {
+    if (c.created_by !== callerId && !convoToOthers[c.id]) {
+      note(c.id, c.created_by);
+    }
+  }
+
+  // Path 3 — RPC backfill
+  for (const r of rpcParticipants) {
+    if (!convoToOthers[r.conversation_id]) {
+      note(r.conversation_id, r.user_id);
+    }
+  }
+
+  return { convoToOthers, otherUserIds };
+}

--- a/supabase/migrations/20260428000000_get_other_participants_rpc.sql
+++ b/supabase/migrations/20260428000000_get_other_participants_rpc.sql
@@ -1,0 +1,57 @@
+-- Audit 2026-04-28: ConversationList.tsx surfaces the recipient as
+-- "Unknown" the first time a volunteer messages a coordinator. The
+-- frontend reverse-engineers "the other participant" from
+-- `messages.sender_id` and `conversations.created_by` because the
+-- per-row RLS on `conversation_participants` (`Users read own
+-- participations`) returns only the calling user's own row — there's
+-- no path to the recipient until they reply.
+--
+-- This migration adds a SECURITY DEFINER RPC that returns
+-- (conversation_id, user_id) for the OTHER participants in any
+-- conversation the caller is also a participant of. The function
+-- enforces caller-membership inside the body so SECURITY DEFINER does
+-- not become a way to enumerate arbitrary conversations' participants.
+--
+-- Frontend uses this as a third resolution path inside
+-- `ConversationList.fetchConversations()`. RLS on `profiles` is
+-- unchanged; the existing `profiles: volunteer read admins and dept
+-- coordinators` policy already permits the subsequent profile lookup
+-- for the user IDs this RPC returns.
+
+CREATE OR REPLACE FUNCTION "public"."get_other_participants"(
+  "p_conversation_ids" uuid[]
+)
+RETURNS TABLE ("conversation_id" uuid, "user_id" uuid)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  -- Caller-membership filter: only return rows for conversations
+  -- where the caller is themselves a participant. Without this clause
+  -- a volunteer could pass any conversation_id and learn its members.
+  -- The SECURITY DEFINER context bypasses the participants RLS, so
+  -- the WHERE EXISTS check is the only authorization layer.
+  SELECT cp_other.conversation_id, cp_other.user_id
+  FROM public.conversation_participants cp_other
+  WHERE cp_other.conversation_id = ANY(p_conversation_ids)
+    AND cp_other.user_id <> auth.uid()
+    AND EXISTS (
+      SELECT 1
+      FROM public.conversation_participants cp_self
+      WHERE cp_self.conversation_id = cp_other.conversation_id
+        AND cp_self.user_id = auth.uid()
+    );
+$$;
+
+ALTER FUNCTION "public"."get_other_participants"(uuid[]) OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "public"."get_other_participants"(uuid[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "public"."get_other_participants"(uuid[]) TO "authenticated";
+-- Service role intentionally also gets execute for the RLS test
+-- harness (which can call as service role to verify the function's
+-- caller-membership logic with a known auth.uid()).
+GRANT EXECUTE ON FUNCTION "public"."get_other_participants"(uuid[]) TO "service_role";
+
+COMMENT ON FUNCTION "public"."get_other_participants"(uuid[]) IS
+  'Returns (conversation_id, user_id) for participants OTHER than the caller in conversations the caller is a member of. SECURITY DEFINER bypasses the per-row RLS on conversation_participants (which only exposes the caller''s own row); the EXISTS clause inside the body re-applies the membership check so the function cannot be used to enumerate arbitrary conversations'' members. Used by ConversationList.fetchConversations to resolve the recipient display name on a freshly-created conversation pending the first reply.';

--- a/supabase/test/get-other-participants.test.ts
+++ b/supabase/test/get-other-participants.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { signInAs, adminBypassClient, getHarnessUsers } from "./clients";
+
+/**
+ * Coverage for the `get_other_participants` SECURITY DEFINER RPC
+ * introduced in `20260428000000_get_other_participants_rpc.sql`.
+ *
+ * The RPC's job is to let a caller resolve the OTHER participants in
+ * conversations the caller is a member of, working around the per-row
+ * RLS on `conversation_participants` ("Users read own participations")
+ * that hides the recipient's row from the caller.
+ *
+ * Two safety properties to pin:
+ *
+ *   1. Callers see other participants ONLY for conversations they
+ *      themselves are members of.
+ *   2. Callers do NOT see participants for conversations they aren't
+ *      members of, even if they pass the conversation_id explicitly.
+ *
+ * Property #2 is what prevents the SECURITY DEFINER bypass from
+ * becoming a participant-enumeration vector.
+ */
+
+let convoVolunteerCoord: string; // volunteer ↔ coordinator
+let convoVolunteer2Coord: string; // volunteer2 ↔ coordinator (volunteer is NOT a member)
+
+beforeAll(async () => {
+  const admin = adminBypassClient();
+  const users = getHarnessUsers();
+
+  // Conversation 1: volunteer ↔ coordinator (the typical "fresh send"
+  // case from the audit — created by the volunteer, no replies yet).
+  const { data: c1, error: c1Err } = await admin
+    .from("conversations")
+    .insert({
+      created_by: users.volunteer.id,
+      conversation_type: "direct",
+      subject: "Audit ping (test)",
+    } as never)
+    .select("id")
+    .single();
+  if (c1Err) throw new Error(`convo1 insert: ${c1Err.message}`);
+  convoVolunteerCoord = (c1 as { id: string }).id;
+
+  await admin.from("conversation_participants").insert([
+    { conversation_id: convoVolunteerCoord, user_id: users.volunteer.id },
+    { conversation_id: convoVolunteerCoord, user_id: users.coordinator.id },
+  ] as never);
+
+  // Conversation 2: volunteer2 ↔ coordinator. The first volunteer is
+  // not a member — used to prove property #2.
+  const { data: c2, error: c2Err } = await admin
+    .from("conversations")
+    .insert({
+      created_by: users.volunteer2.id,
+      conversation_type: "direct",
+      subject: "Other thread (test)",
+    } as never)
+    .select("id")
+    .single();
+  if (c2Err) throw new Error(`convo2 insert: ${c2Err.message}`);
+  convoVolunteer2Coord = (c2 as { id: string }).id;
+
+  await admin.from("conversation_participants").insert([
+    { conversation_id: convoVolunteer2Coord, user_id: users.volunteer2.id },
+    { conversation_id: convoVolunteer2Coord, user_id: users.coordinator.id },
+  ] as never);
+});
+
+afterAll(async () => {
+  const admin = adminBypassClient();
+  const ids = [convoVolunteerCoord, convoVolunteer2Coord];
+  await admin.from("conversation_participants").delete().in("conversation_id", ids);
+  await admin.from("conversations").delete().in("id", ids);
+});
+
+describe("get_other_participants RPC", () => {
+  it("returns the coordinator for a conversation the volunteer is a member of", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+
+    const { data, error } = await client.rpc("get_other_participants", {
+      p_conversation_ids: [convoVolunteerCoord],
+    });
+
+    expect(error).toBeNull();
+    const rows = (data ?? []) as Array<{ conversation_id: string; user_id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].conversation_id).toBe(convoVolunteerCoord);
+    expect(rows[0].user_id).toBe(users.coordinator.id);
+  });
+
+  it("does NOT return the volunteer's own user_id", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+
+    const { data } = await client.rpc("get_other_participants", {
+      p_conversation_ids: [convoVolunteerCoord],
+    });
+
+    const rows = (data ?? []) as Array<{ conversation_id: string; user_id: string }>;
+    for (const row of rows) {
+      expect(row.user_id).not.toBe(users.volunteer.id);
+    }
+  });
+
+  it("does NOT leak participants of a conversation the caller isn't a member of", async () => {
+    // The volunteer is NOT a member of convoVolunteer2Coord. Even if
+    // they pass the conversation_id explicitly, the RPC's EXISTS
+    // clause should filter out the row. This is the
+    // SECURITY-DEFINER-bypass guard.
+    const client = await signInAs("volunteer");
+
+    const { data, error } = await client.rpc("get_other_participants", {
+      p_conversation_ids: [convoVolunteer2Coord],
+    });
+
+    expect(error).toBeNull();
+    expect((data ?? []) as unknown[]).toEqual([]);
+  });
+
+  it("filters per-row when the input mixes member + non-member conversation ids", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+
+    const { data } = await client.rpc("get_other_participants", {
+      p_conversation_ids: [convoVolunteerCoord, convoVolunteer2Coord],
+    });
+
+    const rows = (data ?? []) as Array<{ conversation_id: string; user_id: string }>;
+    // Exactly one row — the volunteer's own conversation. The
+    // volunteer2's conversation must be filtered, even though it was
+    // in the input.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].conversation_id).toBe(convoVolunteerCoord);
+    expect(rows[0].user_id).toBe(users.coordinator.id);
+  });
+
+  it("coordinator side: same RPC resolves the volunteer for the same conversation", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("coordinator");
+
+    const { data } = await client.rpc("get_other_participants", {
+      p_conversation_ids: [convoVolunteerCoord],
+    });
+
+    const rows = (data ?? []) as Array<{ conversation_id: string; user_id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].user_id).toBe(users.volunteer.id);
+  });
+});


### PR DESCRIPTION
## Phase 1 — diagnosis (per brief)

The audit reported \"Unknown\" surfacing in the volunteer's conversation list when they sent the FIRST message in a new thread to a coordinator. Static analysis found:

### The symptom is NOT an RLS bug on \`profiles\`

\`ConversationList.fetchConversations\` reverse-engineers \"the other participant\" through two paths:

1. \`messages.sender_id\` where sender ≠ self
2. \`conversations.created_by\` where creator ≠ self

For a conversation the **volunteer just created** with no replies yet, BOTH paths fail (the volunteer is the only sender AND the creator). The recipient ID is never added to \`otherUserIds\`, no \`profiles\` SELECT is issued, and \`otherName\` falls through to \`\"Unknown\"\` at line 125.

### Existing \`profiles\` policy already permits the lookup

\`profiles: volunteer read admins and dept coordinators\` (\`baseline.sql:4983\`) gates volunteer reads of coordinator profiles on \`is_coordinator_for_my_dept(id)\` — true when the volunteer has any booking in a department the coordinator manages. For the reported user (sabih.usman@live.com had bookings in Adult Day Program + Grounds & Facilities, both managed by sabih-usman@uiowa.edu), the predicate returns true. **The RLS lookup would succeed if the frontend ran it.** Broadening RLS would expose more PII without fixing the symptom.

The original brief's stop condition fired: \"Phase 1 reveals the bug isn't RLS-shaped … don't broaden RLS for a non-RLS bug.\"

### Why the workaround pattern exists

The author's comment at line 68: \`// (conversation_participants RLS only returns own rows)\`. Confirmed by policy \`Users read own participations\` (\`baseline.sql:4602\`) — volunteers can only see their own participation row, never the recipient's. So the frontend reverse-engineers the recipient from \`messages\` + \`conversations.created_by\`. That dual fallback fails for a self-created conversation pending the first reply.

## Phase 2 — fix (Option A from the diagnosis comment)

Selected option: SECURITY DEFINER RPC \`get_other_participants(uuid[])\` that returns \`(conversation_id, user_id)\` for participants OTHER than the caller in conversations the caller is a member of. The RPC re-checks caller-membership inside the body, so SECURITY DEFINER cannot be used to enumerate arbitrary conversations' members.

\`\`\`sql
SELECT cp_other.conversation_id, cp_other.user_id
FROM public.conversation_participants cp_other
WHERE cp_other.conversation_id = ANY(p_conversation_ids)
  AND cp_other.user_id <> auth.uid()
  AND EXISTS (
    SELECT 1 FROM public.conversation_participants cp_self
    WHERE cp_self.conversation_id = cp_other.conversation_id
      AND cp_self.user_id = auth.uid()
  );
\`\`\`

Frontend changes a third resolution path that runs ONLY for conversations paths 1+2 didn't resolve (avoids an unnecessary SECURITY DEFINER round trip per render). The resolver itself was extracted to \`src/lib/conversation-participants.ts\` so the audit-driven case has a focused unit test without mocking the entire Supabase chain.

### Why not Option B (denormalize \`conversations.recipient_id\`)

\`conversations.conversation_type\` already exists in the schema, suggesting group conversations are at least anticipated. A denormalized 1:1 column would assume forever-1:1 and make the future migration messier. RPC scales cleanly to N participants.

### Why not the original brief's RLS broadening

Phase 1 says it's not where the bug lives. Adding a profiles read scope for cross-volunteer visibility would expand PII surface (volunteer enumerates all coordinators globally) without resolving the symptom. The DB policies are unchanged in this PR.

## Other UI surfaces this also fixes

The same resolver feeds anywhere \`fetchConversations\` is rendered, so the conversation list left rail in \`Messages\` (both volunteer and coordinator side) is the only direct beneficiary today. Shift cards displaying the coordinator name aren't affected — they read coordinator names via the existing \`profiles: volunteer read admins and dept coordinators\` policy through the shifts-side joins.

## Latent issue NOT fixed (separate ticket)

\`is_coordinator_for_my_dept(coord_id)\` requires the volunteer to already have a booking in that coordinator's dept. A brand-new volunteer with zero bookings can't see any coordinator's profile until they book a shift first. No one has reported this; flagging for separate triage.

## Test plan

- [x] **Unit** (\`src/lib/__tests__/conversation-participants.test.ts\`) — 7 tests pinning the resolver. The audit case (\"self-created conversation with no replies → resolves via RPC\") is the first test.
- [x] **RLS integration** (\`supabase/test/get-other-participants.test.ts\`) — 5 tests against real Postgres. Volunteer + coordinator can both resolve the OTHER party in shared conversations. Volunteer who isn't a member gets \`[]\` back even when passing the conversation_id explicitly — pins the SECURITY DEFINER bypass guard.
- [x] \`npx vitest run\` — 210 tests pass
- [x] \`npx eslint --max-warnings=0\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vite build\` clean

## Spec edits

\`docs/RLS_REFERENCE.md\` — updated \`conversation_participants > Users read own participations\` row to document all three resolution paths and the new RPC, and the security guard inside the function body.

## Out of scope (per brief)

- Coordinator/admin profile editing surface for volunteers
- Avatar display in the conversation list
- Other audit findings
- Brand-new-volunteer-can't-see-coordinators latent issue (flagged above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)