### PR TITLE
feat: dark-launch messenger, documents, notes for 90-day pilot

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import AccountDeleted from "./pages/AccountDeleted";
+import { MESSAGING_ENABLED, DOCUMENTS_ENABLED, NOTES_ENABLED } from "./config/featureFlags";
 import MfaVerify from "./pages/MfaVerify";
 import VolunteerDashboard from "./pages/VolunteerDashboard";
 import BrowseShifts from "./pages/BrowseShifts";
@@ -85,8 +86,15 @@ const App = () => (
             <Route path="/shifts" element={<ProtectedRoute requiredRole={["volunteer"]}><BrowseShifts /></ProtectedRoute>} />
             <Route path="/history" element={<ProtectedRoute requiredRole={["volunteer"]}><ShiftHistory /></ProtectedRoute>} />
             <Route path="/my-shifts/confirm/:bookingId" element={<ProtectedRoute requiredRole={["volunteer"]}><ShiftConfirmation /></ProtectedRoute>} />
-            <Route path="/notes" element={<ProtectedRoute requiredRole={["volunteer"]}><MyNotes /></ProtectedRoute>} />
-            <Route path="/documents" element={<ProtectedRoute requiredRole={["volunteer"]}><VolunteerDocuments /></ProtectedRoute>} />
+            {/* Pilot dark-launch — see src/config/featureFlags.ts.
+                When disabled, route is not registered and falls
+                through to <Route path="*" element={<NotFound />} />. */}
+            {NOTES_ENABLED && (
+              <Route path="/notes" element={<ProtectedRoute requiredRole={["volunteer"]}><MyNotes /></ProtectedRoute>} />
+            )}
+            {DOCUMENTS_ENABLED && (
+              <Route path="/documents" element={<ProtectedRoute requiredRole={["volunteer"]}><VolunteerDocuments /></ProtectedRoute>} />
+            )}
             <Route path="/unactioned" element={<ProtectedRoute requiredRole={["volunteer"]}><VolunteerUnactionedShifts /></ProtectedRoute>} />
 
             <Route path="/coordinator" element={<ProtectedRoute requiredRole={["coordinator", "admin"]}><CoordinatorDashboard /></ProtectedRoute>} />
@@ -106,7 +114,10 @@ const App = () => (
             <Route path="/admin/disputes" element={<ProtectedRoute requiredRole={["admin"]}><AdminDisputes /></ProtectedRoute>} />
             <Route path="/events" element={<ProtectedRoute><VolunteerEvents /></ProtectedRoute>} />
 
-            <Route path="/messages" element={<ProtectedRoute><Messages /></ProtectedRoute>} />
+            {/* Pilot dark-launch — see src/config/featureFlags.ts. */}
+            {MESSAGING_ENABLED && (
+              <Route path="/messages" element={<ProtectedRoute><Messages /></ProtectedRoute>} />
+            )}
             <Route path="/settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
 
             <Route path="*" element={<NotFound />} />

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -10,6 +10,7 @@ import { Leaf, MessageSquare, Sun, Moon } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useUnreadCount } from "@/hooks/useUnreadCount";
 import { useNavigate } from "react-router-dom";
+import { MESSAGING_ENABLED } from "@/config/featureFlags";
 
 export function AppLayout({ children }: { children: ReactNode }) {
   const isMobile = useIsMobile();
@@ -48,27 +49,30 @@ export function AppLayout({ children }: { children: ReactNode }) {
                 {theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
               </TooltipContent>
             </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={() => navigate("/messages")}
-                  className="relative p-2 rounded-md hover:bg-muted transition-colors"
-                  aria-label={`Messages${unreadCount > 0 ? `, ${unreadCount} unread` : ""}`}
-                >
-                  <MessageSquare className="h-5 w-5" />
-                  {unreadCount > 0 && (
-                    <span className="absolute -top-0.5 -right-0.5 h-4 min-w-[1rem] px-1 flex items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
-                      {unreadCount > 9 ? "9+" : unreadCount}
-                    </span>
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {unreadCount > 0
-                  ? `Messages (${unreadCount} unread)`
-                  : "Messages"}
-              </TooltipContent>
-            </Tooltip>
+            {/* Pilot dark-launch — see src/config/featureFlags.ts */}
+            {MESSAGING_ENABLED && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => navigate("/messages")}
+                    className="relative p-2 rounded-md hover:bg-muted transition-colors"
+                    aria-label={`Messages${unreadCount > 0 ? `, ${unreadCount} unread` : ""}`}
+                  >
+                    <MessageSquare className="h-5 w-5" />
+                    {unreadCount > 0 && (
+                      <span className="absolute -top-0.5 -right-0.5 h-4 min-w-[1rem] px-1 flex items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
+                        {unreadCount > 9 ? "9+" : unreadCount}
+                      </span>
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {unreadCount > 0
+                    ? `Messages (${unreadCount} unread)`
+                    : "Messages"}
+                </TooltipContent>
+              </Tooltip>
+            )}
             <NotificationBell />
           </header>
           <main className="flex-1 p-4 md:p-8 pb-24 md:pb-8 overflow-auto" role="main" style={{ paddingBottom: 'max(6rem, calc(6rem + env(safe-area-inset-bottom)))' }}>

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/sidebar";
 import { Calendar, CalendarDays, ClipboardList, Users, Shield, Settings, LogOut, Home, Building2, Bell, FileText, Cog, FolderOpen, CheckSquare, MessageSquare, BarChart3, AlertCircle, Scale } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { MESSAGING_ENABLED, DOCUMENTS_ENABLED, NOTES_ENABLED } from "@/config/featureFlags";
 
 export function AppSidebar() {
   const { role, profile, signOut } = useAuth();
@@ -14,15 +15,24 @@ export function AppSidebar() {
   const collapsed = state === "collapsed";
   const location = useLocation();
 
+  // Pilot dark-launch: filter out nav entries for hidden features.
+  // See src/config/featureFlags.ts. When flags flip back to true,
+  // the entries reappear automatically — no other code changes.
   const volunteerItems = role === "volunteer" ? [
     { title: "My Shifts", url: "/dashboard", icon: Home },
     { title: "Browse Shifts", url: "/shifts", icon: Calendar },
     { title: "Unactioned Shifts", url: "/unactioned", icon: AlertCircle },
     { title: "Events", url: "/events", icon: CalendarDays },
     { title: "My History", url: "/history", icon: ClipboardList },
-    { title: "My Notes", url: "/notes", icon: FileText },
-    { title: "Documents", url: "/documents", icon: FolderOpen },
-    { title: "Messages", url: "/messages", icon: MessageSquare },
+    ...(NOTES_ENABLED
+      ? [{ title: "My Notes", url: "/notes", icon: FileText }]
+      : []),
+    ...(DOCUMENTS_ENABLED
+      ? [{ title: "Documents", url: "/documents", icon: FolderOpen }]
+      : []),
+    ...(MESSAGING_ENABLED
+      ? [{ title: "Messages", url: "/messages", icon: MessageSquare }]
+      : []),
   ] : [];
 
   const coordinatorItems = [
@@ -30,7 +40,9 @@ export function AppSidebar() {
     { title: "Manage Shifts", url: "/coordinator/manage", icon: Settings },
     { title: "Unactioned Shifts", url: "/admin/unactioned-shifts", icon: AlertCircle },
     { title: "Reports", url: "/reports", icon: BarChart3 },
-    { title: "Messages", url: "/messages", icon: MessageSquare },
+    ...(MESSAGING_ENABLED
+      ? [{ title: "Messages", url: "/messages", icon: MessageSquare }]
+      : []),
   ];
 
   const adminItems = [

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate, NavLink } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
+import { MESSAGING_ENABLED, DOCUMENTS_ENABLED, NOTES_ENABLED } from "@/config/featureFlags";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -66,14 +67,21 @@ function getSections(role: UserRole): NavSection[] {
     sections.push({
       heading: "Volunteer",
       items: [
+        // Pilot dark-launch: see src/config/featureFlags.ts
         { label: "My Shifts", to: "/dashboard", icon: Home },
         { label: "Browse Shifts", to: "/shifts", icon: Calendar },
         { label: "Unactioned Shifts", to: "/unactioned", icon: AlertCircle },
         { label: "Events", to: "/events", icon: CalendarDays },
         { label: "My History", to: "/history", icon: ClipboardList },
-        { label: "My Notes", to: "/notes", icon: FileText },
-        { label: "Documents", to: "/documents", icon: FolderOpen },
-        { label: "Messages", to: "/messages", icon: MessageSquare },
+        ...(NOTES_ENABLED
+          ? [{ label: "My Notes", to: "/notes", icon: FileText }]
+          : []),
+        ...(DOCUMENTS_ENABLED
+          ? [{ label: "Documents", to: "/documents", icon: FolderOpen }]
+          : []),
+        ...(MESSAGING_ENABLED
+          ? [{ label: "Messages", to: "/messages", icon: MessageSquare }]
+          : []),
       ],
     });
   }
@@ -86,7 +94,9 @@ function getSections(role: UserRole): NavSection[] {
         { label: "Manage Shifts", to: "/coordinator/manage", icon: Settings },
         { label: "Unactioned Shifts", to: "/admin/unactioned-shifts", icon: AlertCircle },
         { label: "Reports", to: "/reports", icon: BarChart3 },
-        { label: "Messages", to: "/messages", icon: MessageSquare },
+        ...(MESSAGING_ENABLED
+          ? [{ label: "Messages", to: "/messages", icon: MessageSquare }]
+          : []),
       ],
     });
   }

--- a/src/components/messaging/BulkComposeMessage.tsx
+++ b/src/components/messaging/BulkComposeMessage.tsx
@@ -13,6 +13,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { Loader2 } from "lucide-react";
+import { MESSAGING_ENABLED } from "@/config/featureFlags";
 
 interface Department {
   id: string;
@@ -146,15 +147,18 @@ export function BulkComposeMessage({ open, onOpenChange, onSent }: BulkComposeMe
         content: content.trim(),
       });
 
-      // Notification
-      await supabase.from("notifications").insert({
-        user_id: recipient.id,
-        title: `Message from ${senderName}`,
-        message: content.trim().slice(0, 100),
-        type: "new_message",
-        link: "/messages",
-        is_read: false,
-      });
+      // Notification (gated for pilot dark-launch — see
+      // src/config/featureFlags.ts).
+      if (MESSAGING_ENABLED) {
+        await supabase.from("notifications").insert({
+          user_id: recipient.id,
+          title: `Message from ${senderName}`,
+          message: content.trim().slice(0, 100),
+          type: "new_message",
+          link: "/messages",
+          is_read: false,
+        });
+      }
 
       sentCount++;
     }

--- a/src/components/messaging/ComposeMessage.tsx
+++ b/src/components/messaging/ComposeMessage.tsx
@@ -13,6 +13,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { Loader2 } from "lucide-react";
+import { MESSAGING_ENABLED } from "@/config/featureFlags";
 
 interface User {
   id: string;
@@ -133,20 +134,28 @@ export function ComposeMessage({ open, onOpenChange, onSent }: ComposeMessagePro
       .update({ updated_at: new Date().toISOString() })
       .eq("id", conversationId);
 
-    // Send notification
+    // Send notification.
     // NOTE: `users` is filtered to exclude the current user (line 49),
     // so the previous `users.find(u => u.id === user.id)` always failed
     // and every compose-notification said "Someone". Pull the sender's
     // name directly from their own profile via useAuth instead.
-    const senderName = profile?.full_name || user.email || "Someone";
-    await supabase.from("notifications").insert({
-      user_id: selectedUserId,
-      title: `New message from ${senderName || "a user"}`,
-      message: content.trim().slice(0, 100),
-      type: "new_message",
-      link: "/messages",
-      is_read: false,
-    });
+    //
+    // Pilot dark-launch (see src/config/featureFlags.ts): the
+    // messaging UI is unreachable when MESSAGING_ENABLED is false,
+    // so this code path doesn't run anyway — but gating the fan-out
+    // here too prevents stray dead-link notifications if a deep
+    // import or test happens to call this component.
+    if (MESSAGING_ENABLED) {
+      const senderName = profile?.full_name || user.email || "Someone";
+      await supabase.from("notifications").insert({
+        user_id: selectedUserId,
+        title: `New message from ${senderName || "a user"}`,
+        message: content.trim().slice(0, 100),
+        type: "new_message",
+        link: "/messages",
+        is_read: false,
+      });
+    }
 
     setSending(false);
 

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -6,6 +6,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { MessageBubble } from "./MessageBubble";
 import { Send, Loader2 } from "lucide-react";
+import { MESSAGING_ENABLED } from "@/config/featureFlags";
 
 interface Message {
   id: string;
@@ -156,19 +157,25 @@ export function ConversationThread({ conversationId, participantNames: externalN
       setNewMessage("");
       onMessageSent?.();
 
-      // Insert notification for other participants
-      const otherParticipants = Object.keys(participantNames).filter((id) => id !== user.id);
-      if (otherParticipants.length > 0) {
-        const senderName = participantNames[user.id] || "Someone";
-        const notifs = otherParticipants.map((uid) => ({
-          user_id: uid,
-          title: `New message from ${senderName}`,
-          message: newMessage.trim().slice(0, 100),
-          type: "new_message",
-          link: `/messages`,
-          is_read: false,
-        }));
-        await supabase.from("notifications").insert(notifs);
+      // Insert notification for other participants. Gated for the
+      // pilot dark-launch — see src/config/featureFlags.ts. The
+      // messaging UI is unreachable when the flag is off, so this
+      // path can't run; the gate is a belt-and-suspenders guard
+      // against stray imports / future test harnesses.
+      if (MESSAGING_ENABLED) {
+        const otherParticipants = Object.keys(participantNames).filter((id) => id !== user.id);
+        if (otherParticipants.length > 0) {
+          const senderName = participantNames[user.id] || "Someone";
+          const notifs = otherParticipants.map((uid) => ({
+            user_id: uid,
+            title: `New message from ${senderName}`,
+            message: newMessage.trim().slice(0, 100),
+            type: "new_message",
+            link: `/messages`,
+            is_read: false,
+          }));
+          await supabase.from("notifications").insert(notifs);
+        }
       }
     }
     setSending(false);

--- a/src/config/__tests__/featureFlags.test.tsx
+++ b/src/config/__tests__/featureFlags.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { MESSAGING_ENABLED, DOCUMENTS_ENABLED, NOTES_ENABLED } from "@/config/featureFlags";
+
+/**
+ * Pilot dark-launch — pinning the three flag values at compile time.
+ *
+ * The flags live in src/config/featureFlags.ts and gate route
+ * registration, nav entries, in-page CTAs, and notification
+ * fan-out for the messenger / documents / notes features. For the
+ * 90-day pilot all three MUST be false; this test fails the build
+ * if anyone flips one prematurely.
+ *
+ * To re-enable a feature at pilot end:
+ *   1. Edit src/config/featureFlags.ts and flip the relevant flag.
+ *   2. Update this test (delete the assertion for the now-true flag,
+ *      or change the expectation) so the test stays a tripwire for
+ *      the OTHER flags that should remain false.
+ *   3. Verify routes/nav/CTAs reappear in the UI and notification
+ *      fan-out resumes.
+ */
+
+describe("pilot dark-launch feature flags", () => {
+  it("MESSAGING_ENABLED is false during the pilot", () => {
+    expect(MESSAGING_ENABLED).toBe(false);
+  });
+
+  it("DOCUMENTS_ENABLED is false during the pilot", () => {
+    expect(DOCUMENTS_ENABLED).toBe(false);
+  });
+
+  it("NOTES_ENABLED is false during the pilot", () => {
+    expect(NOTES_ENABLED).toBe(false);
+  });
+});

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,0 +1,50 @@
+/**
+ * Compile-time feature flags for the 90-day pilot dark-launch.
+ *
+ * Three features are intentionally hidden from end users for the
+ * duration of the pilot:
+ *
+ *   - In-app messenger
+ *   - Volunteer document uploads
+ *   - Volunteer notes (the /notes page AND the per-booking add-note
+ *     dialog inside ShiftHistory, AND the admin shift-notes audit
+ *     panel inside AdminSettings)
+ *
+ * The dark-launch uses the ROUTE-HIDE pattern (not RLS-deny):
+ *   - Routes are not registered when the flag is false → URLs 404
+ *     via the catch-all <Route path="*" />.
+ *   - Sidebar / mobile / header nav entries are filtered out.
+ *   - In-page CTAs that surface the feature are conditionally
+ *     rendered.
+ *   - Frontend notification fan-out sites that reference these
+ *     features short-circuit early.
+ *
+ * What's intentionally NOT done:
+ *   - RLS policies are unchanged (the brief explicitly excludes them)
+ *   - Database tables, triggers, RPC functions, and migrations are
+ *     unchanged
+ *   - Edge functions and storage buckets are unchanged
+ *   - Component / page source files are kept (only their
+ *     route registrations are dropped)
+ *
+ * To re-enable for pilot end:
+ *   Flip the corresponding boolean below to `true`. That single
+ *   change re-registers the route, restores the nav entry, and
+ *   unblocks the frontend fan-out gates.
+ *
+ * Why a TS module rather than environment variables:
+ *   - Tree-shakeable: the bundler can drop disabled-feature code
+ *     paths entirely once the flag is statically false.
+ *   - No runtime startup cost or env-var-mismatch failure mode.
+ *   - Reverting the pilot is a single-file diff that's reviewable
+ *     and revertible.
+ *
+ * Why no environment-variable override:
+ *   - The pilot end-state is a code change ("we're going live") that
+ *     should be visible in the diff and PR review process. An env-var
+ *     override would let prod silently diverge from staging.
+ */
+
+export const MESSAGING_ENABLED = false;
+export const DOCUMENTS_ENABLED = false;
+export const NOTES_ENABLED = false;

--- a/src/pages/AdminSettings.tsx
+++ b/src/pages/AdminSettings.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@/hooks/use-toast";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
 import { Shield, FileText } from "lucide-react";
 import { format } from "date-fns";
+import { NOTES_ENABLED } from "@/config/featureFlags";
 
 export default function AdminSettings() {
   const { user } = useAuth();
@@ -88,34 +89,41 @@ export default function AdminSettings() {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2"><FileText className="h-5 w-5" />All Shift Notes</CardTitle>
-          <CardDescription>Notes from all departments</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {loadingNotes ? (
-            <p className="text-muted-foreground">Loading...</p>
-          ) : notes.length === 0 ? (
-            <p className="text-muted-foreground text-center py-4">No notes found.</p>
-          ) : (
-            <div className="space-y-3">
-              {notes.map((n) => (
-                <div key={n.id} className="p-3 rounded-md bg-muted/50 space-y-1">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium">{n.profiles?.full_name}</span>
-                    <span className="text-xs text-muted-foreground">{format(new Date(n.created_at), "MMM d, yyyy")}</span>
+      {/* Pilot dark-launch — see src/config/featureFlags.ts.
+          The notes audit panel is part of the Notes feature surface;
+          hiding it keeps the admin UI consistent with the volunteer-
+          side hide. The shift_notes table itself is untouched, so
+          existing rows remain in the DB for re-enable. */}
+      {NOTES_ENABLED && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2"><FileText className="h-5 w-5" />All Shift Notes</CardTitle>
+            <CardDescription>Notes from all departments</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {loadingNotes ? (
+              <p className="text-muted-foreground">Loading...</p>
+            ) : notes.length === 0 ? (
+              <p className="text-muted-foreground text-center py-4">No notes found.</p>
+            ) : (
+              <div className="space-y-3">
+                {notes.map((n) => (
+                  <div key={n.id} className="p-3 rounded-md bg-muted/50 space-y-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium">{n.profiles?.full_name}</span>
+                      <span className="text-xs text-muted-foreground">{format(new Date(n.created_at), "MMM d, yyyy")}</span>
+                    </div>
+                    <p className="text-sm">{n.content}</p>
+                    <div className="text-xs text-muted-foreground">
+                      {n.shift_bookings?.shifts?.title} • {n.shift_bookings?.shifts?.departments?.name}
+                    </div>
                   </div>
-                  <p className="text-sm">{n.content}</p>
-                  <div className="text-xs text-muted-foreground">
-                    {n.shift_bookings?.shifts?.title} • {n.shift_bookings?.shifts?.departments?.name}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/src/pages/ShiftHistory.tsx
+++ b/src/pages/ShiftHistory.tsx
@@ -14,6 +14,7 @@ import { useToast } from "@/hooks/use-toast";
 import { downloadCSV, timeLabel } from "@/lib/calendar-utils";
 import { BookedSlotsDisplay } from "@/components/volunteer/BookedSlotsDisplay";
 import { VolunteerHoursLetter } from "@/components/volunteer/VolunteerHoursLetter";
+import { NOTES_ENABLED } from "@/config/featureFlags";
 
 export default function ShiftHistory() {
   const { user, profile } = useAuth();
@@ -304,20 +305,23 @@ export default function ShiftHistory() {
                       )}
                     </div>
                     <div className="flex gap-2">
-                      <Dialog>
-                        <DialogTrigger asChild>
-                          <Button variant="outline" size="sm" onClick={() => setActiveBooking(b.id)}>
-                            <FileText className="h-3 w-3 mr-1" />Note
-                          </Button>
-                        </DialogTrigger>
-                        <DialogContent>
-                          <DialogHeader><DialogTitle>Add Note for {s.title}</DialogTitle></DialogHeader>
-                          <Textarea placeholder="Write your note..." value={noteContent} onChange={(e) => setNoteContent(e.target.value)} rows={4} maxLength={2000} />
-                          <p className="text-xs text-muted-foreground">{noteContent.length}/2000</p>
-                          {noteContent.length > 2000 && <p className="text-xs text-destructive">Note must be under 2000 characters</p>}
-                          <Button onClick={handleAddNote} disabled={!noteContent.trim() || noteContent.length > 2000}>Save Note</Button>
-                        </DialogContent>
-                      </Dialog>
+                      {/* Pilot dark-launch — see src/config/featureFlags.ts */}
+                      {NOTES_ENABLED && (
+                        <Dialog>
+                          <DialogTrigger asChild>
+                            <Button variant="outline" size="sm" onClick={() => setActiveBooking(b.id)}>
+                              <FileText className="h-3 w-3 mr-1" />Note
+                            </Button>
+                          </DialogTrigger>
+                          <DialogContent>
+                            <DialogHeader><DialogTitle>Add Note for {s.title}</DialogTitle></DialogHeader>
+                            <Textarea placeholder="Write your note..." value={noteContent} onChange={(e) => setNoteContent(e.target.value)} rows={4} maxLength={2000} />
+                            <p className="text-xs text-muted-foreground">{noteContent.length}/2000</p>
+                            {noteContent.length > 2000 && <p className="text-xs text-destructive">Note must be under 2000 characters</p>}
+                            <Button onClick={handleAddNote} disabled={!noteContent.trim() || noteContent.length > 2000}>Save Note</Button>
+                          </DialogContent>
+                        </Dialog>
+                      )}
                       <label className="cursor-pointer">
                         <Button variant="outline" size="sm" asChild>
                           <span><Upload className="h-3 w-3 mr-1" />{uploading ? "..." : "Upload"}</span>


### PR DESCRIPTION
Hide messenger, document uploads, and notes from end users for the 90-day pilot using the **route-hide pattern**. RLS, schema, edge functions, storage buckets, and component source files are untouched.

## Phase 1 — inventory

### Routes (3)

| File:Line | Route | Component |
|---|---|---|
| `src/App.tsx:88` | `/notes` | `MyNotes` |
| `src/App.tsx:89` | `/documents` | `VolunteerDocuments` |
| `src/App.tsx:109` | `/messages` | `Messages` |

`/admin/compliance` (admin oversight) stays — brief named only `VolunteerDocuments.tsx`.

### Nav entries (9)

`src/components/layout/AppSidebar.tsx:23-25` (volunteer: My Notes / Documents / Messages), `:33` (coordinator: Messages); `src/components/layout/MobileNav.tsx:74-76` (volunteer), `:89` (coordinator); `src/components/layout/AppLayout.tsx:51-71` (header messages icon).

### Cross-page CTAs (2)

`src/pages/ShiftHistory.tsx:307-320` — per-booking Add Note dialog. `src/pages/AdminSettings.tsx:91-118` — All Shift Notes audit panel.

### Frontend notification fan-out (3)

`ComposeMessage.tsx:142`, `BulkComposeMessage.tsx:150`, `ConversationThread.tsx:171` — gated belt-and-suspenders. Messaging UI is unreachable when flag is off so these never fire, but the gate prevents stray dead-link notifications from any future deep import / test path.

### Phase 1 stop-check ✅

No cross-reference would break a kept feature:
- `DocumentStatusBadge` is also used by `DocumentCompliance` (admin-side, kept) — component stays
- Onboarding doesn't reference VolunteerDocuments
- `shifts.coordinator_note` (kept) is a different column from `shift_notes` table (hidden)
- `shift_attachments` upload in ShiftHistory uses a different bucket and table from volunteer compliance documents (different feature, kept)

## Phase 2 — implementation

### Feature flags (single source of truth)

`src/config/featureFlags.ts`:

\`\`\`ts
export const MESSAGING_ENABLED = false;
export const DOCUMENTS_ENABLED = false;
export const NOTES_ENABLED = false;
\`\`\`

All gates import from this file. **To re-enable a feature: flip the corresponding boolean.** Single-file diff.

### Routes — App.tsx

\`\`\`tsx
{NOTES_ENABLED && (
  <Route path="/notes" element={<ProtectedRoute requiredRole={["volunteer"]}><MyNotes /></ProtectedRoute>} />
)}
{DOCUMENTS_ENABLED && (
  <Route path="/documents" element={<ProtectedRoute requiredRole={["volunteer"]}><VolunteerDocuments /></ProtectedRoute>} />
)}
{MESSAGING_ENABLED && (
  <Route path="/messages" element={<ProtectedRoute><Messages /></ProtectedRoute>} />
)}
\`\`\`

When unregistered, the URLs fall through to `<Route path="*" element={<NotFound />} />`.

### Nav — AppSidebar / MobileNav

Conditional spreads into the items array. Gone when off, reappear when on. Both volunteer and coordinator nav surfaces handled.

### Header — AppLayout

Messages icon button gated; the bell icon for general notifications stays.

### In-page CTAs

ShiftHistory Add Note dialog and AdminSettings All Shift Notes panel — both wrapped in `{NOTES_ENABLED && ...}`.

### Notification fan-out gates

\`\`\`ts
if (MESSAGING_ENABLED) {
  await supabase.from("notifications").insert({ /* ... */ });
}
\`\`\`

Three sites: `ComposeMessage`, `BulkComposeMessage`, `ConversationThread`. The messaging UI itself is unreachable when off, so this is belt-and-suspenders against future deep imports.

## Phase 3 — verification

**Vitest tripwire** (`src/config/__tests__/featureFlags.test.tsx`): pins all three flags at \`false\`. Fails the build if anyone flips one prematurely.

**Manual verification** (post-deploy preview): log in as volunteer / coordinator / admin; confirm:
- `/messages`, `/documents`, `/notes` resolve to NotFound
- Sidebar + mobile nav show no entries for hidden features
- Header messages icon is gone
- ShiftHistory has no Add Note button
- AdminSettings has no All Shift Notes panel

**Production E2E** (deferred): \`PLAYWRIGHT_BASE_URL\` in \`ci.yml\` points at production. Adding an E2E asserting the routes 404 would fail until the PR is shipped — same sequencing problem as PR #177. Re-add as part of the re-enable PR if useful.

## Notification fan-out gates added

| File:Line | Type | Gate |
|---|---|---|
| `ComposeMessage.tsx:142-153` | `new_message` | `MESSAGING_ENABLED` |
| `BulkComposeMessage.tsx:149-160` | `new_message` | `MESSAGING_ENABLED` |
| `ConversationThread.tsx:159-179` | `new_message` | `MESSAGING_ENABLED` |

**DB-side document expiry cron** (\`warn_expiring_documents\` Postgres function): NOT disabled. Out of scope per brief (\"Database schema changes\"). Risk: any pre-existing \`volunteer_documents\` rows could trigger expiry notifications during the pilot, which would deep-link to \`/documents\` → NotFound. Low impact (small number of rows expected from this recently-rolled-out feature). Flagged here as a follow-up if expiry-notification noise becomes visible during the pilot — could be silenced via \`cron.unschedule('warn-expiring-documents')\` in a small migration.

## Reversing the pilot at end-of-90-days

1. Edit `src/config/featureFlags.ts` and set the three flags to `true` (or whichever subset).
2. Update `src/config/__tests__/featureFlags.test.tsx` to match — the tripwire test asserts they're all false.
3. Deploy.

That's it. Routes re-register, nav entries reappear, in-page CTAs come back, notification fan-outs resume.

## Test plan

- [x] `npx vitest run` — 264 tests pass (3 new tripwire tests)
- [x] `npx eslint --max-warnings=0` clean
- [x] `npx tsc --build` clean (strict CI mode)
- [x] `npx vite build` clean
- [ ] Manual smoke on deploy preview (see verification checklist above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)