### PR TITLE
feat: remove DOB capture; flip is_minor source to user-answered (Half A)

### DIFF
--- a/src/components/admin/UserCard.tsx
+++ b/src/components/admin/UserCard.tsx
@@ -52,7 +52,7 @@ export function UserCard({ profile: p, adminCount, actions }: Props) {
             )}
             {p.role === "volunteer" && p.is_minor && (
               <div className="text-xs text-muted-foreground">
-                Minor (DOB: {p.date_of_birth}) —{" "}
+                Minor —{" "}
                 <Button
                   variant="link"
                   size="sm"

--- a/src/components/settings/ProfilePanel.tsx
+++ b/src/components/settings/ProfilePanel.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { AvatarUploadField } from "./AvatarUploadField";
 import type { SettingsProfile } from "./types";
@@ -18,26 +17,32 @@ interface Props {
   setPhone: (v: string) => void;
   emergencyPhone: string;
   setEmergencyPhone: (v: string) => void;
+  /**
+   * Read-only here. is_minor is now answered once at signup (over-18
+   * radio in Auth.tsx) and is not editable from this panel — see
+   * migration 20260501000000_remove_dob_capture.sql. Settings.tsx still
+   * passes it down because ParentalConsentPanel visibility depends on
+   * it, but this panel no longer mutates it.
+   */
   isMinor: boolean;
-  setIsMinor: (v: boolean) => void;
   /** Called after a successful save so the parent can refreshProfile(). */
   onSaved: () => Promise<void> | void;
 }
 
-const MIN_AGE_MS = 13 * 365.25 * 86400000;
-
 /**
  * Profile information panel: avatar, display name, email (with auth update),
- * phone, emergency contact, and date-of-birth (with minor detection).
+ * phone, and emergency contact.
  *
- * Phone/emergencyPhone/isMinor are lifted to the page so other panels can
- * react to in-progress edits before the user clicks Save.
+ * Phone/emergencyPhone are lifted to the page so NotificationsPanel can
+ * react to in-progress edits before the user clicks Save. isMinor is read
+ * but no longer mutated here — Half A removed DOB capture in favor of a
+ * one-time signup question.
  */
 export function ProfilePanel({
   userId, profile,
   phone, setPhone,
   emergencyPhone, setEmergencyPhone,
-  isMinor, setIsMinor,
+  isMinor: _isMinor,
   onSaved,
 }: Props) {
   const { toast } = useToast();
@@ -45,7 +50,6 @@ export function ProfilePanel({
   const [fullName, setFullName] = useState(profile.full_name || "");
   const [email, setEmail] = useState(profile.email || "");
   const [emergencyName, setEmergencyName] = useState(profile.emergency_contact_name || "");
-  const [dateOfBirth, setDateOfBirth] = useState(profile.date_of_birth || "");
   const [loading, setLoading] = useState(false);
 
   // Re-sync local form state when a fresh profile arrives.
@@ -53,7 +57,6 @@ export function ProfilePanel({
     setFullName(profile.full_name || "");
     setEmail(profile.email || "");
     setEmergencyName(profile.emergency_contact_name || "");
-    setDateOfBirth(profile.date_of_birth || "");
   }, [profile]);
 
   const handleSave = async () => {
@@ -66,7 +69,6 @@ export function ProfilePanel({
         phone: phone || null,
         emergency_contact_name: emergencyName.trim() || null,
         emergency_contact_phone: emergencyPhone.trim() || null,
-        date_of_birth: dateOfBirth || null,
         updated_at: new Date().toISOString(),
       } as never)
       .eq("id", userId);
@@ -129,28 +131,6 @@ export function ProfilePanel({
         <div className="space-y-2">
           <Label>Emergency Contact Phone</Label>
           <Input type="tel" placeholder="(XXX) XXX-XXXX" value={emergencyPhone} onChange={(e) => setEmergencyPhone(e.target.value)} />
-        </div>
-        <Separator />
-        <div className="space-y-2">
-          <Label>Date of Birth</Label>
-          <Input
-            type="date"
-            value={dateOfBirth}
-            onChange={(e) => {
-              setDateOfBirth(e.target.value);
-              if (e.target.value) {
-                const age = (Date.now() - new Date(e.target.value).getTime()) / (365.25 * 86400000);
-                setIsMinor(age < 18);
-              } else {
-                setIsMinor(false);
-              }
-            }}
-            max={new Date(Date.now() - MIN_AGE_MS).toISOString().slice(0, 10)}
-          />
-          <p className="text-xs text-muted-foreground">Must be at least 13 years old to volunteer.</p>
-          {isMinor && (
-            <Badge className="bg-yellow-500 text-white">Under 18 — Parental consent required</Badge>
-          )}
         </div>
         <Button onClick={handleSave} disabled={loading}>
           {loading ? "Saving..." : "Save Changes"}

--- a/src/components/settings/__tests__/ProfilePanel.test.tsx
+++ b/src/components/settings/__tests__/ProfilePanel.test.tsx
@@ -54,7 +54,6 @@ const baseProfile: SettingsProfile = {
   notif_email: true,
   notif_in_app: true,
   notif_sms: false,
-  date_of_birth: "1990-05-15",
   is_minor: false,
   username: "voltester",
   notif_shift_reminders: true,
@@ -80,14 +79,12 @@ interface RenderOptions {
   isMinor?: boolean;
   setPhone?: (v: string) => void;
   setEmergencyPhone?: (v: string) => void;
-  setIsMinor?: (v: boolean) => void;
   onSaved?: () => Promise<void> | void;
 }
 
 function renderPanel(opts: RenderOptions = {}) {
   const setPhone = opts.setPhone ?? vi.fn();
   const setEmergencyPhone = opts.setEmergencyPhone ?? vi.fn();
-  const setIsMinor = opts.setIsMinor ?? vi.fn();
   const onSaved = opts.onSaved ?? vi.fn();
   render(
     <ProfilePanel
@@ -98,11 +95,10 @@ function renderPanel(opts: RenderOptions = {}) {
       emergencyPhone={opts.emergencyPhone ?? baseProfile.emergency_contact_phone ?? ""}
       setEmergencyPhone={setEmergencyPhone}
       isMinor={opts.isMinor ?? false}
-      setIsMinor={setIsMinor}
       onSaved={onSaved}
     />
   );
-  return { setPhone, setEmergencyPhone, setIsMinor, onSaved };
+  return { setPhone, setEmergencyPhone, onSaved };
 }
 
 function clickSave() {
@@ -176,23 +172,18 @@ describe("ProfilePanel", () => {
     });
   });
 
-  it("calls setIsMinor(true) when DOB changes to a minor age", () => {
-    const setIsMinor = vi.fn();
-    renderPanel({ setIsMinor });
-    // 2015 → ~10 years old → minor.
-    fireEvent.change(screen.getByDisplayValue(baseProfile.date_of_birth!), {
-      target: { value: "2015-06-15" },
-    });
-    expect(setIsMinor).toHaveBeenCalledWith(true);
-  });
+  // DOB-driven setIsMinor tests removed in Half A — the panel no
+  // longer captures DOB or mutates is_minor. is_minor is now answered
+  // once at signup via the over-18 radio in Auth.tsx and is read-only
+  // in this panel. See migration 20260501000000_remove_dob_capture.sql.
 
-  it("calls setIsMinor(false) when DOB changes to an adult age", () => {
-    const setIsMinor = vi.fn();
-    renderPanel({ setIsMinor });
-    // 1990 → adult.
-    fireEvent.change(screen.getByDisplayValue(baseProfile.date_of_birth!), {
-      target: { value: "1980-06-15" },
+  it("does NOT send date_of_birth in the profile update payload", async () => {
+    renderPanel();
+    clickSave();
+    await waitFor(() => {
+      expect(profileUpdateMock).toHaveBeenCalledTimes(1);
     });
-    expect(setIsMinor).toHaveBeenCalledWith(false);
+    const payload = profileUpdateMock.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("date_of_birth");
   });
 });

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -19,7 +19,10 @@ export interface SettingsProfile {
   notif_in_app: boolean;
   notif_sms: boolean;
   // Columns the type generator hasn't surfaced:
-  date_of_birth: string | null;
+  // (date_of_birth removed from boundary type in Half A — capture
+  // surface is gone; column still exists in DB but should not be
+  // read or written by app code. See migration
+  // 20260501000000_remove_dob_capture.sql.)
   is_minor: boolean;
   username: string | null;
   notif_shift_reminders: boolean | null;

--- a/src/hooks/useAdminUsers.ts
+++ b/src/hooks/useAdminUsers.ts
@@ -5,12 +5,17 @@ export type AdminUserRole = "volunteer" | "coordinator" | "admin";
 
 /**
  * Profile shape as needed by the AdminUsers page. Extends the supabase
- * generated `Profile` row with three columns the type generator hasn't
- * picked up yet (`is_minor`, `date_of_birth`, `messaging_blocked`). Same
- * pattern as `SettingsProfile` / `AlertProfile` in earlier refactors.
+ * generated `Profile` row with two columns the type generator hasn't
+ * picked up yet (`is_minor`, `messaging_blocked`). Same pattern as
+ * `SettingsProfile` / `AlertProfile` in earlier refactors.
  *
  * Page bridges with `profile as unknown as AdminProfile` once at the panel
  * boundary; sub-components accept the typed prop.
+ *
+ * Note: date_of_birth was removed from this type in Half A. The DB
+ * column still exists (per the product call to leave the door open
+ * for a future regulatory reversal) but app code should not read or
+ * write it. See migration 20260501000000_remove_dob_capture.sql.
  */
 export interface AdminProfile {
   id: string;
@@ -24,7 +29,6 @@ export interface AdminProfile {
   emergency_contact_phone: string | null;
   // Columns the type generator hasn't surfaced yet:
   is_minor: boolean;
-  date_of_birth: string | null;
   messaging_blocked: boolean;
 }
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -7,6 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useToast } from "@/hooks/use-toast";
 import { Leaf, Mail, Lock, User, Phone } from "lucide-react";
 import { z } from "zod";
@@ -44,7 +45,12 @@ export default function Auth() {
   const [regPassword, setRegPassword] = useState("");
   const [regName, setRegName] = useState("");
   const [regPhone, setRegPhone] = useState("");
-  const [regDob, setRegDob] = useState("");
+  // Required at signup: "Are you 18 or older?". null until answered so
+  // we can block submit on missing answer (radio buttons have no
+  // unselected default in our RadioGroup wrapper). Yes → is_minor=false,
+  // No → is_minor=true. Replaces the previous date_of_birth capture;
+  // see migration 20260501000000_remove_dob_capture.sql.
+  const [regIsAdult, setRegIsAdult] = useState<boolean | null>(null);
   const [tosAccepted, setTosAccepted] = useState(false);
   const [regErrors, setRegErrors] = useState<Record<string, string>>({});
 
@@ -116,6 +122,10 @@ export default function Auth() {
       toast({ title: "Terms required", description: "Please accept the Terms of Service and Code of Conduct.", variant: "destructive" });
       return;
     }
+    if (regIsAdult === null) {
+      toast({ title: "Age confirmation required", description: "Please answer whether you are 18 or older.", variant: "destructive" });
+      return;
+    }
     if (!turnstileToken) {
       toast({ title: "Verification required", description: "Please complete the security check.", variant: "destructive" });
       return;
@@ -143,7 +153,10 @@ export default function Auth() {
         username: result.data.username,
         full_name: result.data.name,
         phone: regPhone || null,
-        date_of_birth: regDob || null,
+        // is_minor is the inverse of the over-18 toggle — see migration
+        // 20260501000000_remove_dob_capture.sql for the data-side
+        // counterpart that drops trg_sync_is_minor.
+        is_minor: regIsAdult === false,
         role: "volunteer",
         is_active: false,
         onboarding_complete: false,
@@ -293,15 +306,22 @@ export default function Auth() {
                     </div>
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="reg-dob">Date of Birth (optional)</Label>
-                    <Input
-                      id="reg-dob"
-                      type="date"
-                      value={regDob}
-                      onChange={(e) => setRegDob(e.target.value)}
-                      max={new Date(Date.now() - 13 * 365.25 * 86400000).toISOString().slice(0, 10)}
-                    />
-                    <p className="text-xs text-muted-foreground">Must be at least 13 years old. Volunteers under 18 will need parental consent.</p>
+                    <Label>Are you 18 or older?</Label>
+                    <RadioGroup
+                      value={regIsAdult === null ? "" : regIsAdult ? "yes" : "no"}
+                      onValueChange={(v) => setRegIsAdult(v === "yes")}
+                      className="flex gap-6 pt-1"
+                    >
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem value="yes" id="reg-adult-yes" />
+                        <Label htmlFor="reg-adult-yes" className="font-normal cursor-pointer">Yes</Label>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem value="no" id="reg-adult-no" />
+                        <Label htmlFor="reg-adult-no" className="font-normal cursor-pointer">No</Label>
+                      </div>
+                    </RadioGroup>
+                    <p className="text-xs text-muted-foreground">Volunteers under 18 will need parental consent before booking shifts.</p>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="reg-password">Password</Label>
@@ -331,7 +351,7 @@ export default function Auth() {
                       options={{ theme: "light", size: "normal" }}
                     />
                   </div>
-                  <Button type="submit" className="w-full" disabled={loading || !tosAccepted || !turnstileToken}>
+                  <Button type="submit" className="w-full" disabled={loading || !tosAccepted || !turnstileToken || regIsAdult === null}>
                     {loading ? "Creating account..." : !turnstileToken ? "Verifying..." : "Create Account"}
                   </Button>
                 </form>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,22 +17,21 @@ import type { SettingsProfile } from "@/components/settings/types";
  *   - phone, emergencyPhone — read by NotificationsPanel to gate the SMS
  *     toggle. Lifting preserves the pre-refactor UX where typing a phone in
  *     the profile form enables SMS *before* save.
- *   - isMinor — drives ParentalConsentPanel visibility. Lifted so the consent
- *     panel appears immediately when DOB is changed to a minor's birthday.
+ *   - isMinor — drives ParentalConsentPanel visibility. Read directly from
+ *     the profile (not lifted to local state) since Half A removed the
+ *     in-page editing path that needed pre-save reactivity.
  */
 export default function Settings() {
   const { user, profile, session, role, signOut, refreshProfile } = useAuth();
 
   const [phone, setPhone] = useState("");
   const [emergencyPhone, setEmergencyPhone] = useState("");
-  const [isMinor, setIsMinor] = useState(false);
 
   // Sync the lifted cross-panel state when a fresh profile arrives.
   useEffect(() => {
     if (!profile) return;
     setPhone(profile.phone || "");
     setEmergencyPhone(profile.emergency_contact_phone || "");
-    setIsMinor((profile as unknown as SettingsProfile).is_minor === true);
   }, [profile]);
 
   const lastSignIn = session?.user?.last_sign_in_at
@@ -42,9 +41,10 @@ export default function Settings() {
   if (!user || !profile) return null;
 
   // The supabase generated Profile type doesn't model is_minor / username /
-  // notif_* / date_of_birth — bridge with SettingsProfile here. Same boundary-
-  // cast pattern as AlertProfile in src/components/volunteer/DashboardAlerts.tsx.
+  // notif_* — bridge with SettingsProfile here. Same boundary-cast pattern
+  // as AlertProfile in src/components/volunteer/DashboardAlerts.tsx.
   const settingsProfile = profile as unknown as SettingsProfile;
+  const isMinor = settingsProfile.is_minor === true;
 
   return (
     <div className="max-w-2xl mx-auto space-y-6">
@@ -58,7 +58,6 @@ export default function Settings() {
         emergencyPhone={emergencyPhone}
         setEmergencyPhone={setEmergencyPhone}
         isMinor={isMinor}
-        setIsMinor={setIsMinor}
         onSaved={refreshProfile}
       />
 

--- a/src/pages/__tests__/Auth.test.tsx
+++ b/src/pages/__tests__/Auth.test.tsx
@@ -128,7 +128,7 @@ function submitFormContaining(input: HTMLElement) {
   fireEvent.submit(form);
 }
 
-function fillRegister(opts: Partial<{ name: string; email: string; username: string; password: string; tos: boolean }>) {
+function fillRegister(opts: Partial<{ name: string; email: string; username: string; password: string; tos: boolean; isAdult: boolean }>) {
   if (opts.name !== undefined) {
     fireEvent.change(getInput("reg-name"), { target: { value: opts.name } });
   }
@@ -143,6 +143,13 @@ function fillRegister(opts: Partial<{ name: string; email: string; username: str
   }
   if (opts.tos) {
     fireEvent.click(screen.getByRole("checkbox", { name: /terms of service/i }));
+  }
+  // Over-18 radio (Half A): required to enable submit. Default to true
+  // for the happy-path tests; tests that exercise the missing-answer
+  // path opt out by passing isAdult: undefined.
+  if (opts.isAdult !== undefined) {
+    const id = opts.isAdult ? "reg-adult-yes" : "reg-adult-no";
+    fireEvent.click(document.getElementById(id)!);
   }
 }
 
@@ -319,7 +326,7 @@ describe("Auth — Register tab", () => {
 
     render(<Auth />);
     await switchToRegister();
-    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234", tos: true });
+    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234", tos: true, isAdult: true });
     clickTurnstile();
     fireEvent.click(screen.getByRole("button", { name: /create account/i }));
 
@@ -335,6 +342,7 @@ describe("Auth — Register tab", () => {
         username: "jane_doe",
         full_name: "Jane Doe",
         role: "volunteer",
+        is_minor: false,
       }));
       expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
         title: "Account created",
@@ -351,7 +359,7 @@ describe("Auth — Register tab", () => {
     rpcMock.mockResolvedValue({ data: false, error: null });
     render(<Auth />);
     await switchToRegister();
-    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234", tos: true });
+    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234", tos: true, isAdult: true });
     clickTurnstile();
     fireEvent.click(screen.getByRole("button", { name: /create account/i }));
 
@@ -365,7 +373,7 @@ describe("Auth — Register tab", () => {
     rpcMock.mockResolvedValue({ data: true, error: null });
     render(<Auth />);
     await switchToRegister();
-    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234" });
+    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234", isAdult: true });
     // Skip TOS click intentionally.
     clickTurnstile();
     submitFormContaining(getInput("reg-name"));
@@ -376,5 +384,54 @@ describe("Auth — Register tab", () => {
       }));
     });
     expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit (button disabled) when the over-18 question is unanswered", async () => {
+    render(<Auth />);
+    await switchToRegister();
+    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234", tos: true });
+    // Intentionally skip the isAdult radio.
+    clickTurnstile();
+    const submitBtn = screen.getByRole("button", { name: /create account/i }) as HTMLButtonElement;
+    expect(submitBtn).toBeDisabled();
+    fireEvent.click(submitBtn);
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("persists is_minor=true on profile insert when user answers 'No' to over-18", async () => {
+    rpcMock.mockResolvedValue({ data: true, error: null });
+    signUpMock.mockResolvedValue({ data: { user: { id: "new-minor-id" } }, error: null });
+    insertMock.mockResolvedValue({ error: null });
+
+    render(<Auth />);
+    await switchToRegister();
+    fillRegister({ name: "Tim Minor", email: "tim@example.com", username: "tim_m", password: "abcd1234", tos: true, isAdult: false });
+    clickTurnstile();
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({
+        id: "new-minor-id",
+        is_minor: true,
+      }));
+    });
+  });
+
+  it("does NOT send date_of_birth in the profile insert payload (Half A — DOB removed)", async () => {
+    rpcMock.mockResolvedValue({ data: true, error: null });
+    signUpMock.mockResolvedValue({ data: { user: { id: "new-user-id" } }, error: null });
+    insertMock.mockResolvedValue({ error: null });
+
+    render(<Auth />);
+    await switchToRegister();
+    fillRegister({ name: "Jane Doe", email: "jane@example.com", username: "jane_doe", password: "abcd1234", tos: true, isAdult: true });
+    clickTurnstile();
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalled();
+    });
+    const payload = insertMock.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("date_of_birth");
   });
 });

--- a/supabase/migrations/20260501000000_remove_dob_capture.sql
+++ b/supabase/migrations/20260501000000_remove_dob_capture.sql
@@ -1,0 +1,92 @@
+-- =============================================
+-- Half A — Remove date-of-birth capture; flip is_minor source
+-- to user-answered (the new "Are you 18 or older?" toggle in
+-- onboarding).
+--
+-- Background
+-- ----------
+-- date_of_birth was captured on signup and in profile settings,
+-- and a BEFORE INSERT/UPDATE trigger (trg_sync_is_minor, defined
+-- in 20260410_minor_consent.sql) derived profiles.is_minor from
+-- it via age(date_of_birth) < interval '18 years'.
+--
+-- Product decision: stop capturing DOB. It's PHI we don't need.
+-- The only thing the system used DOB for was minor classification,
+-- and a single yes/no question at signup is sufficient for that.
+--
+-- This migration is the data side of that change. The matching
+-- frontend changes (Auth signup radio replacing the DOB input,
+-- ProfilePanel DOB section removed, UserCard "Minor (DOB: …)"
+-- line removed) ship together with this migration in the same
+-- PR so we never have a runtime where the UI captures a column
+-- the DB no longer derives from.
+--
+-- What this changes
+-- -----------------
+-- 1. NULL out every existing date_of_birth value. The column is
+--    kept (not dropped) per the product call to leave the door
+--    open for a future regulatory reversal — but the data is
+--    cleared so we don't sit on stale PHI. The column was
+--    already nullable (added via `ADD COLUMN ... date` in
+--    20260410_minor_consent.sql with no NOT NULL), so no
+--    DROP NOT NULL is required.
+--
+-- 2. Drop trg_sync_is_minor and the sync_is_minor() function.
+--    From this point on, profiles.is_minor is set directly by
+--    the frontend at signup based on the over-18 radio answer
+--    (Yes → is_minor=false, No → is_minor=true). The column
+--    keeps its NOT NULL DEFAULT false, so legacy users who never
+--    answered the new question stay at false — which matches the
+--    reality that 99% of existing volunteers are adults; the
+--    handful of minors who already booked have parental_consents
+--    rows already, and admins can flip is_minor manually if
+--    needed before they re-book.
+--
+-- 3. The parental-consents flow (parental_consents table,
+--    ParentalConsentPanel UI, enforce_booking_window minor
+--    consent gate) is INTENTIONALLY left intact in this PR.
+--    Half B will rewrite it as part of the minor approval queue
+--    feature. Right now: minors with active consent still book;
+--    minors without consent still get rejected by the existing
+--    trigger. That continuity is what makes Half A safe to ship
+--    on its own.
+--
+-- One-off post-deploy seed
+-- ------------------------
+-- For sabih.usman@live.com (the first admin), `is_minor=false`
+-- needs to be set after this migration runs. That update is NOT
+-- in this file — versioned migrations should not contain
+-- environment-specific user data. Run it manually post-deploy:
+--
+--   UPDATE public.profiles
+--   SET is_minor = false, updated_at = now()
+--   WHERE email = 'sabih.usman@live.com';
+--
+-- It's a no-op against the existing column default, but it
+-- documents intent and makes the change auditable.
+-- =============================================
+
+-- ── 1. NULL out existing date_of_birth values ──
+UPDATE public.profiles
+SET date_of_birth = NULL
+WHERE date_of_birth IS NOT NULL;
+
+-- ── 2. Drop the DOB-derived is_minor sync trigger and function ──
+-- Trigger first (depends on the function), then the function.
+DROP TRIGGER IF EXISTS trg_sync_is_minor ON public.profiles;
+DROP FUNCTION IF EXISTS public.sync_is_minor();
+
+-- ── 3. Sanity-check post-state ──
+-- After this migration:
+--   - profiles.date_of_birth column still exists, all values NULL
+--   - profiles.is_minor still exists, NOT NULL DEFAULT false,
+--     no longer auto-derived
+--   - parental_consents table and its policies are untouched
+--   - enforce_booking_window still gates minor bookings on consent
+--
+-- Half B (separate PR) will:
+--   - Add the pending_admin_approval booking_status enum value
+--   - Replace the consent gate in enforce_booking_window with a
+--     pending-approval routing trigger
+--   - Add the /admin/pending-minor-approvals page
+--   - Remove the parental_consents UI and (eventually) the table


### PR DESCRIPTION
**Half A of a two-PR product change.** Half B (minor approval queue, parental-consent removal, `pending_admin_approval` booking_status, capacity tie-break) will follow on a separate branch.

## What this changes

Stops capturing `date_of_birth`. Replaces it with a single required radio at signup — "Are you 18 or older?". `is_minor` — the only thing the system used DOB for — is now written directly from that toggle answer (Yes → `false`, No → `true`) at signup, not derived from a stored DOB.

## Why these decisions

**`is_minor` source flip vs. adding a new `is_adult` column:** the brief proposed `is_adult` as a new boolean. I confirmed with the user (option (c)) that we keep the existing `is_minor` column — flipping its source from "trigger derives from DOB" to "user answers a question at signup" is a smaller change than adding a parallel inverse column and migrating 8 frontend usages.

**Parental-consent flow untouched:** the brief listed parental-consent removal as out of scope for the prior PR design, but didn't say what to do with it during Half A. User confirmed: leave it intact in Half A. Minors with active consent still book; minors without are still rejected by `enforce_booking_window`. Half B will rewrite that.

**Per-user seed for `sabih.usman@live.com`** is handled as a manual post-deploy `UPDATE`, not in the migration file — environment-specific user data shouldn't live in versioned migrations.

## Migration SQL

`supabase/migrations/20260501000000_remove_dob_capture.sql`:

```sql
-- 1. NULL out existing date_of_birth values (column kept, not dropped)
UPDATE public.profiles SET date_of_birth = NULL WHERE date_of_birth IS NOT NULL;

-- 2. Drop the DOB-derived is_minor sync trigger and function
DROP TRIGGER IF EXISTS trg_sync_is_minor ON public.profiles;
DROP FUNCTION IF EXISTS public.sync_is_minor();
```

`profiles.is_minor` keeps `NOT NULL DEFAULT false`. Column was already nullable, so no `DROP NOT NULL` needed.

**Manual post-deploy** (not in migration):
```sql
UPDATE public.profiles SET is_minor = false, updated_at = now()
WHERE email = 'sabih.usman@live.com';
```

## DOB audit results

| Site | Type | Action |
|---|---|---|
| `src/pages/Auth.tsx` (signup form) | Capture | Replaced with required Yes/No radio |
| `src/components/settings/ProfilePanel.tsx` | Capture | DOB input + state + age-calc removed; panel no longer mutates is_minor |
| `src/components/admin/UserCard.tsx` | Display | "Minor (DOB: …)" → "Minor" (kept Manage Consent link) |
| `src/components/settings/types.ts` | Type | `date_of_birth` removed from `SettingsProfile` |
| `src/hooks/useAdminUsers.ts` | Type | `date_of_birth` removed from `AdminProfile` |
| `src/pages/Settings.tsx` | Wiring | Dropped lifted `setIsMinor` state (read-only now) |
| `src/components/settings/__tests__/ProfilePanel.test.tsx` | Tests | Two DOB→isMinor tests removed; replaced with one assertion that no `date_of_birth` is sent in the update payload |
| Reports / exports / CSV / PDF / DOCX | — | **Zero hits** in audit |
| Birthday emails / age-based filters | — | **Zero hits** in audit |
| Coordinator dashboards | — | **Zero hits** in audit |

DOB was used ONLY for minor classification. No non-PHI uses to flag.

## Test list

All 266 unit tests pass. New / updated:

- ✅ `Auth.test.tsx` — happy-path register asserts `is_minor: false` in insert payload
- ✅ `Auth.test.tsx` — username-taken still works after the gate change
- ✅ `Auth.test.tsx` — TOS-not-accepted toast still works after the gate change
- ✅ `Auth.test.tsx` (new) — submit blocked (button disabled) when over-18 unanswered
- ✅ `Auth.test.tsx` (new) — `is_minor: true` persisted when user answers "No"
- ✅ `Auth.test.tsx` (new) — insert payload does NOT contain `date_of_birth`
- ✅ `ProfilePanel.test.tsx` (new) — update payload does NOT contain `date_of_birth`
- ❌ `ProfilePanel.test.tsx` — removed: two tests that drove `setIsMinor` from a DOB input that no longer exists

Lint + typecheck green.

## Test plan

- [ ] CI green (vitest + lint + typecheck — RLS suite unaffected, no shift_bookings changes here)
- [ ] Smoke on preview: new signup with "Yes" → can book normally
- [ ] Smoke on preview: new signup with "No" → `is_minor=true` in profiles row, parental-consent panel appears in Settings, booking blocked until consent submitted (existing `enforce_booking_window` behavior)
- [ ] Smoke on preview: existing user's Profile page no longer shows DOB input
- [ ] Smoke on preview: Admin Users page minor row shows "Minor — Manage Consent" without DOB
- [ ] After merge, run manual post-deploy SQL: `UPDATE profiles SET is_minor=false WHERE email='sabih.usman@live.com'`
- [ ] After merge, verify migration ran on prod Supabase: `SELECT count(*) FROM profiles WHERE date_of_birth IS NOT NULL` returns 0; `SELECT tgname FROM pg_trigger WHERE tgrelid = 'profiles'::regclass` does NOT include `trg_sync_is_minor`

## Half B preview

Half B will:
- Add `pending_admin_approval` value to the `booking_status` enum
- Add a BEFORE INSERT trigger on `shift_bookings` that overrides `booking_status` to `pending_admin_approval` when the volunteer is_minor (defensive — not relying on RLS)
- Replace the parental-consent gate in `enforce_booking_window` with the pending-approval routing
- Add `/admin/pending-minor-approvals` page with nav badge count
- Volunteer-side "Pending approval" booking badge + notifications
- Capacity tie-break at approval (over-capacity-by-1 default per user decision)
- Remove `ParentalConsentPanel` UI; defer `parental_consents` table drop to a follow-up PR
- E2E coverage for the full minor-book → admin-approve flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)