### PR TITLE
fix: lock admin-only profile columns against volunteer self-update

### DIFF
--- a/supabase/migrations/20260502000000_lock_admin_only_profile_columns.sql
+++ b/supabase/migrations/20260502000000_lock_admin_only_profile_columns.sql
@@ -1,0 +1,173 @@
+-- =============================================
+-- Lock admin-only profile columns against volunteer self-update.
+--
+-- Background
+-- ----------
+-- The `profiles: own update` RLS policy (defined in baseline.sql)
+-- has no WITH CHECK clause:
+--
+--   CREATE POLICY "profiles: own update" ON public.profiles
+--     FOR UPDATE USING (auth.uid() = id);
+--
+-- That means any authenticated user can PATCH their own profile row
+-- with arbitrary column values. During the Half B-1 prod migration
+-- investigation (2026-05-02) I demonstrated this concretely: a
+-- newly-signed-up volunteer (Test Minor B1) was able to flip
+-- `bg_check_status` from `pending` to `cleared` directly via Supabase
+-- REST. This bypasses the booking-window BG-check gate in
+-- enforce_booking_window — a real privilege escalation.
+--
+-- Why a trigger and not a tighter RLS WITH CHECK
+-- -----------------------------------------------
+-- RLS WITH CHECK only sees the new row, not the old. There's no
+-- cross-row way to express "NEW.col = OLD.col" in a policy. The
+-- codebase already uses the trigger pattern for exactly this kind of
+-- column-lock — see `prevent_role_self_escalation` (baseline.sql:1566)
+-- which protects `profiles.role` against self-promotion. This migration
+-- extends the same pattern to cover every other admin-controlled
+-- column.
+--
+-- What's locked (non-admin users cannot change)
+-- ---------------------------------------------
+--   - bg_check_status            ← driver of this PR
+--   - bg_check_expires_at
+--   - bg_check_updated_at
+--   - is_active                  ← admin activation gate
+--   - booking_privileges         ← admin-controlled grant
+--   - is_minor                   ← signup-only; protects approval queue
+--   - messaging_blocked          ← admin moderation flag
+--   - consistency_score          ← derived from completed shifts
+--   - extended_booking           ← derived from consistency_score
+--   - total_hours                ← aggregate of confirmed bookings
+--   - volunteer_points           ← derived from hours + ratings
+--   - location_id                ← admin-assigned dept / location
+--   - tos_accepted_at            ← historical record
+--   - created_at                 ← never editable
+--
+-- What's NOT locked (volunteer can still self-edit)
+-- -------------------------------------------------
+--   - full_name, phone, avatar_url, username (separate flow), email
+--   - emergency_contact_name, emergency_contact_phone
+--   - notif_* preference columns
+--   - onboarding_complete (volunteer flips this themselves)
+--   - updated_at (timestamp the user's own client sets)
+--
+-- The existing `role` lock from `prevent_role_self_escalation` stays
+-- as-is; this migration adds protection for every other admin column.
+-- Both triggers fire on the same UPDATE — no conflict.
+--
+-- Admins bypass the lock via `public.is_admin()`; service-role calls
+-- bypass RLS and triggers entirely (the booking-trigger function uses
+-- SECURITY DEFINER for similar reasons).
+-- =============================================
+
+CREATE OR REPLACE FUNCTION public.prevent_user_from_changing_admin_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  -- Admins can change anything. Service-role bypasses RLS+triggers.
+  IF public.is_admin() THEN
+    RETURN NEW;
+  END IF;
+
+  -- Same escape hatch the role-escalation guard uses, in case a
+  -- future admin-transfer flow needs to bypass this too.
+  IF current_setting('app.skip_self_escalation_check', true) = 'true' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Only check rows the actor owns. A coordinator updating someone
+  -- else's profile is gated by other policies; this trigger is about
+  -- self-update overreach.
+  IF NEW.id IS DISTINCT FROM auth.uid() THEN
+    RETURN NEW;
+  END IF;
+
+  -- BG-check fields — the security finding driving this PR.
+  IF NEW.bg_check_status IS DISTINCT FROM OLD.bg_check_status THEN
+    RAISE EXCEPTION 'You cannot change your own background-check status. Contact an administrator.'
+      USING ERRCODE = '42501';
+  END IF;
+  IF NEW.bg_check_expires_at IS DISTINCT FROM OLD.bg_check_expires_at THEN
+    RAISE EXCEPTION 'You cannot change your own background-check expiration. Contact an administrator.'
+      USING ERRCODE = '42501';
+  END IF;
+  IF NEW.bg_check_updated_at IS DISTINCT FROM OLD.bg_check_updated_at THEN
+    RAISE EXCEPTION 'You cannot change your own background-check timestamp.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Admin gates (account state).
+  IF NEW.is_active IS DISTINCT FROM OLD.is_active THEN
+    RAISE EXCEPTION 'You cannot change your own active status.'
+      USING ERRCODE = '42501';
+  END IF;
+  IF NEW.booking_privileges IS DISTINCT FROM OLD.booking_privileges THEN
+    RAISE EXCEPTION 'You cannot change your own booking privileges.'
+      USING ERRCODE = '42501';
+  END IF;
+  IF NEW.messaging_blocked IS DISTINCT FROM OLD.messaging_blocked THEN
+    RAISE EXCEPTION 'You cannot change your own messaging-blocked status.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Minor flag — answered once at signup (Half A); editing it later
+  -- would let a minor bypass the admin approval queue (Half B-1).
+  IF NEW.is_minor IS DISTINCT FROM OLD.is_minor THEN
+    RAISE EXCEPTION 'You cannot change your own minor status. Contact an administrator if this needs correction.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Derived / aggregate fields — these are computed by triggers
+  -- (recalculate_consistency, recalculate_points, etc.) and the
+  -- volunteer should never write to them directly.
+  IF NEW.consistency_score IS DISTINCT FROM OLD.consistency_score THEN
+    RAISE EXCEPTION 'consistency_score is derived from completed shifts and cannot be set directly.'
+      USING ERRCODE = '42501';
+  END IF;
+  IF NEW.extended_booking IS DISTINCT FROM OLD.extended_booking THEN
+    RAISE EXCEPTION 'extended_booking is derived from consistency_score and cannot be set directly.'
+      USING ERRCODE = '42501';
+  END IF;
+  IF NEW.total_hours IS DISTINCT FROM OLD.total_hours THEN
+    RAISE EXCEPTION 'total_hours is an aggregate and cannot be set directly.'
+      USING ERRCODE = '42501';
+  END IF;
+  IF NEW.volunteer_points IS DISTINCT FROM OLD.volunteer_points THEN
+    RAISE EXCEPTION 'volunteer_points is derived and cannot be set directly.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Admin-assigned slot.
+  IF NEW.location_id IS DISTINCT FROM OLD.location_id THEN
+    RAISE EXCEPTION 'You cannot change your own location assignment.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Historical immutables.
+  IF NEW.tos_accepted_at IS DISTINCT FROM OLD.tos_accepted_at THEN
+    RAISE EXCEPTION 'tos_accepted_at is a historical record and cannot be modified.'
+      USING ERRCODE = '42501';
+  END IF;
+  IF NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+    RAISE EXCEPTION 'created_at cannot be modified.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+ALTER FUNCTION public.prevent_user_from_changing_admin_columns() OWNER TO postgres;
+
+-- Granting EXECUTE to authenticated/anon/service_role mirrors how
+-- prevent_role_self_escalation was granted in baseline.sql.
+GRANT EXECUTE ON FUNCTION public.prevent_user_from_changing_admin_columns()
+  TO anon, authenticated, service_role;
+
+DROP TRIGGER IF EXISTS trg_prevent_user_from_changing_admin_columns ON public.profiles;
+CREATE TRIGGER trg_prevent_user_from_changing_admin_columns
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.prevent_user_from_changing_admin_columns();

--- a/supabase/test/profile-self-update-locks.test.ts
+++ b/supabase/test/profile-self-update-locks.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { signInAs, adminBypassClient, getHarnessUsers } from "./clients";
+
+/**
+ * Pins the column-lock contract from
+ * 20260502000000_lock_admin_only_profile_columns.sql.
+ *
+ * Background: discovered during the Half B-1 prod-migration
+ * investigation — `profiles: own update` had no WITH CHECK clause,
+ * so a volunteer could PATCH their own bg_check_status from
+ * 'pending' to 'cleared' and bypass the booking-window BG-check
+ * gate. The fix is a BEFORE UPDATE trigger
+ * (prevent_user_from_changing_admin_columns) that raises 42501 when
+ * a non-admin tries to mutate any of the locked columns on their
+ * own row.
+ *
+ * These tests exercise both the negative cases (volunteer cannot
+ * write the locked columns) and the positive case (volunteer CAN
+ * still update normal self-edit columns like full_name and
+ * emergency contact).
+ *
+ * Per the lesson from PR #173: NO it.skip in this file.
+ */
+
+beforeAll(async () => {
+  const admin = adminBypassClient();
+  const users = getHarnessUsers();
+  // Reset the volunteer's bg_check_status so the test starts from a
+  // known state.
+  await admin.from("profiles").update({
+    bg_check_status: "pending",
+    is_active: true,
+    booking_privileges: true,
+    is_minor: false,
+    messaging_blocked: false,
+  } as never).eq("id", users.volunteer.id);
+});
+
+afterAll(async () => {
+  const admin = adminBypassClient();
+  const users = getHarnessUsers();
+  await admin.from("profiles").update({
+    bg_check_status: "pending",
+    is_active: true,
+  } as never).eq("id", users.volunteer.id);
+});
+
+const expectRlsRejection = (error: unknown) => {
+  const e = error as { code?: string; message?: string } | null;
+  expect(e).not.toBeNull();
+  expect(
+    e?.code === "42501" || /cannot change|cannot be (set|modified)/i.test(e?.message ?? ""),
+  ).toBe(true);
+};
+
+describe("profiles: column locks on volunteer self-update", () => {
+  it("volunteer CANNOT change their own bg_check_status (the security finding)", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+    const { error } = await client
+      .from("profiles")
+      .update({ bg_check_status: "cleared" } as never)
+      .eq("id", users.volunteer.id);
+    expectRlsRejection(error);
+  });
+
+  it("volunteer CANNOT change their own is_active", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+    const { error } = await client
+      .from("profiles")
+      .update({ is_active: false } as never)
+      .eq("id", users.volunteer.id);
+    expectRlsRejection(error);
+  });
+
+  it("volunteer CANNOT change their own booking_privileges", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+    const { error } = await client
+      .from("profiles")
+      .update({ booking_privileges: false } as never)
+      .eq("id", users.volunteer.id);
+    expectRlsRejection(error);
+  });
+
+  it("volunteer CANNOT change their own is_minor (would bypass admin approval queue)", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+    const { error } = await client
+      .from("profiles")
+      .update({ is_minor: true } as never)
+      .eq("id", users.volunteer.id);
+    expectRlsRejection(error);
+  });
+
+  it("volunteer CANNOT change their own messaging_blocked", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+    const { error } = await client
+      .from("profiles")
+      .update({ messaging_blocked: true } as never)
+      .eq("id", users.volunteer.id);
+    expectRlsRejection(error);
+  });
+
+  it("volunteer CANNOT change derived consistency_score / extended_booking / total_hours / volunteer_points", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+    const probes = [
+      { consistency_score: 100 },
+      { extended_booking: true },
+      { total_hours: 999 },
+      { volunteer_points: 9999 },
+    ] as const;
+    for (const patch of probes) {
+      const { error } = await client
+        .from("profiles")
+        .update(patch as never)
+        .eq("id", users.volunteer.id);
+      expectRlsRejection(error);
+    }
+  });
+
+  it("volunteer CAN still update normal self-edit columns (full_name, phone, emergency contact)", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+    const newName = `Test Volunteer (${Date.now()})`;
+    const { error, data } = await client
+      .from("profiles")
+      .update({
+        full_name: newName,
+        phone: "555-0100",
+        emergency_contact_name: "Test Contact",
+        emergency_contact_phone: "555-0200",
+      } as never)
+      .eq("id", users.volunteer.id)
+      .select("id, full_name");
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect((data as Array<{ full_name: string }>)[0].full_name).toBe(newName);
+  });
+
+  it("admin CAN change a volunteer's bg_check_status (admin bypass)", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("admin");
+    const { error, data } = await client
+      .from("profiles")
+      .update({ bg_check_status: "cleared" } as never)
+      .eq("id", users.volunteer.id)
+      .select("id, bg_check_status");
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect((data as Array<{ bg_check_status: string }>)[0].bg_check_status).toBe("cleared");
+  });
+});


### PR DESCRIPTION
**Security finding** discovered during the Half B-1 prod-migration investigation on 2026-05-02. Fix is one new migration + a pinning RLS test.

## What was wrong

The `profiles: own update` RLS policy in baseline.sql:
```sql
CREATE POLICY "profiles: own update" ON public.profiles
  FOR UPDATE USING (auth.uid() = id);
```

No `WITH CHECK` clause. Any authenticated user could PATCH any column on their own row.

I demonstrated this live as Test Minor B1 (a freshly-signed-up volunteer with `bg_check_status='pending'`):

```http
PATCH /rest/v1/profiles?id=eq.<my-id>
Authorization: Bearer <my-jwt>

{"bg_check_status": "cleared"}

→ HTTP 200, persisted
```

That bypasses `enforce_booking_window`'s BG-check gate — any volunteer could self-clear and book BG-required shifts. Same shape applies to `is_minor` (bypasses the new admin approval queue from Half B-1), `is_active`, `booking_privileges`, `messaging_blocked`, the derived stats columns, etc.

## Why a trigger and not tighter RLS

RLS `WITH CHECK` only sees the new row, not the old. There's no in-policy way to say `NEW.col = OLD.col`. The codebase already uses a trigger for exactly this kind of column-lock (`prevent_role_self_escalation` in baseline.sql:1566 protects `profiles.role`). This PR extends the same pattern to every other admin-controlled column.

## What's locked (non-admin can't change on own row)

| Column | Why |
|---|---|
| `bg_check_status` | Driver of this PR — bypasses booking-window BG gate |
| `bg_check_expires_at`, `bg_check_updated_at` | Same gate, related fields |
| `is_active` | Admin activation gate |
| `booking_privileges` | Admin-controlled grant |
| `messaging_blocked` | Admin moderation flag |
| `is_minor` | Half B-1: bypasses admin approval queue if a minor flips to false |
| `consistency_score`, `extended_booking`, `total_hours`, `volunteer_points` | Derived; user shouldn't write directly |
| `location_id` | Admin-assigned |
| `tos_accepted_at`, `created_at` | Historical immutables |

## What's NOT locked (volunteer can still self-edit)

`full_name`, `phone`, `avatar_url`, `username` (separate flow), `email` (separate auth flow), `emergency_contact_name`, `emergency_contact_phone`, `notif_*` preferences, `onboarding_complete`, `updated_at`.

## Bypass paths preserved

- **Admin** — `public.is_admin()` short-circuits the trigger early.
- **Service role** — bypasses RLS and triggers entirely.
- **Admin-transfer flow** — same `app.skip_self_escalation_check` GUC the existing role-lock trigger respects.

## Test plan

8 RLS integration tests in `profile-self-update-locks.test.ts`:
- ✅ Volunteer cannot change own `bg_check_status` (the security finding)
- ✅ Volunteer cannot change own `is_active`
- ✅ Volunteer cannot change own `booking_privileges`
- ✅ Volunteer cannot change own `is_minor` (would bypass admin approval queue)
- ✅ Volunteer cannot change own `messaging_blocked`
- ✅ Volunteer cannot change derived stats columns
- ✅ **Positive**: volunteer CAN still update normal self-edit columns (full_name, phone, emergency contact)
- ✅ **Positive**: admin CAN change volunteer's `bg_check_status` (bypass path works)

Per the lesson from PR #173: positive cases are NOT skipped.

## Cross-references

- Discovered during the Half B-1 prod-migration incident (PR #183 deployed but its migrations sat unapplied; investigation found this as a side effect).
- Existing column-lock pattern: `prevent_role_self_escalation` in baseline.sql:1566.
- Companion PR adds `supabase db push` to the deploy workflow so future migrations don't drift the way Half B-1's did.

## Smoke checklist

- [ ] CI green (RLS suite picks up the 8 new tests)
- [ ] Volunteer's own profile-edit form (Settings → name, phone, emergency contact) still works
- [ ] Admin can still update any volunteer's bg_check / is_active / etc. via AdminUsers page
- [ ] After merge: migration applies (will need either the CI-automation PR or a manual `supabase db push` until automation lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
