### PR TITLE
fix: coordinator can cancel shifts in their dept (RLS visibility on cancelled rows)

### DIFF
--- a/supabase/migrations/20260430000000_shifts_coord_read_cancelled.sql
+++ b/supabase/migrations/20260430000000_shifts_coord_read_cancelled.sql
@@ -1,0 +1,48 @@
+-- Coordinator/admin SELECT visibility on shifts in their own department,
+-- regardless of status.
+--
+-- Why: the existing SELECT policies on `shifts` are:
+--   1. "shifts: all read open"  — USING (status <> 'cancelled' AND ...)
+--   2. "shifts: read booked"    — USING (has_active_booking_on(id))
+--
+-- Neither admits a `cancelled` shift to a coordinator who manages that
+-- department. That gap surfaces in production as a misleading error:
+-- when a coordinator UPDATEs a shift to status='cancelled', PostgREST
+-- (and supabase-js's `.update().select()`) issue UPDATE ... RETURNING.
+-- Postgres re-evaluates SELECT RLS against the new row to populate
+-- RETURNING, finds no SELECT policy admits it, and reports
+--   42501 / "new row violates row-level security policy for table 'shifts'"
+-- — the same SQLSTATE used for genuine WITH CHECK violations.
+--
+-- This breaks the coordinator-facing soft-delete flow shipped in
+-- PR #173: cancelShiftWithNotifications calls .update().select() and
+-- falls into its 'error' branch, surfacing the raw 42501 message in a
+-- toast. The same bug forced the harness to mark the positive-case
+-- shift-cancel RLS test as it.skip — see supabase/test/shift-cancel-rls.test.ts.
+--
+-- Fix: add a permissive SELECT policy that lets a coordinator (or any
+-- admin) see every shift in a department they manage, regardless of
+-- status. Visibility is strictly narrower than the existing UPDATE/
+-- INSERT/DELETE rights these roles already have on the same rows, so
+-- this does not broaden the security model — it closes a visibility
+-- gap that was masquerading as a write-side denial.
+--
+-- Combined with the two existing SELECT policies via OR (Postgres
+-- permissive-policy semantics), volunteers' visibility is unchanged.
+
+CREATE POLICY "shifts: coord/admin read all"
+  ON public.shifts
+  FOR SELECT
+  TO authenticated
+  USING (
+    public.is_admin()
+    OR (
+      public.is_coordinator_or_admin()
+      AND EXISTS (
+        SELECT 1
+        FROM public.department_coordinators dc
+        WHERE dc.department_id = shifts.department_id
+          AND dc.coordinator_id = auth.uid()
+      )
+    )
+  );

--- a/supabase/test/shift-cancel-rls.test.ts
+++ b/supabase/test/shift-cancel-rls.test.ts
@@ -95,29 +95,16 @@ afterAll(async () => {
 });
 
 describe("shifts: coordinator soft-delete (UPDATE status='cancelled') — RLS", () => {
-  // TODO(audit-followup): the coordinator's UPDATE on a shift in
-  // their own department fails RLS with 42501 in this harness, even
-  // though all the preconditions are individually visible:
-  //
-  //   - profiles.role = 'coordinator' (auth.uid() resolves correctly)
-  //   - dept_coordinators row linking coord ↔ TEST_DEPARTMENT_ID is
-  //     readable as the coord
-  //   - shift row is readable as the coord
-  //   - the EXISTS subquery the policy uses, run as a regular SELECT,
-  //     returns the row
-  //
-  // The static analysis of `shifts: coord/admin update` says this
-  // should work. The harness reproducibly says otherwise. That gap
-  // is bigger than this PR — separate investigation needed (could
-  // be a Supabase storage-API/PostgREST quirk on UPDATE with WITH
-  // CHECK, or a harness-specific GUC issue).
-  //
-  // The negative case below (foreign-dept UPDATE returns 0 rows) is
-  // the load-bearing audit assertion — it pins the bug fix's "RLS
-  // denial returns 200+[] not an error" behavior. Skipping the
-  // positive case keeps the regression net rather than dropping the
-  // whole suite.
-  it.skip("coordinator can UPDATE a shift in their own department (returns the row)", async () => {
+  // The 42501 the harness used to hit on this case wasn't a WITH CHECK
+  // violation — it was a SELECT-on-RETURNING failure. The two existing
+  // SELECT policies on `shifts` (`all read open` requires status<>'cancelled';
+  // `read booked` is volunteer-only) didn't admit a freshly-cancelled
+  // row back to its author, so PostgREST's RETURNING-after-UPDATE
+  // surfaced as 42501 with the same message Postgres uses for WITH CHECK
+  // failures. Migration 20260430000000_shifts_coord_read_cancelled.sql
+  // adds a coord/admin SELECT policy that closes that visibility gap.
+  // This positive-case test is the regression net for that fix.
+  it("coordinator can UPDATE a shift in their own department (returns the row)", async () => {
     const users = getHarnessUsers();
     const client = await signInAs("coordinator");
 


### PR DESCRIPTION
## Summary
- Closes the RLS visibility gap that made coordinators see `42501 / "new row violates row-level security policy"` whenever they tried to cancel a shift in their own department — the user-facing bug PR #173 was meant to fix but couldn't reach.
- Adds a permissive `shifts: coord/admin read all` SELECT policy scoped to managed departments. Strictly narrower than the existing UPDATE/INSERT/DELETE rights these roles already have on the same rows.
- Un-skips the positive-case test in `supabase/test/shift-cancel-rls.test.ts` that PR #173 had to mark `it.skip` because of this exact bug; replaces the misleading "harness flakiness" TODO with the actual root-cause comment.

## Root cause (verified live on prod)
Two existing SELECT policies on `shifts`:
- `shifts: all read open` — `USING (status <> 'cancelled' AND ...)`
- `shifts: read booked` — volunteer-only

Neither admits a newly-cancelled row back to its author. `supabase-js`'s `.update().select()` and PostgREST's UPDATE both issue `RETURNING`. Postgres re-evaluates SELECT RLS on the new row to populate `RETURNING`, finds nothing visible, and reports it as `42501` with the same message used for genuine WITH CHECK failures — which is why static analysis of `shifts: coord/admin update` looked correct but reality kept failing.

Bisected on prod with the Chrome extension as `sabih-usman@uiowa.edu`:
- `PATCH shifts {status:'cancelled'}` → 42501
- `PATCH shifts {status:'full'}` → 200
- `PATCH shifts {title:'…'}` → 200
- `INSERT shift {status:'cancelled', Prefer: return=minimal}` → 201 ✓
- `INSERT shift {status:'cancelled', Prefer: return=representation}` → 42501

That last pair pins the failure to RETURNING + SELECT RLS, not to WITH CHECK.

## Test plan
- [ ] CI green — RLS suite picks up the un-skipped positive-case test and it passes against the new policy
- [ ] Smoke as coordinator on a preview deploy: cancel a shift in own dept → success toast, shift moves to cancelled, booked volunteers receive notifications
- [ ] Smoke as coordinator: cancel attempt on a shift in a foreign dept → still RLS-filtered to 0 rows (negative-case test still passes, unchanged)
- [ ] After merge: confirm the migration runs against prod Supabase before announcing fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)