### PR TITLE
chore(ci): apply Supabase migrations on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,35 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      - name: Apply Supabase migrations to prod
+        # Closes the workflow gap that produced the Half B-1 incident
+        # (2026-05-02): Vercel auto-deployed the new frontend on merge,
+        # but the matching DB migrations sat unapplied for ~6 days
+        # because applying them was a manual step. Backlog at the
+        # time of the incident: 8 migrations, going back to 2026-04-26,
+        # including a security-relevant cancel-shift RLS fix from PR
+        # #181.
+        #
+        # Position matters: this runs BEFORE `vercel build`, which
+        # invokes the `prebuild` → `gen:types` script that regenerates
+        # supabase types from the linked project. If migrations
+        # applied AFTER build, the build would compile against stale
+        # types — same drift, different shape.
+        #
+        # The CLI runs non-interactively when stdin is not a TTY, so
+        # `supabase db push --linked` proceeds without the Y/N prompt.
+        # The `--include-all` flag is defensive — it tells the CLI to
+        # apply every pending migration even if the runner is on a
+        # CLI version that defaults to a confirmation per file.
+        #
+        # Required repo secret: SUPABASE_DB_PASSWORD (the project's
+        # database password). The CLI uses SUPABASE_ACCESS_TOKEN for
+        # auth and SUPABASE_DB_PASSWORD for the DB connection itself.
+        run: supabase db push --linked --include-all
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
       - name: Install dependencies
         run: bun install
 


### PR DESCRIPTION
**The workflow gap that produced the Half B-1 incident on 2026-05-02.**

## What happened

PR #183 (Half B-1) was merged 2026-05-01 and "deployed". Vercel auto-deployed the frontend, so the new admin Pending Minor Approvals page, sidebar nav, and minor-side booking UX all went live. But the matching DB migrations sat in the repo unapplied. Nobody ran `supabase db push` after merge.

By the time we caught it (the user noticed `uq_booking_per_slot` still had the old predicate during a prod sanity check), the discrepancy had been live for ~24 hours. And it wasn't just B-1 — when we pushed the migrations manually, the CLI listed **8 unapplied migrations** going back to 2026-04-26, including:

- `20260430000000_shifts_coord_read_cancelled.sql` — PR #181's coordinator-cancel-shift RLS fix, sitting unapplied for 2+ days
- `20260501000000_remove_dob_capture.sql` — Half A's migration, which explained why a minor signup with "No" to over-18 was silently persisting `is_minor=false` (the `trg_sync_is_minor` trigger that Half A was supposed to drop was still alive and overriding the value)

Half A only worked the first time because someone manually ran `supabase db push` after #182 merged. That same step was forgotten for #183, and forgotten in 2-day intervals before that.

## What this PR does

Adds one step to `.github/workflows/deploy.yml`:

```yaml
- name: Apply Supabase migrations to prod
  run: supabase db push --linked --include-all
  env:
    SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
    SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
```

## Position matters

The step is inserted between **"Link Supabase project"** and **"Install dependencies"** — i.e., **before `vercel build`**. The `prebuild` script invokes `supabase gen types typescript --linked` against the live project, so types regenerate from whatever schema is currently deployed. If migrations applied after build, the build would compile against stale types — same drift, different shape.

Sequence after this PR:
1. Checkout
2. Setup Bun + Supabase CLI + Link
3. **NEW: `supabase db push`** ← migrations apply here
4. Install deps
5. Run vitest
6. `vercel build` (prebuild → gen:types from the now-current schema)
7. `vercel deploy`

## Required new repo secret

**`SUPABASE_DB_PASSWORD`** — the project's database password. The CLI uses `SUPABASE_ACCESS_TOKEN` for API auth and this for the DB connection. **Add via Settings → Secrets and variables → Actions before merging this PR.** Without it, the new step will fail at runtime and block the deploy.

## CLI flags

- `--linked` — explicit (already linked above, but documents intent).
- `--include-all` — defensive against any CLI version that prompts per-file. Current CLI runs non-interactively when stdin isn't a TTY, but pinning the behavior costs nothing.

## What this does NOT cover

- **Migration rollback**: if a migration fails on prod, the deploy step fails and stops — but the broken migration may have partially committed. Not worse than today; today the same migration would fail when manually pushed. A future improvement is a staging-DB dry-run, but that's its own refactor.
- **Backfill protection**: if a migration relies on data state prod doesn't have, this won't catch it pre-deploy. Deploy preview environments would.

## Test plan

- [ ] Add `SUPABASE_DB_PASSWORD` to repo secrets (one-time setup)
- [ ] Merge this PR; observe the next `Deploy` workflow run executes the new step successfully
- [ ] Run `SELECT version FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 5;` and confirm all in-tree migrations are recorded
- [ ] Companion PR #184 (the security column-locks PR) is a good real test case — merging it after this PR should auto-apply `20260502000000_lock_admin_only_profile_columns.sql`

## Cross-reference

- Companion security PR from the same investigation: #184 (`fix: lock admin-only profile columns against volunteer self-update`)
- Half B-1 PR that surfaced the gap: #183
- Half A: #182
- Coordinator cancel-shift RLS fix that was also caught up in the drift: #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
