### PR TITLE
feat(security): Phase 2 SECURITY DEFINER lockdown (closes #194)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,90 @@ npx eslint .
 - Follow existing patterns in the codebase.
 - Use Tailwind semantic tokens — never hardcode colors in components.
 - Keep components small and focused.
+
+## Writing Supabase Migrations
+
+### `CREATE TABLE` — always include explicit grants
+
+Supabase changed default Data API grants on new public-schema tables effective **2026-10-30**. Tables created after that date on existing projects are NOT reachable via `supabase-js` / PostgREST unless the migration grants explicit table-level privileges. (Tables created before the cutoff are grandfathered; this rule is forward-looking.)
+
+Every `CREATE TABLE public.<name>` migration **must** include the following block, customized for the table:
+
+```sql
+CREATE TABLE public.<name> ( ... );
+
+-- Data API grants (required for Supabase Data API / supabase-js access).
+-- See https://supabase.com/blog/changes-to-data-api-grants-october-2026
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.<name> TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.<name> TO service_role;
+-- Uncomment ONLY if anonymous read access is intentionally required
+-- (e.g., kiosk flows, public sign-up surfaces):
+-- GRANT SELECT ON public.<name> TO anon;
+```
+
+RLS policies are still required for row-level authz — table-level grants are necessary but not sufficient. If the table has no RLS, anon would be able to read all rows; if RLS denies all, the table is unusable even with the grants. Both must be in place.
+
+### `CREATE OR REPLACE FUNCTION` — always re-pin `SET search_path`
+
+`CREATE OR REPLACE FUNCTION` replaces the entire function definition, **including any prior function-level `SET` clauses**. If you rewrite a `SECURITY DEFINER` function (or any trigger function in the public schema) and omit `SET search_path`, you silently drop the pinning that the April 2026 hardening sweep added — Supabase's Security Advisor will flag `function_search_path_mutable` on the next scan.
+
+Whenever you `CREATE OR REPLACE` a SECURITY DEFINER function or a trigger function, include:
+
+```sql
+CREATE OR REPLACE FUNCTION public.my_function(...)
+RETURNS ...
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog   -- ← do not omit this line
+AS $$
+...
+$$;
+```
+
+The Phase 2 lockdown migration `20260513120000_security_definer_lockdown.sql` documents seven functions that regressed this way. Don't add an eighth.
+
+### SECURITY DEFINER function grants
+
+After the Phase 2 lockdown (PR following #194), every SECURITY DEFINER function in `public` either:
+
+- Has its EXECUTE grant revoked from `PUBLIC, anon, authenticated` (triggers, cron callbacks, internal helpers), OR
+- Has it revoked from `PUBLIC, anon` and granted to `authenticated` (admin RPCs, frontend-only RPCs), OR
+- Is on the **Bucket B intentional-exposure list** below.
+
+When you add a new SECURITY DEFINER function, write the appropriate grant block as part of the same migration:
+
+```sql
+CREATE OR REPLACE FUNCTION public.new_admin_rpc(...) ... SECURITY DEFINER ...;
+
+-- Default tightening for a SECURITY DEFINER function. Pick ONE pattern:
+
+-- Pattern A: trigger function / cron callback / internal helper
+REVOKE EXECUTE ON FUNCTION public.new_admin_rpc(...) FROM PUBLIC, anon, authenticated;
+
+-- Pattern B: authenticated-only RPC (frontend caller after sign-in)
+REVOKE EXECUTE ON FUNCTION public.new_admin_rpc(...) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.new_admin_rpc(...) TO authenticated;
+
+-- Pattern C: anon-callable (sign-up, kiosk, etc.) — REQUIRES JUSTIFICATION
+-- in a comment in the migration AND an entry added to the Bucket B
+-- table in CONTRIBUTING.md.
+```
+
+### Bucket B — intentional anon/authenticated exposure (do not lock down)
+
+These SECURITY DEFINER functions are deliberately callable by `anon` and/or `authenticated`. Supabase Security Advisor will flag them on every scan; the rationale below is the answer.
+
+| function | callable by | why |
+|---|---|---|
+| `is_admin()` | authenticated | RLS predicate invoked per-row in dozens of policies. Locking down breaks RLS. |
+| `is_coordinator_or_admin()` | authenticated | Same — RLS predicate. |
+| `is_coordinator_for_my_dept(uuid)` | authenticated | RLS predicate for departmental scoping. |
+| `my_role()` | authenticated | RLS predicate + frontend role gating. |
+| `has_active_booking_on(uuid)` | authenticated | RLS predicate used in `shift_bookings` policies. |
+| `is_current_user_minor()` | authenticated | RLS predicate for minor-consent gating. |
+| `username_available(text)` | anon, authenticated | Sign-up flow needs to check username availability before the user has a JWT. |
+| `get_email_by_username(text)` | anon, authenticated | Sign-in flow accepts username OR email; the username→email lookup happens pre-auth. |
+| `notification_link_booking_id(text)` | authenticated | STABLE helper used in `notifications` views/RLS — a per-row evaluator, not an RPC. |
+| `validate_checkin_token(text)` | anon | Kiosk check-in flow uses the project anon key; the function only validates the token and returns a boolean. |
+
+If you're adding a function to this list, you need a security review comment in the PR and a one-line justification in the table above.

--- a/supabase/migrations/20260513120000_security_definer_lockdown.sql
+++ b/supabase/migrations/20260513120000_security_definer_lockdown.sql
@@ -242,28 +242,34 @@ GRANT  EXECUTE ON FUNCTION public.score_shifts_for_volunteer(uuid, integer) TO a
 -- Frontend compat: RecommendedShifts.tsx:83-86 always passes
 -- p_volunteer_id: user.id, so the check is a no-op for the current UI.
 
+-- Signature MUST match the existing baseline definition exactly
+-- (column names + the `p_max_days integer DEFAULT 14`). CREATE OR
+-- REPLACE FUNCTION can't change the return type of an existing
+-- function — see SQLSTATE 42P13. Renaming an output column counts as
+-- a return-type change. If a future refactor needs the rename, do it
+-- in a separate migration with DROP FUNCTION first.
 CREATE OR REPLACE FUNCTION public.score_shifts_for_volunteer(
   p_volunteer_id uuid,
-  p_max_days     integer
+  p_max_days     integer DEFAULT 14
 )
 RETURNS TABLE(
-  shift_id           uuid,
-  title              text,
-  shift_date         date,
-  department_id      uuid,
-  department_name    text,
-  start_time         time without time zone,
-  end_time           time without time zone,
-  time_type          text,
-  total_slots        integer,
-  booked_slots       integer,
-  requires_bg_check  boolean,
-  fill_rate          numeric,
-  preference_score   numeric,
-  org_need_score     numeric,
-  novelty_score      numeric,
-  total_score        numeric,
-  score_breakdown    jsonb
+  shift_id            uuid,
+  title               text,
+  shift_date          date,
+  department_id       uuid,
+  department_name     text,
+  start_time          time without time zone,
+  end_time            time without time zone,
+  time_type           text,
+  total_slots         integer,
+  booked_slots        integer,
+  requires_bg_check   boolean,
+  fill_ratio          numeric,
+  preference_match    numeric,
+  organizational_need numeric,
+  novelty_bonus       numeric,
+  total_score         numeric,
+  score_breakdown     jsonb
 )
 LANGUAGE plpgsql
 STABLE

--- a/supabase/migrations/20260513120000_security_definer_lockdown.sql
+++ b/supabase/migrations/20260513120000_security_definer_lockdown.sql
@@ -116,7 +116,10 @@ REVOKE EXECUTE ON FUNCTION public.route_minor_booking_to_pending()           FRO
 REVOKE EXECUTE ON FUNCTION public.set_document_request_expiry()              FROM PUBLIC, anon, authenticated;
 REVOKE EXECUTE ON FUNCTION public.set_updated_at()                           FROM PUBLIC, anon, authenticated;
 REVOKE EXECUTE ON FUNCTION public.sync_booked_slots()                        FROM PUBLIC, anon, authenticated;
-REVOKE EXECUTE ON FUNCTION public.sync_is_minor()                            FROM PUBLIC, anon, authenticated;
+-- sync_is_minor() was dropped in 20260501000000_remove_dob_capture.sql:77
+-- (Half A removed the DOB capture + the BEFORE INSERT/UPDATE trigger that
+-- backed it). Intentionally NOT referenced here — referencing a dropped
+-- function would fail with SQLSTATE 42883.
 REVOKE EXECUTE ON FUNCTION public.sync_slot_booked_count()                   FROM PUBLIC, anon, authenticated;
 REVOKE EXECUTE ON FUNCTION public.sync_volunteer_reported_hours()            FROM PUBLIC, anon, authenticated;
 REVOKE EXECUTE ON FUNCTION public.trg_recalculate_consistency_fn()           FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/20260513120000_security_definer_lockdown.sql
+++ b/supabase/migrations/20260513120000_security_definer_lockdown.sql
@@ -1,0 +1,343 @@
+-- Phase 2 lockdown: SECURITY DEFINER grant tightening + search_path
+-- re-pins + score_shifts_for_volunteer caller check.
+--
+-- Source: 2026-05-13 Supabase Security Advisor sweep. Full triage and
+-- per-function rationale: GitHub issue #194. Hotfix that closed two
+-- active vulnerabilities (transfer_admin_role,
+-- transfer_coordinator_and_delete) landed in PR #195
+-- (20260513000000_harden_transfer_admin_functions.sql) — this
+-- migration does NOT re-touch those two.
+--
+-- ─── What this migration does ──────────────────────────────────────
+--
+-- 1. Re-pins search_path on 7 trigger functions that were pinned by
+--    20260414000001_fix_security_advisor.sql but lost the SET clause
+--    when subsequent migrations rewrote their bodies via
+--    CREATE OR REPLACE FUNCTION (which silently strips function-level
+--    SET clauses).
+--
+-- 2. REVOKEs EXECUTE FROM PUBLIC, anon, authenticated on:
+--      • Every trigger function (return type `trigger`). Triggers are
+--        fired by Postgres through the trigger plan; they never need
+--        a REST-callable grant.
+--      • pg_cron callbacks and internal maintenance helpers. These
+--        run as the cron job owner / service_role, not via REST.
+--      • Internal recompute helpers invoked only from other functions
+--        / triggers (promote_next_waitlist, update_volunteer_preferences).
+--      • export_critical_data — full-dump function that had no auth
+--        check on the body and was anon-callable. The advisor sweep's
+--        worst confidentiality finding.
+--
+-- 3. REVOKEs FROM PUBLIC, anon and GRANTs TO authenticated on:
+--      • Admin RPCs whose body already has an internal role check
+--        (is_admin / is_coordinator_or_admin). Grant tightening is
+--        defence-in-depth; the body check is the authoritative gate.
+--      • Bucket C functions that are legitimately called from the
+--        frontend after sign-in but have no anon use case.
+--
+-- 4. Refactors score_shifts_for_volunteer to reject callers who pass a
+--    p_volunteer_id that isn't their own auth.uid() unless they're a
+--    coordinator/admin. Pre-fix, any authenticated user could rank
+--    another volunteer's recommended shifts (low risk — no PII leaves
+--    the function — but "you can rank for any volunteer" is suspicious
+--    API shape).
+--
+-- ─── What this migration does NOT do ───────────────────────────────
+--
+-- • Touch Bucket B (intentional exposures: is_admin, my_role,
+--   username_available, etc.). These MUST stay callable; rationale is
+--   documented in CONTRIBUTING.md (this PR's companion change).
+--
+-- • Touch validate_checkin_token — kiosk check-in flow uses the anon
+--   key, so the anon grant is load-bearing.
+--
+-- • Touch resolve_hours_discrepancy — declared LANGUAGE plpgsql with
+--   NO SECURITY DEFINER clause (verified at baseline.sql:1959). It's
+--   SECURITY INVOKER and was never on the advisor's list.
+--
+-- • Touch the transfer_* pair — handled in PR #195 hotfix.
+--
+-- ─── Idempotency ───────────────────────────────────────────────────
+--
+-- REVOKE on a grant that doesn't exist is a no-op. GRANT on an
+-- existing grant is a no-op. ALTER FUNCTION ... SET search_path
+-- overwrites any prior setting. The migration can therefore be safely
+-- re-applied after a partial failure.
+
+-- ═══════════════════════════════════════════════════════════════════
+-- SECTION 1 — search_path re-pins
+-- ═══════════════════════════════════════════════════════════════════
+-- Pattern: `ALTER FUNCTION ... SET search_path = public, pg_catalog`
+-- matches the canonical form from the April 14 hardening sweep.
+
+ALTER FUNCTION public.cancel_bookings_on_profile_delete()
+  SET search_path = public, pg_catalog;
+ALTER FUNCTION public.enforce_eligibility_on_profile_update()
+  SET search_path = public, pg_catalog;
+ALTER FUNCTION public.enforce_document_request_state_machine()
+  SET search_path = public, pg_catalog;
+ALTER FUNCTION public.set_document_request_expiry()
+  SET search_path = public, pg_catalog;
+ALTER FUNCTION public.enforce_booking_window()
+  SET search_path = public, pg_catalog;
+ALTER FUNCTION public.prevent_overlapping_bookings()
+  SET search_path = public, pg_catalog;
+ALTER FUNCTION public.prevent_user_from_changing_admin_columns()
+  SET search_path = public, pg_catalog;
+
+-- ═══════════════════════════════════════════════════════════════════
+-- SECTION 2 — REVOKE EXECUTE FROM PUBLIC, anon, authenticated
+--             (triggers, cron callbacks, internal helpers)
+-- ═══════════════════════════════════════════════════════════════════
+-- service_role retains EXECUTE via its blanket schema-level grant —
+-- not affected by these REVOKEs.
+
+-- Triggers (return type `trigger` — invoked by Postgres, never via REST)
+REVOKE EXECUTE ON FUNCTION public.cancel_bookings_on_profile_delete()        FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.cascade_bg_check_expiry()                  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.check_attendance_dispute()                 FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.cleanup_notifications_for_booking()        FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.cleanup_notifications_for_shift()          FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.create_self_confirmation_report()          FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enforce_admin_cap()                        FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enforce_admin_only_approval()              FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enforce_booking_window()                   FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enforce_department_restriction()           FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enforce_document_request_state_machine()   FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enforce_eligibility_on_profile_update()    FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enforce_shift_not_ended_on_booking()       FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enforce_volunteer_only_booking()           FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.generate_shift_time_slots()                FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_email_on_notification()             FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.prevent_overlapping_bookings()             FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.prevent_role_self_escalation()             FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.prevent_user_from_changing_admin_columns() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.route_minor_booking_to_pending()           FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.set_document_request_expiry()              FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.set_updated_at()                           FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.sync_booked_slots()                        FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.sync_is_minor()                            FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.sync_slot_booked_count()                   FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.sync_volunteer_reported_hours()            FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.trg_recalculate_consistency_fn()           FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.trg_recalculate_points_fn()                FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.trg_update_preferences_on_interaction()    FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.trg_waitlist_promote_on_cancel()           FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.trg_waitlist_promote_on_delete()           FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_shift_status()                      FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.validate_booking_slot_count()              FROM PUBLIC, anon, authenticated;
+
+-- pg_cron callbacks + service_role-only operations
+REVOKE EXECUTE ON FUNCTION public.admin_emergency_mfa_reset(text)          FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.log_mfa_reset(text)                      FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.process_confirmation_reminders()         FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.reconcile_shift_counters()               FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.send_self_confirmation_reminders()       FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.transition_past_shifts_to_completed()    FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.warn_expiring_documents()                FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.export_critical_data()                   FROM PUBLIC, anon, authenticated;
+
+-- Internal recompute helpers (called from other functions / triggers only)
+REVOKE EXECUTE ON FUNCTION public.update_volunteer_preferences(uuid)       FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.promote_next_waitlist(uuid)              FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.promote_next_waitlist(uuid, uuid)        FROM PUBLIC, anon, authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════
+-- SECTION 3 — REVOKE FROM PUBLIC, anon; GRANT TO authenticated
+--             (admin RPCs + Bucket C auth-only RPCs)
+-- ═══════════════════════════════════════════════════════════════════
+
+-- Admin RPCs (body already gates on is_admin / is_coordinator_or_admin)
+REVOKE EXECUTE ON FUNCTION public.admin_action_off_shift(uuid)               FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.admin_action_off_shift(uuid)               TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.admin_break_glass_read_notes(uuid, text)   FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.admin_break_glass_read_notes(uuid, text)   TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.admin_delete_unactioned_shift(uuid)        FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.admin_delete_unactioned_shift(uuid)        TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.admin_update_shift_hours(uuid, numeric)    FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.admin_update_shift_hours(uuid, numeric)    TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_unactioned_shifts()                    FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_unactioned_shifts()                    TO authenticated;
+
+-- Bucket C — authenticated callers only (frontend RPCs after sign-in)
+REVOKE EXECUTE ON FUNCTION public.get_unread_conversation_count()                       FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_unread_conversation_count()                       TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_shift_consistency(uuid[])                         FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_shift_consistency(uuid[])                         TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_shift_popularity(uuid[])                          FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_shift_popularity(uuid[])                          TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_shift_rating_aggregates(uuid[])                   FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_shift_rating_aggregates(uuid[])                   TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_department_report(uuid[], date, date)             FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_department_report(uuid[], date, date)             TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_other_participants(uuid[])                        FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_other_participants(uuid[])                        TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.waitlist_accept(uuid)                                 FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.waitlist_accept(uuid)                                 TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.waitlist_decline(uuid)                                FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.waitlist_decline(uuid)                                TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.extend_document_request(uuid)                         FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.extend_document_request(uuid)                         TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.submit_document(uuid, text, text, text, integer, text, text, text, text, inet, text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.submit_document(uuid, text, text, text, integer, text, text, text, text, inet, text) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.gdpr_erase_document(uuid)                             FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.gdpr_erase_document(uuid)                             TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.mfa_consume_backup_code(text)                         FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.mfa_consume_backup_code(text)                         TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.mfa_generate_backup_codes()                           FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.mfa_generate_backup_codes()                           TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.mfa_unused_backup_code_count()                        FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.mfa_unused_backup_code_count()                        TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.shift_end_at(date, time without time zone, text)      FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.shift_end_at(date, time without time zone, text)      TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.shift_start_at(date, time without time zone, text)    FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.shift_start_at(date, time without time zone, text)    TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.recalculate_consistency(uuid)                         FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.recalculate_consistency(uuid)                         TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.recalculate_points(uuid)                              FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.recalculate_points(uuid)                              TO authenticated;
+
+-- score_shifts_for_volunteer — refactored below in SECTION 4. Grant
+-- tightening happens here so the new definition starts with the
+-- correct EXECUTE set.
+REVOKE EXECUTE ON FUNCTION public.score_shifts_for_volunteer(uuid, integer) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.score_shifts_for_volunteer(uuid, integer) TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════
+-- SECTION 4 — score_shifts_for_volunteer caller-identity refactor
+-- ═══════════════════════════════════════════════════════════════════
+-- Pre-fix: any authenticated caller could pass any volunteer's UUID
+-- and rank that volunteer's recommended shifts. Not a confidentiality
+-- breach (the function returns shift metadata, scored against a
+-- volunteer's history) but the API shape was suspicious.
+--
+-- Post-fix: a caller can rank shifts for themselves; a coordinator or
+-- admin can rank shifts for any volunteer. Anyone else passing a
+-- non-self p_volunteer_id gets a 42501.
+--
+-- Frontend compat: RecommendedShifts.tsx:83-86 always passes
+-- p_volunteer_id: user.id, so the check is a no-op for the current UI.
+
+CREATE OR REPLACE FUNCTION public.score_shifts_for_volunteer(
+  p_volunteer_id uuid,
+  p_max_days     integer
+)
+RETURNS TABLE(
+  shift_id           uuid,
+  title              text,
+  shift_date         date,
+  department_id      uuid,
+  department_name    text,
+  start_time         time without time zone,
+  end_time           time without time zone,
+  time_type          text,
+  total_slots        integer,
+  booked_slots       integer,
+  requires_bg_check  boolean,
+  fill_rate          numeric,
+  preference_score   numeric,
+  org_need_score     numeric,
+  novelty_score      numeric,
+  total_score        numeric,
+  score_breakdown    jsonb
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  v_prefs record;
+  v_max_interactions numeric;
+BEGIN
+  -- Caller-identity check. A volunteer can only rank their own
+  -- recommended shifts; coordinators and admins can rank for anyone.
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'forbidden: authentication required'
+      USING ERRCODE = '42501';
+  END IF;
+  IF auth.uid() <> p_volunteer_id AND NOT public.is_coordinator_or_admin() THEN
+    RAISE EXCEPTION 'forbidden: caller may only score their own shifts'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_prefs FROM public.volunteer_preferences WHERE volunteer_id = p_volunteer_id;
+
+  SELECT LEAST(COALESCE(MAX(cnt), 1), 50)::numeric INTO v_max_interactions
+  FROM (
+    SELECT COUNT(*) AS cnt
+      FROM public.volunteer_shift_interactions
+     WHERE volunteer_id = p_volunteer_id
+     GROUP BY volunteer_shift_interactions.shift_id
+  ) sub;
+
+  RETURN QUERY
+  WITH si AS (
+    SELECT vsi.shift_id AS si_shift_id, COUNT(*)::numeric AS interaction_count
+      FROM public.volunteer_shift_interactions vsi
+     WHERE vsi.volunteer_id = p_volunteer_id
+     GROUP BY vsi.shift_id
+  ),
+  avail AS (
+    SELECT
+      s.id AS s_id, s.title AS s_title, s.shift_date AS s_date, s.department_id AS s_dept,
+      d.name AS d_name, s.start_time AS s_start, s.end_time AS s_end, s.time_type::text AS s_time_type,
+      s.total_slots AS s_total, s.booked_slots AS s_booked, s.requires_bg_check AS s_bg,
+      COALESCE(si.interaction_count, 0::numeric) AS interactions
+    FROM public.shifts s
+    JOIN public.departments d ON d.id = s.department_id
+    LEFT JOIN si ON si.si_shift_id = s.id
+    WHERE s.status = 'open'
+      AND s.shift_date >= CURRENT_DATE
+      AND s.shift_date <= CURRENT_DATE + (p_max_days || ' days')::interval
+      AND s.booked_slots < s.total_slots
+      AND NOT EXISTS (
+        SELECT 1 FROM public.shift_bookings sb
+         WHERE sb.shift_id = s.id
+           AND sb.volunteer_id = p_volunteer_id
+           AND sb.booking_status = 'confirmed'
+      )
+  )
+  SELECT
+    a.s_id, a.s_title, a.s_date, a.s_dept, a.d_name, a.s_start, a.s_end, a.s_time_type,
+    a.s_total, a.s_booked, a.s_bg,
+    CASE WHEN a.s_total > 0 THEN (a.s_booked::numeric / a.s_total::numeric) ELSE 0::numeric END,
+    COALESCE((v_prefs.department_affinity->>(a.s_dept::text))::numeric / 100.0, 0.5::numeric),
+    CASE WHEN a.s_total > 0 THEN (1.0 - (a.s_booked::numeric / a.s_total::numeric))::numeric ELSE 0.5::numeric END,
+    GREATEST(1.0::numeric - (ln(1.0 + a.interactions)::numeric / ln(1.0 + v_max_interactions)::numeric), 0.3::numeric),
+    (
+        COALESCE((v_prefs.department_affinity->>(a.s_dept::text))::numeric / 100.0, 0.5::numeric) * 0.5
+      + (CASE WHEN a.s_total > 0 THEN (1.0 - (a.s_booked::numeric / a.s_total::numeric))::numeric ELSE 0.5::numeric END) * 0.3
+      + GREATEST(1.0::numeric - (ln(1.0 + a.interactions)::numeric / ln(1.0 + v_max_interactions)::numeric), 0.3::numeric) * 0.2
+    )::numeric,
+    jsonb_build_object(
+      'has_history', (SELECT COUNT(*) > 0 FROM public.volunteer_shift_interactions WHERE volunteer_id = p_volunteer_id),
+      'preference_weight', 0.5, 'org_need_weight', 0.3, 'novelty_weight', 0.2,
+      'interactions', a.interactions, 'novelty_floor', 0.3
+    )
+  FROM avail a
+  ORDER BY 16 DESC
+  LIMIT 20;
+END;
+$$;

--- a/supabase/test/score-shifts-for-volunteer.test.ts
+++ b/supabase/test/score-shifts-for-volunteer.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { anonClient, getHarnessUsers, signInAs } from "./clients";
+
+/**
+ * Phase 2 verification for the score_shifts_for_volunteer caller-identity
+ * check (added in 20260513120000_security_definer_lockdown.sql).
+ *
+ * Pre-fix: any authenticated user could pass any volunteer's UUID and
+ * rank that volunteer's recommended shifts. Not a confidentiality leak
+ * (the function returns shift metadata, scored against a volunteer's
+ * history) but the API shape was wrong — "score X's shifts" is a
+ * self-scoped operation unless the caller is a coordinator/admin.
+ *
+ * Post-fix:
+ *   - anon  → 42501
+ *   - volunteer passing their OWN UID → succeeds (positive path)
+ *   - volunteer passing ANOTHER volunteer's UID → 42501
+ *   - coordinator passing any volunteer's UID → succeeds
+ *   - admin passing any volunteer's UID → succeeds
+ *
+ * The function is SECURITY DEFINER + STABLE. The grant tightening
+ * (REVOKE FROM anon, GRANT TO authenticated) is enforced separately
+ * in the same migration; this test exercises the body-level check
+ * which is the authoritative gate.
+ */
+
+const FORBIDDEN_CODE = "42501";
+
+const expectForbidden = (error: unknown, hint?: string) => {
+  const e = error as { code?: string; message?: string } | null;
+  expect(e, `expected forbidden error${hint ? ` (${hint})` : ""}`).not.toBeNull();
+  expect(
+    e?.code === FORBIDDEN_CODE || /forbidden/i.test(e?.message ?? ""),
+    `expected 42501 / "forbidden", got code=${e?.code} msg=${e?.message}`,
+  ).toBe(true);
+};
+
+describe("score_shifts_for_volunteer: caller-identity check", () => {
+  it("rejects anon caller (auth.uid() IS NULL)", async () => {
+    // anon caller is doubly gated: (1) the EXECUTE grant has been
+    // revoked from anon by SECTION 3 of the migration, and (2) the
+    // body's auth.uid() IS NULL check would reject even if the grant
+    // were restored. Either error is acceptable as long as the call
+    // is rejected.
+    const users = getHarnessUsers();
+    const client = anonClient();
+    const { error } = await (client.rpc as never)("score_shifts_for_volunteer", {
+      p_volunteer_id: users.volunteer.id,
+      p_max_days: 14,
+    });
+    expect(error).not.toBeNull();
+  });
+
+  it("volunteer passing their own UID succeeds (positive path)", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+    const { error } = await (client.rpc as never)("score_shifts_for_volunteer", {
+      p_volunteer_id: users.volunteer.id,
+      p_max_days: 14,
+    });
+    // No 42501 — function executed. Result set may be empty (harness
+    // doesn't seed open shifts by default) but the call itself must
+    // succeed.
+    expect(error).toBeNull();
+  });
+
+  it("volunteer passing ANOTHER volunteer's UID is rejected", async () => {
+    // This is the exact API-shape misuse the refactor closes: a
+    // volunteer ranks another volunteer's recommended shifts. No
+    // legitimate frontend path does this.
+    const users = getHarnessUsers();
+    const client = await signInAs("volunteer");
+    const { error } = await (client.rpc as never)("score_shifts_for_volunteer", {
+      p_volunteer_id: users.volunteer2.id,
+      p_max_days: 14,
+    });
+    expectForbidden(error, "volunteer-as-other-volunteer");
+  });
+
+  it("coordinator passing a volunteer's UID succeeds", async () => {
+    // Coordinator/admin scoring on behalf of a volunteer is a
+    // legitimate (if currently unused) use case — preserved by the
+    // is_coordinator_or_admin() branch of the check.
+    const users = getHarnessUsers();
+    const client = await signInAs("coordinator");
+    const { error } = await (client.rpc as never)("score_shifts_for_volunteer", {
+      p_volunteer_id: users.volunteer.id,
+      p_max_days: 14,
+    });
+    expect(error).toBeNull();
+  });
+
+  it("admin passing a volunteer's UID succeeds", async () => {
+    const users = getHarnessUsers();
+    const client = await signInAs("admin");
+    const { error } = await (client.rpc as never)("score_shifts_for_volunteer", {
+      p_volunteer_id: users.volunteer.id,
+      p_max_days: 14,
+    });
+    expect(error).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #194. Builds on the PR #195 hotfix.

## Summary

Phase 2 of the Supabase Security Advisor remediation. One migration covers four concerns:

1. **search_path re-pins** (7 trigger functions that regressed when later migrations rewrote them via `CREATE OR REPLACE FUNCTION` without re-including the SET clause).
2. **REVOKE EXECUTE FROM PUBLIC, anon, authenticated** on every trigger function, every pg_cron callback, internal maintenance helpers, and `export_critical_data` (a full-dump function that was anon-callable with no body auth check — the sweep's worst confidentiality finding).
3. **REVOKE FROM PUBLIC, anon; GRANT TO authenticated** on admin RPCs (already body-gated; defence-in-depth) and ~20 Bucket C frontend RPCs (reports, MFA helpers, waitlist actions, document ops).
4. **`score_shifts_for_volunteer` body refactor**: caller can only pass their own `auth.uid()` as `p_volunteer_id` unless they're coordinator/admin. Frontend (`RecommendedShifts.tsx:83`) already passes `user.id` — no-op for the current UI.

CONTRIBUTING.md gets a new "Writing Supabase Migrations" section codifying the rules that fell out of this work.

## What this PR doesn't touch

- **Bucket B** intentional exposures (`is_admin`, `my_role`, RLS predicate helpers, sign-up/sign-in RPCs) — rationale documented in CONTRIBUTING.md.
- `validate_checkin_token` — kiosk anon flow uses it; load-bearing.
- `resolve_hours_discrepancy` — it's SECURITY INVOKER (Phase 1 false positive; close reading at `baseline.sql:1959` found no `SECURITY DEFINER` clause).
- `transfer_admin_role` / `transfer_coordinator_and_delete` — handled in PR #195.

## Frontend impact

Zero UI changes required. `score_shifts_for_volunteer` caller already passes `p_volunteer_id: user.id`. All Bucket C functions are called from authenticated surfaces only (verified via `.rpc('<name>'` greps).

## CONTRIBUTING.md changes

New section "Writing Supabase Migrations" covers:

- Forward-looking `GRANT` block required on every new `CREATE TABLE public.*` (per Supabase's 2026-10-30 Data API change).
- "Always include `SET search_path` when `CREATE OR REPLACE`-ing a SECURITY DEFINER function".
- Default REVOKE/GRANT patterns for new SECURITY DEFINER functions (Pattern A: trigger/internal; B: authenticated-only RPC; C: anon-callable requires justification).
- Bucket B intentional-exposure table — 10 functions, one-line rationale each.

## Idempotency

REVOKE on a non-existent grant is a no-op. GRANT on an existing grant is a no-op. ALTER FUNCTION ... SET search_path overwrites any prior setting. Safely re-applicable after a partial failure.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [ ] `npm run test:rls` — adds `supabase/test/score-shifts-for-volunteer.test.ts` (5 cases: anon, self, other-volunteer, coordinator, admin)
- [ ] Post-deploy: re-run Supabase Security Advisor; expect `function_search_path_mutable` to drop from 7 to 0, and `anon_security_definer` to drop substantially (remaining hits should be Bucket B + `validate_checkin_token`).

## Out of scope (deferred)

- HaveIBeenPwned password-protection dashboard toggle (owner handling directly).
- Body-level role/owner check verification on `extend_document_request`, `submit_document`, `gdpr_erase_document` — grants tightened here, but bodies not audited line-by-line. Follow up when the document UI lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
