### PR TITLE
fix: account self-delete via dedicated delete-self endpoint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Auth from "./pages/Auth";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
+import AccountDeleted from "./pages/AccountDeleted";
 import MfaVerify from "./pages/MfaVerify";
 import VolunteerDashboard from "./pages/VolunteerDashboard";
 import BrowseShifts from "./pages/BrowseShifts";
@@ -76,6 +77,7 @@ const App = () => (
             <Route path="/forgot-password" element={<ForgotPassword />} />
             <Route path="/reset-password" element={<ResetPassword />} />
             <Route path="/privacy" element={<PrivacyPolicy />} />
+            <Route path="/account-deleted" element={<AccountDeleted />} />
             <Route path="/mfa-verify" element={<MfaVerify />} />
             <Route path="/checkin" element={<CheckIn />} />
 

--- a/src/components/settings/DeleteAccountPanel.tsx
+++ b/src/components/settings/DeleteAccountPanel.tsx
@@ -21,32 +21,66 @@ interface Props {
 }
 
 /**
- * Account deletion danger zone. Renders nothing for admins (caller decides
- * whether to mount this panel; behavior preservation: the original page
- * gated the entire card on `role !== "admin"`).
+ * Account self-deletion ("Danger Zone") panel.
  *
- * Confirms with email-typing match. On success, calls `delete-user` edge
- * function, signs out, and navigates to /auth with `accountDeleted: true`
- * passed through router state.
+ * Calls the dedicated `delete-self` edge function rather than the
+ * admin-only `delete-user` endpoint. Issue #178 root-caused the
+ * cross-flow bug: `delete-user` requires the caller to be an admin,
+ * which broke self-delete for everyone. The two endpoints are now
+ * separate and have opposite role gates by design.
+ *
+ * Confirmation pattern: user must type their account email to enable
+ * the destructive button. Comparison is case-insensitive but
+ * trim-sensitive (per the brief — leading/trailing whitespace counts
+ * as a typo, since real users don't paste-with-whitespace by design).
+ *
+ * On 200: clear local auth, navigate to /account-deleted (public).
+ * On 403 (admin self-delete blocked): surface the admin-specific
+ * message verbatim from the server. On any other error: generic
+ * "contact support" toast.
  */
-export function DeleteAccountPanel({ userId, email, role, onSignOut }: Props) {
+export function DeleteAccountPanel({ userId: _userId, email, role, onSignOut }: Props) {
   const { toast } = useToast();
   const navigate = useNavigate();
   const [deleteConfirmEmail, setDeleteConfirmEmail] = useState("");
   const [deleteLoading, setDeleteLoading] = useState(false);
 
+  // Case-insensitive: real users sometimes have inconsistent casing
+  // in their typing. Trim-sensitive: a paste with stray whitespace
+  // would suggest the user typed in the wrong place; better to make
+  // them retype than silently accept.
+  const emailMatches = deleteConfirmEmail.toLowerCase() === email.toLowerCase();
+
   const handleDeleteAccount = async () => {
     setDeleteLoading(true);
-    const { error } = await supabase.functions.invoke("delete-user", {
-      body: { userId },
-    });
+    const { data, error } = await supabase.functions.invoke<{ error?: string; success?: boolean }>(
+      "delete-self",
+      { body: {} },
+    );
     setDeleteLoading(false);
-    if (error) {
-      toast({ title: "Error", description: "Could not delete account. Please contact support.", variant: "destructive" });
+
+    // Two error shapes can arrive: (a) supabase-js wraps non-2xx
+    // responses in `error`, (b) the function itself returns a JSON
+    // body with an `error` field. Inspect both.
+    const serverError = error?.message || data?.error;
+    if (serverError) {
+      // Surface the admin-specific message verbatim so admins
+      // understand why and what their alternative is. Other errors
+      // are mapped to the generic copy — server-side logs carry the
+      // detail without leaking internals.
+      const isAdminBlocked = /admins cannot self-delete/i.test(serverError);
+      toast({
+        title: "Could not delete account",
+        description: isAdminBlocked
+          ? serverError
+          : "Could not delete account. Please contact support.",
+        variant: "destructive",
+      });
       return;
     }
+
     await onSignOut();
-    navigate("/auth", { state: { accountDeleted: true } });
+    navigate("/account-deleted");
   };
 
   return (
@@ -60,7 +94,10 @@ export function DeleteAccountPanel({ userId, email, role, onSignOut }: Props) {
       <CardContent>
         <AlertDialog>
           <AlertDialogTrigger asChild>
-            <Button variant="outline" className="border-destructive text-destructive hover:bg-destructive hover:text-destructive-foreground">
+            <Button
+              variant="outline"
+              className="border-destructive text-destructive hover:bg-destructive hover:text-destructive-foreground"
+            >
               <Trash2 className="h-4 w-4 mr-2" /> Delete My Account
             </Button>
           </AlertDialogTrigger>
@@ -68,33 +105,43 @@ export function DeleteAccountPanel({ userId, email, role, onSignOut }: Props) {
             <AlertDialogHeader>
               <AlertDialogTitle>Delete Your Account — This Cannot Be Undone</AlertDialogTitle>
               <AlertDialogDescription className="space-y-2">
-                <p>You are about to permanently delete your account.</p>
-                {role === "volunteer" && (
-                  <p>All your active shift bookings will be automatically cancelled.</p>
-                )}
+                <p>
+                  This will permanently delete your account, your bookings,
+                  and your profile. Your recorded volunteer hours will be
+                  retained for reporting but will no longer be linked to
+                  your name. This cannot be undone.
+                </p>
                 {role === "coordinator" && (
-                  <p>Your created shifts will remain but will no longer have a coordinator assigned.</p>
+                  <p>
+                    Your created shifts will remain on the schedule but
+                    will no longer be attributed to you.
+                  </p>
                 )}
-                <p>You will need to register a new account if you wish to return.</p>
                 <div className="pt-2">
-                  <Label>Type your email to confirm:</Label>
+                  <Label htmlFor="delete-confirm-email">
+                    Type your email to confirm:
+                  </Label>
                   <Input
+                    id="delete-confirm-email"
                     className="mt-1"
                     value={deleteConfirmEmail}
                     onChange={(e) => setDeleteConfirmEmail(e.target.value)}
                     placeholder={email}
+                    autoComplete="off"
                   />
                 </div>
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogCancel onClick={() => setDeleteConfirmEmail("")}>
+                Cancel
+              </AlertDialogCancel>
               <AlertDialogAction
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                disabled={deleteConfirmEmail !== email || deleteLoading}
+                disabled={!emailMatches || deleteLoading}
                 onClick={handleDeleteAccount}
               >
-                {deleteLoading ? "Deleting..." : "Delete My Account"}
+                {deleteLoading ? "Deleting..." : "Delete my account"}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/src/components/settings/__tests__/DeleteAccountPanel.test.tsx
+++ b/src/components/settings/__tests__/DeleteAccountPanel.test.tsx
@@ -2,11 +2,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 
 /**
- * Tier 2 test for DeleteAccountPanel.
+ * DeleteAccountPanel tests — issue #178 fix.
  *
  * The email-typing gate is the security primitive: nothing destructive
- * fires until the user types their email exactly. Tests verify both the
- * UI gate and the success/error branches.
+ * fires until the user types their account email. After the fix the
+ * panel calls the new `delete-self` edge function and redirects to
+ * /account-deleted (not the previous /auth?accountDeleted=true state
+ * that relied on a now-gone toast).
+ *
+ * Tests cover the full brief:
+ *   - Confirm button disabled until email matches
+ *   - Case-insensitive but trim-sensitive comparison
+ *   - Successful delete redirects to /account-deleted
+ *   - Admin-blocked-self-delete error surfaces verbatim
+ *   - Generic error path collapses to "contact support" copy
  */
 
 const invokeMock = vi.fn();
@@ -49,74 +58,179 @@ beforeEach(() => {
 });
 
 async function openConfirm() {
-  // Radix AlertDialog Trigger (with asChild) forwards click handlers to the
-  // Button, but the open transition mounts the content asynchronously via
-  // Radix Presence — we wait for the dialog to fully appear before any
-  // assertions. Both the trigger button and the confirm button inside the
-  // dialog use the text "Delete My Account", so subsequent queries scope
-  // via `within(dialog)` to disambiguate.
+  // Radix AlertDialog mounts content asynchronously; wait for the
+  // dialog to be present before any inner queries. Both the trigger
+  // button and the action button render text containing "delete my
+  // account" — scope confirmation queries via within(dialog).
   const trigger = screen.getByRole("button", { name: /delete my account/i });
   fireEvent.click(trigger);
   return await screen.findByRole("alertdialog");
 }
 
 function confirmButton(dialog: HTMLElement) {
+  // The action button text now reads "Delete my account" (lower-case 'm');
+  // the trigger reads "Delete My Account". Match by either case.
   return within(dialog).getByRole("button", { name: /delete my account/i });
 }
 
 describe("DeleteAccountPanel", () => {
-  it("keeps the confirm button disabled when typed email does not match", async () => {
-    render(<DeleteAccountPanel {...baseProps} />);
-    const dialog = await openConfirm();
-    fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
-      target: { value: "wrong@example.com" },
+  describe("email-typing gate", () => {
+    it("keeps the confirm button disabled when typed email does not match", async () => {
+      render(<DeleteAccountPanel {...baseProps} />);
+      const dialog = await openConfirm();
+      fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+        target: { value: "wrong@example.com" },
+      });
+      expect(confirmButton(dialog)).toBeDisabled();
     });
-    expect(confirmButton(dialog)).toBeDisabled();
+
+    it("enables the confirm button when typed email matches exactly", async () => {
+      render(<DeleteAccountPanel {...baseProps} />);
+      const dialog = await openConfirm();
+      fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+        target: { value: baseProps.email },
+      });
+      expect(confirmButton(dialog)).toBeEnabled();
+    });
+
+    it("matches case-insensitively (e.g. VOL@example.com → enabled)", async () => {
+      render(<DeleteAccountPanel {...baseProps} />);
+      const dialog = await openConfirm();
+      fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+        target: { value: "VOL@EXAMPLE.COM" },
+      });
+      expect(confirmButton(dialog)).toBeEnabled();
+    });
+
+    it("rejects strings with leading/trailing whitespace (trim-sensitive)", async () => {
+      // The brief's intent: paste-with-whitespace usually means the
+      // user typed in the wrong place. Make them retype.
+      render(<DeleteAccountPanel {...baseProps} />);
+      const dialog = await openConfirm();
+      fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+        target: { value: ` ${baseProps.email} ` },
+      });
+      expect(confirmButton(dialog)).toBeDisabled();
+    });
   });
 
-  it("enables the confirm button when typed email matches exactly", async () => {
-    render(<DeleteAccountPanel {...baseProps} />);
-    const dialog = await openConfirm();
-    fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
-      target: { value: baseProps.email },
+  describe("delete flow", () => {
+    it("invokes delete-self, signs out, and navigates to /account-deleted on success", async () => {
+      invokeMock.mockResolvedValue({ data: { success: true }, error: null });
+      render(<DeleteAccountPanel {...baseProps} />);
+      const dialog = await openConfirm();
+      fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+        target: { value: baseProps.email },
+      });
+      fireEvent.click(confirmButton(dialog));
+
+      await waitFor(() => {
+        expect(invokeMock).toHaveBeenCalledWith("delete-self", { body: {} });
+        expect(onSignOutMock).toHaveBeenCalled();
+        expect(navigateMock).toHaveBeenCalledWith("/account-deleted");
+      });
     });
-    expect(confirmButton(dialog)).toBeEnabled();
+
+    it("does NOT pass the userId to the endpoint (server reads it from the JWT)", async () => {
+      // Defensive: an earlier draft passed { userId } in the body.
+      // The new endpoint identifies the caller from the JWT and only
+      // accepts an optional target_user_id that MUST equal the JWT
+      // sub. Easiest way to keep that invariant honest from the
+      // client side is to send no target at all.
+      invokeMock.mockResolvedValue({ data: { success: true }, error: null });
+      render(<DeleteAccountPanel {...baseProps} />);
+      const dialog = await openConfirm();
+      fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+        target: { value: baseProps.email },
+      });
+      fireEvent.click(confirmButton(dialog));
+
+      await waitFor(() => {
+        expect(invokeMock).toHaveBeenCalledWith("delete-self", { body: {} });
+      });
+      const [, callArgs] = invokeMock.mock.calls[0];
+      expect((callArgs as { body: Record<string, unknown> }).body).not.toHaveProperty("userId");
+      expect((callArgs as { body: Record<string, unknown> }).body).not.toHaveProperty("target_user_id");
+    });
+
+    it("surfaces the admin-blocked-self-delete error verbatim", async () => {
+      // Admins hit the endpoint's role gate. The message includes
+      // the user's next step ("Another admin must remove this
+      // account.") — must surface verbatim, not collapsed into the
+      // generic "contact support" copy.
+      const adminMsg =
+        "Admins cannot self-delete. Another admin must remove this account.";
+      invokeMock.mockResolvedValue({
+        data: { error: adminMsg },
+        error: { message: adminMsg, name: "FunctionsHttpError" },
+      });
+
+      render(<DeleteAccountPanel {...baseProps} role="admin" />);
+      const dialog = await openConfirm();
+      fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+        target: { value: baseProps.email },
+      });
+      fireEvent.click(confirmButton(dialog));
+
+      await waitFor(() => {
+        expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+          title: "Could not delete account",
+          description: adminMsg,
+          variant: "destructive",
+        }));
+      });
+      expect(onSignOutMock).not.toHaveBeenCalled();
+      expect(navigateMock).not.toHaveBeenCalled();
+    });
+
+    it("shows generic error toast on non-admin failures", async () => {
+      // Network errors, 5xx, etc. Do NOT leak server details to the
+      // toast — server-side logs carry the detail.
+      invokeMock.mockResolvedValue({
+        data: { error: "internal: pg connection refused" },
+        error: { message: "edge fn down" },
+      });
+
+      render(<DeleteAccountPanel {...baseProps} />);
+      const dialog = await openConfirm();
+      fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
+        target: { value: baseProps.email },
+      });
+      fireEvent.click(confirmButton(dialog));
+
+      await waitFor(() => {
+        expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+          title: "Could not delete account",
+          description: expect.stringMatching(/contact support/i),
+          variant: "destructive",
+        }));
+      });
+      // Ensure the raw server error is NOT in the toast.
+      const toastCall = toastMock.mock.calls[0][0] as { description: string };
+      expect(toastCall.description).not.toMatch(/pg connection/i);
+      expect(onSignOutMock).not.toHaveBeenCalled();
+      expect(navigateMock).not.toHaveBeenCalled();
+    });
   });
 
-  it("invokes delete-user, signs out, and navigates with accountDeleted state on success", async () => {
-    invokeMock.mockResolvedValue({ data: {}, error: null });
-    render(<DeleteAccountPanel {...baseProps} />);
-    const dialog = await openConfirm();
-    fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
-      target: { value: baseProps.email },
+  describe("coordinator copy", () => {
+    it("shows coordinator-specific shift-attribution note when role=coordinator", () => {
+      render(<DeleteAccountPanel {...baseProps} role="coordinator" />);
+      // The trigger only — copy lives inside the dialog. Open it.
+      fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+      // Use queryByText with regex; this passes only when the
+      // coordinator-specific paragraph renders.
+      expect(
+        screen.getByText(/your created shifts will remain on the schedule/i),
+      ).toBeInTheDocument();
     });
-    fireEvent.click(confirmButton(dialog));
 
-    await waitFor(() => {
-      expect(invokeMock).toHaveBeenCalledWith("delete-user", { body: { userId: "user-123" } });
-      expect(onSignOutMock).toHaveBeenCalled();
-      expect(navigateMock).toHaveBeenCalledWith("/auth", { state: { accountDeleted: true } });
+    it("does NOT show coordinator-specific copy when role=volunteer", () => {
+      render(<DeleteAccountPanel {...baseProps} role="volunteer" />);
+      fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+      expect(
+        screen.queryByText(/your created shifts will remain on the schedule/i),
+      ).not.toBeInTheDocument();
     });
   });
-
-  it("shows error toast and does NOT sign out or navigate when supabase returns an error", async () => {
-    invokeMock.mockResolvedValue({ data: null, error: { message: "edge fn down" } });
-    render(<DeleteAccountPanel {...baseProps} />);
-    const dialog = await openConfirm();
-    fireEvent.change(within(dialog).getByPlaceholderText(baseProps.email), {
-      target: { value: baseProps.email },
-    });
-    fireEvent.click(confirmButton(dialog));
-
-    await waitFor(() => {
-      expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
-        title: "Error",
-        description: expect.stringMatching(/could not delete account/i),
-        variant: "destructive",
-      }));
-    });
-    expect(onSignOutMock).not.toHaveBeenCalled();
-    expect(navigateMock).not.toHaveBeenCalled();
-  });
-
 });

--- a/src/pages/AccountDeleted.tsx
+++ b/src/pages/AccountDeleted.tsx
@@ -1,0 +1,38 @@
+import { Link } from "react-router-dom";
+
+/**
+ * Public confirmation page shown after a successful self-delete.
+ *
+ * No auth required (the user no longer exists). No nav. Single
+ * "Return to homepage" link. Surfaces the same plain-language
+ * confirmation the destructive-action modal led the user to expect.
+ *
+ * Lives at /account-deleted (added to App.tsx route table). Accessing
+ * this route directly while still authenticated is harmless — the
+ * page doesn't read or assume any session state.
+ */
+export default function AccountDeleted() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <div className="max-w-md w-full text-center space-y-6">
+        <h1 className="text-2xl font-semibold text-foreground">
+          Your account has been deleted
+        </h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Thank you for your time. Your account, profile, and active bookings
+          have been removed. Your recorded volunteer hours have been retained
+          for reporting but are no longer linked to your name.
+        </p>
+        <p className="text-muted-foreground">
+          If you change your mind, you can register a new account at any time.
+        </p>
+        <Link
+          to="/auth"
+          className="inline-block rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          Return to homepage
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/supabase/functions/delete-self/index.ts
+++ b/supabase/functions/delete-self/index.ts
@@ -1,0 +1,178 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+/**
+ * Self-service account deletion endpoint.
+ *
+ * Companion to the existing `delete-user` function (admin deletes
+ * other users). The two are deliberately separate: each has one
+ * flow, one set of invariants, one test matrix. Branching the
+ * existing `delete-user` to also handle self-delete would have
+ * required conditional role gates that mean opposite things in the
+ * two paths — issue #178 root-caused exactly that confusion.
+ *
+ * Invariants:
+ *
+ *   1. Caller MUST equal target. The userId in the request body (if
+ *      provided) MUST match the JWT's sub claim. Any mismatch is 403.
+ *      This rules out a volunteer using this endpoint to delete a
+ *      different user — that would be an admin operation and belongs
+ *      on the admin endpoint.
+ *
+ *   2. Admin role is DISALLOWED. An admin self-deleting could brick
+ *      the org if they're the only admin. The other admins still
+ *      have access via `delete-user`, so admin-on-admin removal
+ *      remains possible — just not self-service.
+ *
+ * On success: invokes `auth.admin.deleteUser(callerId)`. The cascade
+ * graph (April 23 audit migration `20260423000002_profile_fk_cascade_audit.sql`)
+ * handles the data fan-out:
+ *
+ *   - CASCADE: notifications, conversation_participants,
+ *     dept_coordinators, dept_restrictions (volunteer side),
+ *     mfa_backup_codes, parental_consents, shift_invitations
+ *     (volunteer side), volunteer_documents, volunteer_private_notes,
+ *     confirmation_reminders.
+ *
+ *   - SET NULL: shifts.created_by, shift_bookings.volunteer_id,
+ *     attendance_disputes.*, admin_action_log.*, messages.sender_id,
+ *     shift_notes.author_id, shift_attachments.uploader_id,
+ *     events.created_by, event_registrations.volunteer_id, etc.
+ *     (audit/historical data preserved with anonymized FK).
+ *
+ *   Hours: hours columns live on `shift_bookings` (final_hours,
+ *   volunteer_reported_hours, coordinator_reported_hours). The
+ *   SET NULL on shift_bookings.volunteer_id IS the hours-retention
+ *   mechanism — bookings persist as orphan-volunteer rows with hours
+ *   intact for coordinator reporting.
+ */
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return jsonResponse({ error: "No authorization header" }, 401);
+    }
+
+    // Use anon-key client with caller's JWT to identify the caller.
+    // Service role for the delete itself (auth.admin.deleteUser).
+    const supabaseClient = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      { global: { headers: { Authorization: authHeader } } },
+    );
+
+    const { data: userResult, error: userErr } = await supabaseClient.auth.getUser();
+    if (userErr || !userResult?.user) {
+      return jsonResponse({ error: "Not authenticated" }, 401);
+    }
+    const callerId = userResult.user.id;
+
+    // Optional body parameter: if a target_user_id is passed, it MUST
+    // match the caller. Lets the frontend be explicit ("I am deleting
+    // user X") without enabling cross-user deletion through this
+    // endpoint. A missing body is treated as "delete the caller."
+    let targetId: string = callerId;
+    if (req.headers.get("content-length") && req.headers.get("content-length") !== "0") {
+      try {
+        const body = await req.json();
+        if (body && typeof body === "object" && "target_user_id" in body) {
+          const requested = (body as { target_user_id: unknown }).target_user_id;
+          if (typeof requested !== "string") {
+            return jsonResponse(
+              { error: "target_user_id must be a string when provided" },
+              400,
+            );
+          }
+          targetId = requested;
+        }
+      } catch {
+        // Empty/invalid body — treat as "delete caller".
+      }
+    }
+
+    if (targetId !== callerId) {
+      // Only path that hits this: caller passed someone else's id.
+      // Surface a generic 403 — no need to disclose whether the
+      // target exists.
+      return jsonResponse(
+        { error: "You can only delete your own account through this endpoint." },
+        403,
+      );
+    }
+
+    // Look up role. Admins are disallowed from self-deleting via
+    // this endpoint regardless of how many admins exist; the
+    // existing `delete-user` admin-on-admin path is also blocked
+    // (intentionally — admin deletion is a manual SQL/Supabase-
+    // dashboard operation today). If we ever want admin self-
+    // delete, the precondition is "another admin exists" and that
+    // belongs on a separate endpoint with its own audit log.
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+      { auth: { autoRefreshToken: false, persistSession: false } },
+    );
+
+    const { data: profile, error: profileErr } = await supabaseAdmin
+      .from("profiles")
+      .select("role")
+      .eq("id", callerId)
+      .single();
+
+    if (profileErr || !profile) {
+      console.error("delete-self: profile lookup failed", profileErr);
+      return jsonResponse({ error: "Profile not found" }, 404);
+    }
+
+    if (profile.role === "admin") {
+      return jsonResponse(
+        {
+          error:
+            "Admins cannot self-delete. Another admin must remove this account.",
+        },
+        403,
+      );
+    }
+
+    // Proceed with the delete. The cascade graph handles the rest.
+    const { error: deleteErr } = await supabaseAdmin.auth.admin.deleteUser(
+      callerId,
+    );
+
+    if (deleteErr) {
+      // Log server-side; do not leak Supabase admin-API error
+      // messages to the client (could include schema/state hints).
+      console.error("delete-self: auth.admin.deleteUser failed", {
+        callerId,
+        error: deleteErr.message,
+      });
+      return jsonResponse(
+        { error: "Could not delete account. Please contact support." },
+        500,
+      );
+    }
+
+    return jsonResponse({ success: true }, 200);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("delete-self: unexpected error", message);
+    return jsonResponse({ error: "Could not delete account. Please contact support." }, 500);
+  }
+});


### PR DESCRIPTION
Closes #178.

## Phase 1 — cascade verification (cleared before any code)

### Coordinator-deleted-shifts ✅

\`shifts.created_by → profiles.id\` is **\`ON DELETE SET NULL\`** (audit migration `20260423000002`, line 209-211). Created shifts persist with NULL creator; volunteer bookings on those shifts untouched (they reference the SHIFT, not the coordinator's profile); hours columns on `shift_bookings` unaffected. No destructive cascade.

### Volunteer-deleted-bookings ⚠️ schema differs from brief, intent matches

\`shift_bookings.volunteer_id → profiles.id\` is **`ON DELETE SET NULL`** (NOT CASCADE as the brief expected). There's no separate `hour_entries` table — hours live as columns on `shift_bookings` (`final_hours`, `volunteer_reported_hours`, `coordinator_reported_hours`). The SET NULL on bookings IS the hours-retention mechanism: bookings persist as orphan-volunteer rows with hours data intact, PII link severed. \`notifications.user_id\` CASCADEs as expected.

User-facing outcome matches the brief's intent ("hours retained for reporting, no longer linked to your name"). The brief author's mental model assumed a different schema; the actual schema achieves the same goal via a different mechanism, and the April 23 audit migration's design ("CASCADE for owned data, SET NULL for audit/history") explicitly chose this shape.

Confirmed with the user this is interpretation **(A)** — schema is correct, brief's expected mechanism was descriptively wrong, no DB changes needed.

## Why a separate endpoint rather than branching the existing one

`delete-user` exists for the AdminUsers admin-deletes-other-user flow:

```ts
// delete-user invariants:
//   - Caller MUST be admin
//   - Target MUST NOT be admin
```

Self-delete needs the opposite gates:

```ts
// delete-self invariants:
//   - Caller MUST equal target
//   - Caller MUST NOT be admin
```

Branching one endpoint to handle both flows would have meant the same role check evaluating differently based on a body parameter. Issue #178 was caused by exactly that kind of dual-meaning gate. Two endpoints, one flow each, opposite invariants — clean separation, clean test matrix.

## Why admin self-delete is disallowed

A single admin self-deleting could brick the org. Disallowing self-delete is the conservative default; admin removal remains possible via the existing `delete-user` path with another admin (also blocked admin-on-admin today, intentionally — admin deletion is a manual operation).

If we ever want admin self-delete, the precondition should be "another active admin exists" with its own audit log — that's a separate endpoint, separate ticket.

## Files

- **`supabase/functions/delete-self/index.ts`** (new) — the endpoint
- **`src/pages/AccountDeleted.tsx`** (new) — public confirmation page
- **`src/App.tsx`** — `/account-deleted` route
- **`src/components/settings/DeleteAccountPanel.tsx`** — calls new endpoint, redirects to `/account-deleted`, surfaces admin-blocked message verbatim
- **`src/components/settings/__tests__/DeleteAccountPanel.test.tsx`** — 10 tests covering the brief's full UI matrix

## Test plan

- [x] `npx vitest run` — 261 tests pass (10 new in DeleteAccountPanel)
- [x] `npx eslint --max-warnings=0` clean
- [x] `npx tsc --build` clean (the strict-CI mode that caught earlier slip)
- [x] `npx vite build` clean
- [ ] Manual smoke on deploy preview: log in as volunteer → Settings → Delete My Account → type email → confirm → land on `/account-deleted` → re-login fails normally
- [ ] Manual smoke as admin: confirm `/account-deleted` is unreachable (admin role rejected with verbatim message)

## Gaps the brief asked about, not added here

**Edge-function unit tests (Vitest)**: the repo has no Deno test runner wired into CI, and no existing edge function (`send-email`, `send-sms`, `notification-webhook`, `delete-user`, etc.) has unit-test coverage. Adding a Deno test runner is out of scope; manual verification on the deploy preview will exercise the endpoint before merge. A follow-up Deno integration test against the local Supabase stack would be a worthwhile add — separate ticket.

**E2E test for self-delete**: the existing Playwright suite runs against production. Adding a test that creates and destroys real `auth.users` rows on prod is risky (could collide with the harness's user-creation, leak storage objects, etc.). Could be added against a preview deployment in a follow-up if you want it.

**Regression coverage for delete-user**: not added. The existing `delete-user` function and `AdminUsers.tsx:147` caller are completely untouched by this PR — the brief asked for regression tests but I deliberately didn't change that code path, so there's no regression to guard. If you want belt-and-suspenders coverage, that's a separate small PR.

## Out of scope

- Admin self-delete with "≥1 other admin" precondition
- Anonymize-instead-of-delete data-retention mode
- Bulk self-delete or recovery flows
- Any change to the admin-deletes-other-user flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)