### PR TITLE
test(e2e): un-skip admin-creates-shift after date-picker fix landed on prod

### DIFF
--- a/tests/e2e/06-admin-creates-shift-via-ui.spec.ts
+++ b/tests/e2e/06-admin-creates-shift-via-ui.spec.ts
@@ -105,8 +105,18 @@ test("admin creates a shift via the Create Shift dialog (date picker works end-t
   // Assertion 1: trigger label updates to the formatted date.
   // (This is the assertion that the JSDOM unit test also makes —
   // but in real Chromium against real Radix portals.)
+  //
+  // Trigger format from src/components/shared/DatePicker.tsx:
+  //   {dateValue ? format(dateValue, "MMMM d, yyyy") : <placeholder />}
+  // → e.g. "May 10, 2026". Matching just `targetMonthYear` ("May 2026")
+  // FAILED because the day-of-month + comma sit between them in the
+  // actual label. We assert the full expected string instead.
+  const expectedTriggerLabel = new Date(shiftDate + "T00:00:00").toLocaleString(
+    "en-US",
+    { month: "long", day: "numeric", year: "numeric" },
+  );
   await expect(
-    dialog.getByRole("button", { name: new RegExp(targetMonthYear, "i") })
+    dialog.getByRole("button", { name: new RegExp(expectedTriggerLabel, "i") }),
   ).toBeVisible();
 
   // ── Fill remaining required fields ─────────────────────────────

--- a/tests/e2e/06-admin-creates-shift-via-ui.spec.ts
+++ b/tests/e2e/06-admin-creates-shift-via-ui.spec.ts
@@ -30,27 +30,18 @@ import {
 
 const SHIFT_DATE_OFFSET_DAYS = 11; // distinct from other E2E specs to avoid trigger collisions
 
-// SKIPPED until this PR's fix lands on production main.
-//
-// PLAYWRIGHT_BASE_URL in ci.yml points at production
-// (https://easterseals-volunteer-scheduler.vercel.app), not at the
-// PR preview. Running this spec against production while the fix
-// is still on a branch means we test the OLD broken date picker
-// (only #156's modal={false}, missing the layered onPointerDownOutside
-// + onOpenAutoFocus + initialFocus-removal from this PR).
-//
-// First run on this PR captured the exact Pattern A trace as evidence:
-//
-//   <label "End Time *"> from <div role="dialog" id="radix-:r7:">
-//   subtree intercepts pointer events
-//
-// Confirming that production CI Chromium also exhibits the click-
-// interception bug — not just Sabih's environment. That's why the
-// fix is needed, and why this test will pass once the fix is live.
-//
-// Re-enable in a follow-up PR after this one merges. Tracked at
-// the PR-158 description's "Sequencing" section.
-test.skip("admin creates a shift via the Create Shift dialog (date picker works end-to-end)", async ({ page, context, request }) => {
+// Re-enabled on 2026-04-29 after the date-picker fix saga landed on
+// production via PRs #156, #158, #160, and #171's display polish.
+// Originally skipped because PLAYWRIGHT_BASE_URL points at production
+// and the spec would have tested the OLD broken picker while the fix
+// was on a branch — Pattern A trace
+// `<label "End Time *"> ... subtree intercepts pointer events` was
+// captured on the first run as evidence that the bug repro'd in CI
+// Chromium too. With all four layered defenses now on prod, the
+// spec exercises the full create-shift flow against the FIXED picker
+// and verifies the load-bearing onSelect → setForm → save path that
+// JSDOM unit tests can't reach (per the file header comment).
+test("admin creates a shift via the Create Shift dialog (date picker works end-to-end)", async ({ page, context, request }) => {
   const session = await loginAndVisit(
     request,
     context,


### PR DESCRIPTION
## Summary

Re-enables \`tests/e2e/06-admin-creates-shift-via-ui.spec.ts\`, which was \`test.skip()\`'d during the date-picker bug saga because \`PLAYWRIGHT_BASE_URL\` in \`ci.yml\` points at production — running the spec then would have tested the OLD broken picker.

The layered defenses are now all on production:

| PR | Fix |
|---|---|
| #156 | \`modal={false}\` on the Popover |
| #158 | \`onPointerDownOutside\` conditional preventDefault + \`onOpenAutoFocus\` preventDefault + \`initialFocus\` removal |
| #160 | \`z-[60]\` on PopoverContent above the dialog stacking layer |
| #161 | \`pointer-events-auto\` override (defense-in-depth) |
| #171 | Booked-slot display + adjacency warning copy |

The spec now exercises the full create-shift flow end-to-end and verifies the \`onSelect → setForm → save\` path that JSDOM unit tests can't faithfully reproduce.

## Companion cleanup

PR #159 (the one-time diagnostic spec from the investigation) was closed unmerged. Its assertions were designed to capture the *broken* state pattern A; with prod fixed, those assertions no longer have a meaningful target. The actual end-to-end positive coverage is here in spec 06.

## Test plan

- [ ] CI \`Playwright E2E\` job runs spec 06 against prod and passes
- [ ] No regressions on the other E2E specs (01–05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)