### PR TITLE
fix(security): restore promote_next_waitlist EXECUTE to authenticated (#196 regression)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,26 @@ GRANT  EXECUTE ON FUNCTION public.new_admin_rpc(...) TO authenticated;
 -- table in CONTRIBUTING.md.
 ```
 
+> **⚠️ Before revoking EXECUTE from `authenticated` on ANY function, check
+> whether an invoker-context (non-`SECURITY DEFINER`) trigger calls it.**
+> If so, `authenticated` MUST keep EXECUTE — a `SECURITY INVOKER` trigger
+> runs as the user who fired it, so when an authenticated user's
+> INSERT/UPDATE/DELETE fires the trigger, the trigger's call to the helper
+> is checked against *that user's* grants. Revoking it makes the whole
+> operation fail with `42501 permission denied for function ...`.
+>
+> This is exactly how PR #196 broke `promote_next_waitlist` in production:
+> it's called by `trg_waitlist_promote_on_cancel` / `trg_waitlist_promote_on_delete`
+> (both `LANGUAGE plpgsql`, no `SECURITY DEFINER`), so revoking it from
+> `authenticated` made every booking cancellation / shift deletion 403.
+> Fixed in `20260613000000_grant_promote_next_waitlist_to_authenticated.sql`.
+>
+> Quick check before a REVOKE: `grep` the function name across migrations
+> for `PERFORM`/`SELECT` callers, and for each caller confirm it's either
+> `SECURITY DEFINER` (safe — runs as owner) or pg_cron-only (safe). If a
+> plain `LANGUAGE plpgsql` trigger function calls it, use Pattern B
+> (keep `authenticated`), not Pattern A.
+
 ### Bucket B — intentional anon/authenticated exposure (do not lock down)
 
 These SECURITY DEFINER functions are deliberately callable by `anon` and/or `authenticated`. Supabase Security Advisor will flag them on every scan; the rationale below is the answer.

--- a/supabase/migrations/20260613000000_grant_promote_next_waitlist_to_authenticated.sql
+++ b/supabase/migrations/20260613000000_grant_promote_next_waitlist_to_authenticated.sql
@@ -1,0 +1,48 @@
+-- Hotfix: restore EXECUTE on promote_next_waitlist to `authenticated`.
+--
+-- LIVE PROD REGRESSION introduced by the Phase 2 SECURITY DEFINER
+-- lockdown (20260513120000_security_definer_lockdown.sql, PR #196).
+--
+-- That migration revoked EXECUTE on both promote_next_waitlist
+-- signatures from PUBLIC, anon, AND authenticated, classifying the
+-- function as "internal, trigger-invoked only." That classification
+-- was wrong: the two triggers that call it run in the INVOKER's
+-- security context, not as the function owner:
+--
+--   trg_waitlist_promote_on_cancel()  -- LANGUAGE plpgsql, NO SECURITY DEFINER
+--   trg_waitlist_promote_on_delete()  -- LANGUAGE plpgsql, NO SECURITY DEFINER
+--
+-- (Both defined in 20260101000000_baseline.sql ~L2631/L2646.)
+--
+-- Because those triggers are SECURITY INVOKER, when an authenticated
+-- user cancels a confirmed booking (UPDATE booking_status='cancelled')
+-- or an admin deletes a shift with confirmed bookings, the trigger
+-- fires `PERFORM public.promote_next_waitlist(...)` AS THE INVOKING
+-- USER (authenticated). With EXECUTE revoked from authenticated, that
+-- call raises:
+--
+--   ERROR: permission denied for function promote_next_waitlist
+--   SQLSTATE 42501
+--
+-- which aborts the entire cancel/delete. Net effect on prod: every
+-- waitlist-promoting booking cancellation, and every admin shift
+-- deletion involving confirmed bookings, returns HTTP 403. Surfaced
+-- by the e2e suite (04-admin-delete-shift) once PR #197 unblocked the
+-- test far enough to reach the delete step.
+--
+-- Fix: grant EXECUTE back to `authenticated`. anon stays revoked —
+-- anon never cancels or deletes bookings, so it has no legitimate
+-- path to this function. This restores the pre-#196 (grandfathered)
+-- behavior; the function is SECURITY DEFINER, so granting EXECUTE to
+-- authenticated only lets them INVOKE it (e.g. via the trigger) — it
+-- does not widen what the function itself can do.
+--
+-- The other helpers #196 revoked from authenticated were re-checked
+-- and are NOT affected: their only non-cron callers are SECURITY
+-- DEFINER functions (which run as the owner, so the revoke is
+-- harmless). promote_next_waitlist is the sole invoker-context case.
+-- See CONTRIBUTING.md ("Before revoking EXECUTE from authenticated...")
+-- for the rule that prevents this class of regression.
+
+GRANT EXECUTE ON FUNCTION public.promote_next_waitlist(uuid)        TO authenticated;
+GRANT EXECUTE ON FUNCTION public.promote_next_waitlist(uuid, uuid)  TO authenticated;

--- a/supabase/test/waitlist-promotion-on-cancel.test.ts
+++ b/supabase/test/waitlist-promotion-on-cancel.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { signInAs, adminBypassClient, getHarnessUsers } from "./clients";
+import { TEST_DEPARTMENT_ID } from "./setup";
+
+/**
+ * Regression coverage for the promote_next_waitlist EXECUTE grant
+ * (20260613000000_grant_promote_next_waitlist_to_authenticated.sql).
+ *
+ * The Phase 2 SECURITY DEFINER lockdown (PR #196) revoked EXECUTE on
+ * promote_next_waitlist from `authenticated`. But it's invoked by the
+ * SECURITY INVOKER trigger trg_waitlist_promote_on_cancel — which runs
+ * as the cancelling user. So a volunteer cancelling their own confirmed
+ * booking when someone is waitlisted hit:
+ *
+ *   ERROR 42501: permission denied for function promote_next_waitlist
+ *
+ * aborting the cancel (HTTP 403 in prod). This test pins the path:
+ *
+ *   - WITHOUT the grant: the cancel UPDATE below raises 42501 →
+ *     `cancel.error` is non-null → this test FAILS.
+ *   - WITH the grant: the cancel succeeds AND the waitlisted volunteer
+ *     gets a promotion offer (waitlist_offer_expires_at set by
+ *     promote_next_waitlist) → this test PASSES.
+ *
+ * Note: promote_next_waitlist does not flip the waitlisted booking
+ * straight to 'confirmed' — it extends a time-boxed offer (sets
+ * waitlist_offer_expires_at; the volunteer then accepts via
+ * waitlist_accept). The observable proof that promotion ran is that
+ * offer timestamp going from NULL to non-NULL.
+ *
+ * Harness convention: service-role bypass for setup/teardown; the
+ * assertion path (the cancel) runs as the authenticated volunteer so
+ * the invoker-context trigger fires exactly as it does in prod.
+ */
+
+// 7 days out: inside the 14-day booking window and comfortably past
+// promote_next_waitlist's "shift must be >30min in the future" guard.
+const SHIFT_DATE = (() => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + 7);
+  return d.toISOString().slice(0, 10);
+})();
+
+let shiftId: string;
+let volBookingId: string; // volunteer's confirmed booking
+let vol2BookingId: string; // volunteer2's waitlisted booking
+
+beforeAll(async () => {
+  const admin = adminBypassClient();
+  const users = getHarnessUsers();
+
+  // enforce_booking_window requires both volunteers to have emergency
+  // contacts, else the booking insert is rejected before we reach the
+  // waitlist path. Stamp them via service-role (setup only).
+  await admin
+    .from("profiles")
+    .update({
+      emergency_contact_name: "Harness Contact",
+      emergency_contact_phone: "555-555-0142",
+    } as never)
+    .in("id", [users.volunteer.id, users.volunteer2.id]);
+
+  // Single-slot shift so it fills with one confirmed booking and the
+  // second volunteer is genuinely a waitlist candidate.
+  const { data: shift, error: shiftErr } = await admin
+    .from("shifts")
+    .insert({
+      department_id: TEST_DEPARTMENT_ID,
+      created_by: users.admin.id,
+      title: "Waitlist-Promote-Cancel Test",
+      shift_date: SHIFT_DATE,
+      time_type: "morning",
+      start_time: "10:00:00",
+      end_time: "12:00:00",
+      total_slots: 1,
+      requires_bg_check: false,
+    } as never)
+    .select("id")
+    .single();
+  if (shiftErr || !shift) throw new Error(`shift insert failed: ${shiftErr?.message}`);
+  shiftId = (shift as { id: string }).id;
+});
+
+afterAll(async () => {
+  const admin = adminBypassClient();
+  if (shiftId) {
+    await admin.from("shift_bookings").delete().eq("shift_id", shiftId);
+    await admin.from("shifts").delete().eq("id", shiftId);
+  }
+});
+
+describe("waitlist promotion on cancel (promote_next_waitlist EXECUTE grant)", () => {
+  it("an authenticated volunteer can cancel a confirmed booking when someone is waitlisted, and the waitlisted volunteer is promoted (offered a spot)", async () => {
+    const users = getHarnessUsers();
+
+    // --- Volunteer books the only slot (confirmed) ---
+    const volClient = await signInAs("volunteer");
+    const booked = await volClient
+      .from("shift_bookings")
+      .insert({
+        shift_id: shiftId,
+        volunteer_id: users.volunteer.id,
+        booking_status: "confirmed",
+      } as never)
+      .select("id")
+      .single();
+    expect(booked.error, `confirmed booking insert: ${booked.error?.message}`).toBeNull();
+    volBookingId = (booked.data as { id: string }).id;
+
+    // --- Volunteer2 joins the waitlist (slot is full) ---
+    const vol2Client = await signInAs("volunteer2");
+    const waitlisted = await vol2Client
+      .from("shift_bookings")
+      .insert({
+        shift_id: shiftId,
+        volunteer_id: users.volunteer2.id,
+        booking_status: "waitlisted",
+      } as never)
+      .select("id, waitlist_offer_expires_at")
+      .single();
+    expect(waitlisted.error, `waitlist insert: ${waitlisted.error?.message}`).toBeNull();
+    vol2BookingId = (waitlisted.data as { id: string }).id;
+    // No active offer yet.
+    expect((waitlisted.data as { waitlist_offer_expires_at: string | null }).waitlist_offer_expires_at).toBeNull();
+
+    // --- THE REGRESSION: volunteer cancels their confirmed booking ---
+    // This fires trg_waitlist_promote_on_cancel (SECURITY INVOKER) →
+    // promote_next_waitlist, as the authenticated volunteer. Without the
+    // EXECUTE grant this raises 42501 and the cancel fails (HTTP 403).
+    const cancel = await volClient
+      .from("shift_bookings")
+      .update({ booking_status: "cancelled", cancelled_at: new Date().toISOString() } as never)
+      .eq("id", volBookingId)
+      .select("id, booking_status")
+      .single();
+    expect(
+      cancel.error,
+      `cancel must succeed; 42501 here means promote_next_waitlist EXECUTE is not granted to authenticated: ${cancel.error?.message}`,
+    ).toBeNull();
+    expect((cancel.data as { booking_status: string }).booking_status).toBe("cancelled");
+
+    // --- Promotion ran: the waitlisted volunteer now has an offer ---
+    // Read via service-role so RLS visibility can't mask the result.
+    const admin = adminBypassClient();
+    const { data: vol2After, error: readErr } = await admin
+      .from("shift_bookings")
+      .select("waitlist_offer_expires_at, booking_status")
+      .eq("id", vol2BookingId)
+      .single();
+    expect(readErr).toBeNull();
+    expect(
+      (vol2After as { waitlist_offer_expires_at: string | null }).waitlist_offer_expires_at,
+      "waitlisted volunteer should have been offered the freed spot (waitlist_offer_expires_at set by promote_next_waitlist)",
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

**Live prod regression hotfix.** PR #196 (Phase 2 SECURITY DEFINER lockdown) revoked `EXECUTE` on both `promote_next_waitlist` signatures from `PUBLIC, anon, authenticated`, classifying it as internal/trigger-only.

That classification was wrong. Its callers — `trg_waitlist_promote_on_cancel` and `trg_waitlist_promote_on_delete` — are **`SECURITY INVOKER`** triggers (plain `LANGUAGE plpgsql`, no `SECURITY DEFINER`). They run as the **invoking user**. So when an authenticated user cancels a confirmed booking, or an admin deletes a shift with confirmed bookings, the trigger fires `promote_next_waitlist` *as the authenticated user* → `42501 permission denied` → the whole operation **403s in production**.

## Fix
```sql
GRANT EXECUTE ON FUNCTION public.promote_next_waitlist(uuid)       TO authenticated;
GRANT EXECUTE ON FUNCTION public.promote_next_waitlist(uuid, uuid) TO authenticated;
```
`anon` stays revoked (it never cancels/deletes bookings). The function is `SECURITY DEFINER`, so granting `authenticated` EXECUTE only lets them *invoke* it (via the trigger) — it doesn't widen the function's own privileges. Restores pre-#196 behavior.

## Blast radius — re-checked, narrow
`promote_next_waitlist` is the **only** helper #196 revoked from `authenticated` that's reached via an invoker-context trigger. Every other revoked helper is called only by `SECURITY DEFINER` functions (run as owner) or pg_cron (postgres) — unaffected. Verified by grepping every caller of each revoked function.

## Tests / docs
- `supabase/test/waitlist-promotion-on-cancel.test.ts` — regression test: an authenticated volunteer cancels a confirmed booking with someone waitlisted; asserts the cancel **succeeds** and the waitlisted volunteer is **offered the freed spot** (`waitlist_offer_expires_at` set by `promote_next_waitlist`). Fails with `42501` without the grant; passes with it.
- `CONTRIBUTING.md` — new rule: *before revoking EXECUTE from `authenticated`, check for invoker-context (non-`SECURITY DEFINER`) trigger callers; if any, `authenticated` must keep EXECUTE.* The rule that would have prevented this.

## How discovered
Surfaced by the `#203 + #197` integration proof-branch: once #197's E2E fix unblocked `04-admin-delete-shift` far enough to reach the delete step, it hit this 42501. Discrete, revertable hotfix; merges **before** the #203/#197 sequence so prod is corrected first.

Corrects the `promote_next_waitlist` classification in #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
