### PR TITLE
chore(deps): silence routine Dependabot version PRs (keep security alerts)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,15 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    # Routine version-update PRs are silenced (0). Dependabot cannot
+    # maintain bun.lock — this repo's frozen lockfile — so it only bumps
+    # package.json, which then fails `bun install --frozen-lockfile`
+    # (package-lock.json was removed in #205). Routine bumps are taken
+    # MANUALLY instead (bump package.json → `bun install` → commit both;
+    # see CONTRIBUTING.md). This does NOT affect Dependabot security
+    # updates (separate internal limit) or vulnerability alerts — both
+    # stay enabled at the repo level.
+    open-pull-requests-limit: 0
     labels:
       - dependencies
     # Split-package majors Dependabot can't coordinate correctly — it
@@ -108,6 +116,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    # Routine version-update PRs silenced (0) — Actions are bumped
+    # deliberately. Security updates / alerts are unaffected.
+    open-pull-requests-limit: 0
     labels:
       - dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,3 +187,22 @@ These SECURITY DEFINER functions are deliberately callable by `anon` and/or `aut
 | `validate_checkin_token(text)` | anon | Kiosk check-in flow uses the project anon key; the function only validates the token and returns a boolean. |
 
 If you're adding a function to this list, you need a security review comment in the PR and a one-line justification in the table above.
+
+## Dependency Updates (Dependabot + bun)
+
+This repo uses **bun**, and CI/deploy run `bun install --frozen-lockfile` against **`bun.lock`** (the single source of truth — `package-lock.json` was removed in #205). Dependabot **cannot maintain `bun.lock`**: it only bumps `package.json`, which then fails the frozen-lockfile check. Because of that, and because unreviewed dependency churn is what caused the 2026-06 lockfile-drift incident (#203/#204), **routine version updates are deliberate, not automated.**
+
+What's configured:
+- **Routine version PRs are silenced** — `open-pull-requests-limit: 0` on both Dependabot ecosystems. Dependabot will not open version-bump PRs.
+- **Security stays on** — Dependabot **alerts** and **security updates** remain enabled (repo Settings → Code security). `open-pull-requests-limit: 0` does not affect them (separate internal limit), and the wildcard `version-update:semver-major` ignore does not affect them either (`update-types` applies to version updates only). A real vulnerability still surfaces.
+  - Caveat: a Dependabot *security-update PR* hits the same `bun.lock` limitation, so it too needs a manual `bun install` to pass CI — but the **alert** fires reliably, and a real vuln warrants a deliberate manual fix anyway.
+
+**To take a dependency update (routine or security):**
+```bash
+# Edit the version in package.json (or check out the Dependabot branch), then:
+bun install            # regenerates bun.lock to match
+git add package.json bun.lock
+git commit -m "chore(deps): bump <pkg> to <version>"
+# The frozen-lockfile check now passes.
+```
+Major bumps are additionally held by the wildcard `semver-major` ignore in `.github/dependabot.yml` — they're deliberate, coordinated upgrades (remove the ignore or bump by hand when ready).


### PR DESCRIPTION
## Summary

Final piece of the dependency-hygiene work. Makes routine dependency updates **deliberate, not automated** — the right posture for a solo, pre-pilot repo where unreviewed Dependabot churn caused the 2026-06 lockfile-drift incident (#203/#204).

**Why automation isn't viable here:** Dependabot can't maintain `bun.lock` (this repo's frozen lockfile; `package-lock.json` removed in #205). It only bumps `package.json`, which then fails `bun install --frozen-lockfile`. Rather than build a bun.lock-sync workflow to enable autopilot churn we don't want, we silence routine version PRs and take updates by hand.

## Changes
- **`.github/dependabot.yml`** — `open-pull-requests-limit: 0` on **both** ecosystems (npm + github-actions). No routine version-bump PRs open. (The wildcard `semver-major` ignore from #205 stays as belt-and-suspenders.)
- **`CONTRIBUTING.md`** — documents the manual update flow (`bump package.json → bun install → commit both`) and the security posture.

## Security stays ON (verified)
- Dependabot **alerts** (`GET /vulnerability-alerts` → 204) and **security updates** (`automated-security-fixes` → `enabled:true`) are enabled at the repo level — **enabled before this PR landed**, so there's no window without vuln coverage.
- `open-pull-requests-limit: 0` does **not** affect security updates (separate internal limit of 10), and the wildcard `version-update:semver-major` ignore does **not** affect them either (`update-types` applies to version updates only). A real vulnerability still surfaces.

## Caveat (logged)
A Dependabot *security-update PR* hits the same `bun.lock` limitation and would need a manual `bun install` to pass CI — but the **alert** fires reliably regardless, and a real vuln warrants a deliberate manual fix anyway.

## Follow-up after merge
The straggler version PRs Dependabot opened before `limit: 0` took effect (#209, #210, and any new ones) will be closed once this is on `main` (Dependabot reads config from the default branch, so generation stops only after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
